### PR TITLE
Only raise error of different shapes if dataset is no going to be cropped

### DIFF
--- a/biahub/cli/concatenate.py
+++ b/biahub/cli/concatenate.py
@@ -112,7 +112,8 @@ def concatenate(
             all_voxel_sizes.append(dataset.scale[-3:])
 
     if not all([shape == all_shapes[0] for shape in all_shapes]):
-        raise ValueError("All shapes must match")
+        if settings.Z_slice == settings.Y_slice == settings.X_slice == 'all':
+            raise ValueError("All shapes must match or crop dimentions.")
     if not all([voxel_size == all_voxel_sizes[0] for voxel_size in all_voxel_sizes]):
         raise ValueError("All voxel sizes must match")
     T, C, Z, Y, X = all_shapes[0]


### PR DESCRIPTION
The code in main is raising an error if the files to be concatenated are not in the same shape, but for mantis analysis, the shape of the input will be different, and we crop before concatenating. So here, I just added a check the user passed values to crop the dataset; if they did, the error is not raised.