### PR TITLE
Improve characterize-psf

### DIFF
--- a/biahub/analysis/AnalysisSettings.py
+++ b/biahub/analysis/AnalysisSettings.py
@@ -140,6 +140,8 @@ class CharacterizeSettings(MyBaseModel):
     axis_labels: list[str] = ["AXIS0", "AXIS1", "AXIS2"]
     offset: float = 0.0
     gain: float = 1.0
+    use_robust_1d_fwhm: bool = False
+    fwhm_plot_type: Literal["1D", "3D"] = "3D"
 
     @field_validator("device")
     @classmethod

--- a/biahub/analysis/AnalysisSettings.py
+++ b/biahub/analysis/AnalysisSettings.py
@@ -138,6 +138,8 @@ class CharacterizeSettings(MyBaseModel):
     device: str = "cuda"
     patch_size: tuple[PositiveFloat, PositiveFloat, PositiveFloat] | None = None
     axis_labels: list[str] = ["AXIS0", "AXIS1", "AXIS2"]
+    offset: float = 0.0
+    gain: float = 1.0
 
     @field_validator("device")
     @classmethod

--- a/biahub/analysis/analyze_psf.py
+++ b/biahub/analysis/analyze_psf.py
@@ -453,7 +453,7 @@ def _generate_html(
 
 * Name: `{dataset_name}`
 * Path: `{data_path}`
-* Scale: {tuple(np.round(dataset_scale[::-1], 3))} um  <!-- in XYZ order -->
+* Scale (z, y, x): {tuple(np.round(dataset_scale, 3))} um  <!-- in XYZ order -->
 * Date analyzed: {datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")}
 
 ### Number of beads

--- a/biahub/analysis/analyze_psf.py
+++ b/biahub/analysis/analyze_psf.py
@@ -18,8 +18,8 @@ from napari_psf_analysis.psf_analysis.extract.BeadExtractor import BeadExtractor
 from napari_psf_analysis.psf_analysis.image import Calibrated3DImage
 from napari_psf_analysis.psf_analysis.psf import PSF
 from numpy.typing import ArrayLike
-from scipy.signal import peak_widths
 from scipy.interpolate import interp1d
+from scipy.signal import peak_widths
 
 import biahub.analysis.templates
 
@@ -97,7 +97,13 @@ def generate_report(
 
     # make plots
     (bead_psf_slices_path, fwhm_vs_acq_axes_paths, psf_amp_paths) = _make_plots(
-        output_path, beads, df_gaussian_fit, df_1d_peak_width, scale, axis_labels, fwhm_plot_type
+        output_path,
+        beads,
+        df_gaussian_fit,
+        df_1d_peak_width,
+        scale,
+        axis_labels,
+        fwhm_plot_type,
     )
 
     # calculate statistics
@@ -268,7 +274,10 @@ def compute_noise_level(
 
     for z, y, x in peak_coordinates:
         patch_mask = tuple(
-            slice(max(0, coord - half_patch[i]), min(zyx_data.shape[i], coord + half_patch[i] + 1))
+            slice(
+                max(0, coord - half_patch[i]),
+                min(zyx_data.shape[i], coord + half_patch[i] + 1),
+            )
             for i, coord in enumerate((z, y, x))
         )
         mask[patch_mask] = False
@@ -301,7 +310,7 @@ def calculate_robust_peak_widths(zyx_data: ArrayLike, zyx_scale: tuple):
 
             # Use linear interpolation on each side of the peak to find FWHM
             x = x * _scale
-            indices = np.where(y >= half_max/2)[0]
+            indices = np.where(y >= half_max / 2)[0]
             _il = indices[indices < peak_index]
             _ir = indices[indices > peak_index]
             _fl = interp1d(y[_il], x[_il], kind="linear", fill_value="extrapolate")

--- a/biahub/analysis/analyze_psf.py
+++ b/biahub/analysis/analyze_psf.py
@@ -453,7 +453,7 @@ def _generate_html(
 
 * Name: `{dataset_name}`
 * Path: `{data_path}`
-* Scale (z, y, x): {tuple(np.round(dataset_scale, 3))} um  <!-- in XYZ order -->
+* Scale (z, y, x): {tuple(np.round(dataset_scale, 3))} um
 * Date analyzed: {datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")}
 
 ### Number of beads

--- a/biahub/analysis/analyze_psf.py
+++ b/biahub/analysis/analyze_psf.py
@@ -20,8 +20,6 @@ from napari_psf_analysis.psf_analysis.psf import PSF
 from numpy.typing import ArrayLike
 from scipy.signal import peak_widths
 from scipy.interpolate import interp1d
-from multiprocessing import Pool
-from functools import partial
 
 import biahub.analysis.templates
 
@@ -179,18 +177,6 @@ def extract_beads(
     return beads_data, bead_offset
 
 
-def _fit_PSF(patch, peak_coords, scale=(1.0, 1.0, 1.0), offset=0.0, gain=1.0):
-    patch = (patch + offset) * gain
-    patch = np.clip(patch, 0, None).astype(np.int32)
-    bead = Calibrated3DImage(data=patch, spacing=scale, offset=peak_coords)
-    psf = PSF(image=bead)
-    try:
-        psf.analyze()
-        return psf.get_summary_dict()
-    except Exception:
-        return dict()
-
-
 def analyze_psf(
     zyx_patches: List[ArrayLike],
     peak_coordinates: List[tuple],
@@ -199,7 +185,6 @@ def analyze_psf(
     gain: float = 1.0,
     noise: float = 1.0,
     use_robust_1d_fwhm: bool = False,
-    num_processes: int = 8,
 ):
     """
     Analyze point spread function (PSF) from given 3D patches.
@@ -233,12 +218,19 @@ def analyze_psf(
     else:
         f_1d_peak_width = calculate_peak_widths
 
+    results = []
     peak_coordinates = np.asarray(peak_coordinates)
-    with Pool(num_processes) as pool:
-        results = pool.starmap(
-            partial(_fit_PSF, scale=scale, offset=offset, gain=gain),
-            zip(zyx_patches,peak_coordinates),
-        )
+    for patch, peak_coords in zip(zyx_patches, peak_coordinates):
+        patch = (patch + offset) * gain
+        patch = np.clip(patch, 0, None).astype(np.int32)
+        bead = Calibrated3DImage(data=patch, spacing=scale, offset=peak_coords)
+        psf = PSF(image=bead)
+        try:
+            psf.analyze()
+            summary_dict = psf.get_summary_dict()
+        except Exception:
+            summary_dict = {}
+        results.append(summary_dict)
 
     df_gaussian_fit = pd.DataFrame.from_records(results)
     df_gaussian_fit['z_mu'] += peak_coordinates[:, 0] * scale[0]

--- a/biahub/analysis/analyze_psf.py
+++ b/biahub/analysis/analyze_psf.py
@@ -220,8 +220,8 @@ def analyze_psf(
     df_gaussian_fit['z_mu'] += peak_coordinates[:, 0] * scale[0]
     df_gaussian_fit['y_mu'] += peak_coordinates[:, 1] * scale[1]
     df_gaussian_fit['x_mu'] += peak_coordinates[:, 2] * scale[2]
-    df_gaussian_fit['z_amp'] = (df_gaussian_fit['z_amp'] - offset) / gain
-    df_gaussian_fit['zyx_amp'] = (df_gaussian_fit['zyx_amp'] - offset) / gain
+    df_gaussian_fit['z_amp'] /= gain # amplitude is measured relative to the offset
+    df_gaussian_fit['zyx_amp'] /= gain
 
     df_1d_peak_width = pd.DataFrame(
         [calculate_peak_widths(zyx_patch, scale) for zyx_patch in zyx_patches],

--- a/biahub/analysis/settings/example_characterize_settings.yml
+++ b/biahub/analysis/settings/example_characterize_settings.yml
@@ -7,3 +7,5 @@ max_num_peaks: 2000
 exclude_border: [5, 10, 5]
 device: "cuda"
 axis_labels: ["SCAN", "TILT", "COVERSLIP"]
+offset: 10 # Offset that will be added to the data
+gain: 1000 # Factor by which data will be multiplied after offsetting, useful when working with float data

--- a/biahub/analysis/settings/example_characterize_settings.yml
+++ b/biahub/analysis/settings/example_characterize_settings.yml
@@ -7,5 +7,7 @@ max_num_peaks: 2000
 exclude_border: [5, 10, 5]
 device: "cuda"
 axis_labels: ["SCAN", "TILT", "COVERSLIP"]
-offset: 10 # Offset that will be added to the data
-gain: 1000 # Factor by which data will be multiplied after offsetting, useful when working with float data
+offset: 10  # Offset that will be added to the data
+gain: 1000  # Factor by which data will be multiplied after offsetting, useful when working with float data
+use_robust_1d_fwhm: false  # Use "robust" 1D FWHM calculation algorithm, usually not needed
+fwhm_plot_type: '1D'  # Which data to use in FWHM vs acquisition axis plots, either '1D' or '3D'

--- a/biahub/cli/characterize_psf.py
+++ b/biahub/cli/characterize_psf.py
@@ -14,10 +14,10 @@ from iohub.ngff import open_ome_zarr
 from biahub.analysis.AnalysisSettings import CharacterizeSettings
 from biahub.analysis.analyze_psf import (
     analyze_psf,
+    compute_noise_level,
     detect_peaks,
     extract_beads,
     generate_report,
-    compute_noise_level,
 )
 from biahub.cli.parsing import config_filepath, input_position_dirpaths, output_dirpath
 from biahub.cli.utils import yaml_to_model


### PR DESCRIPTION
Tweak `characterize-psf` to enable analysis of phase data. Phase reconstructions are float32 and the PSF fitter only works with ints. Here I'm adding a offset and gain parameters which can be used to cast phase data as ints. I've also tweaked how we plot PSF slices - in one figure rather than 3 separate ones, and added an SNR measurement computed from the PSF amplitude and the std in the background.