### PR TITLE
`estimate-stitch` generates 3D translations from stage-position metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,15 +105,18 @@ biahub concatenate \
 
 # STITCH
 # estimate stitching parameters
-biahub estimate-stitching \
+biahub estimate-stitch \
     -i ./acq_name.zarr/*/*/* \
-    -o ./stitching.yml \
+    -o ./stitching.yml
+# optimize stitching parameters
+biahub optimize-stitch \
+    -i ./stitching.yml \
+    -o ./optimized-stitching.yml \
     --channel DAPI
-    --percent-overlap 0.05
 # stitch fields of view
 biahub stitch \
     -i ./acq_name.zarr/*/*/* \
-    -c ./stitching.yml \
+    -c ./optimized-stitching.yml \
     -o ./acq_name_stitched.zarr/*/*/*
 ```
 

--- a/biahub/estimate_stitch.py
+++ b/biahub/estimate_stitch.py
@@ -67,6 +67,13 @@ def estimate_stitch_cli(
     """
     Estimate stitching parameters for positions in wells of a zarr store.
 
+    This routine uses micro-manager stage position metadata and iohub scale
+    metadata to generate translation parameters for stitching. Translations are
+    saved in pixel units.
+
+    This function estimates translations using metadata alone. More precise
+    translations require phase cross-correlation using `optimize-stitch`.
+
     >>> biahub estimate-stitch -i ./input.zarr/*/*/* -o ./stitch_params.yml
     """
     input_plate_path = Path(*input_position_dirpaths[0].parts[:-3])

--- a/biahub/estimate_stitch.py
+++ b/biahub/estimate_stitch.py
@@ -83,16 +83,12 @@ def estimate_stitch_cli(
 
     # Split fov_names and stage_position_array by well
     unique_well_names = set(["/".join(x.split("/")[:2]) for x in fov_names])
-    fov_names_by_well = []
     stage_position_by_well = []
     for unique_well_name in unique_well_names:
-        fov_name_list = []
         stage_position_list = []
         for fov_name, stage_position in zip(fov_names, stage_position_array):
             if unique_well_name in fov_name:
-                fov_name_list.append(fov_name)
                 stage_position_list.append(stage_position)
-        fov_names_by_well.append(fov_name_list)
         stage_position_by_well.append(stage_position_list)
 
     # Prepare final
@@ -105,6 +101,7 @@ def estimate_stitch_cli(
         # Scale to pixel coordinates
         zyx_position_array /= zyx_scale
 
+        # Write back into original
         stage_position_by_well[i] = zyx_position_array
 
     position_pixel_coordinates = np.concatenate(stage_position_by_well)

--- a/biahub/estimate_stitch.py
+++ b/biahub/estimate_stitch.py
@@ -1,64 +1,18 @@
 from pathlib import Path
 
 import click
-import pandas as pd
-import submitit
+import numpy as np
 
 from iohub import open_ome_zarr
 
-from biahub.cli.parsing import input_position_dirpaths, local, output_filepath
+from biahub.cli.parsing import input_position_dirpaths, output_filepath
 from biahub.cli.utils import model_to_yaml
 from biahub.settings import ProcessingSettings, StitchSettings
-from biahub.stitch import (
-    cleanup_shifts,
-    compute_total_translation,
-    consolidate_zarr_fov_shifts,
-    estimate_zarr_fov_shifts,
-    get_grid_rows_cols,
-)
-
-
-def write_config_file(
-    shifts: pd.DataFrame,
-    output_filepath: str,
-    channel: str,
-    fliplr: bool,
-    flipud: bool,
-    rot90: int,
-):
-    total_translation_dict = shifts.apply(
-        lambda row: [float(row['shift-y'].round(2)), float(row['shift-x'].round(2))], axis=1
-    ).to_dict()
-
-    settings = StitchSettings(
-        channels=[channel],
-        preprocessing=ProcessingSettings(fliplr=fliplr, flipud=flipud, rot90=rot90),
-        postprocessing=ProcessingSettings(),
-        total_translation=total_translation_dict,
-    )
-    model_to_yaml(settings, output_filepath)
-
-
-def cleanup_and_write_shifts(
-    output_filepath, channel, fliplr, flipud, rot90, csv_filepath, pixel_size_um
-):
-    cleanup_shifts(csv_filepath, pixel_size_um)
-    shifts = compute_total_translation(csv_filepath)
-    write_config_file(shifts, output_filepath, channel, fliplr, flipud, rot90)
 
 
 @click.command("estimate-stitch")
 @input_position_dirpaths()
 @output_filepath()
-@click.option(
-    "--channel",
-    required=True,
-    type=str,
-    help="Channel to use for estimating stitch parameters",
-)
-@click.option(
-    "--percent-overlap", "-p", required=True, type=float, help="Percent overlap between images"
-)
 @click.option("--fliplr", is_flag=True, help="Flip images left-right before stitching")
 @click.option("--flipud", is_flag=True, help="Flip images up-down before stitching")
 @click.option(
@@ -67,167 +21,107 @@ def cleanup_and_write_shifts(
     type=int,
     help="rotate the images 90 counterclockwise n times before stitching",
 )
-@click.option(
-    "--add_offset",
-    is_flag=True,
-    help="add the offset to estimated shifts, needed for OPS experiments",
-)
-@local()
 def estimate_stitch_cli(
     input_position_dirpaths: list[Path],
     output_filepath: str,
-    channel: str,
-    percent_overlap: float,
     fliplr: bool,
     flipud: bool,
     rot90: int,
-    add_offset: bool,
-    local: bool,
 ):
     """
     Estimate stitching parameters for positions in wells of a zarr store.
-    Position names must follow the naming format XXXYYY, e.g. 000000, 000001, 001000, etc.
-    as created by the Micro-manager Tile Creator: https://micro-manager.org/Micro-Manager_User's_Guide#positioning
-    Assumes all wells have the save FOV grid layout.
 
-    >>> biahub estimate-stitch -i ./input.zarr/*/*/* -o ./stitch_params.yml --channel DAPI --percent-overlap 0.05
+    >>> biahub estimate-stitch -i ./input.zarr/*/*/* -o ./stitch_params.yml
     """
-    if not (0 <= percent_overlap <= 1):
-        raise ValueError("Percent overlap must be between 0 and 1")
-
-    input_zarr_path = Path(*input_position_dirpaths[0].parts[:-3])
+    input_plate_path = Path(*input_position_dirpaths[0].parts[:-3])
     output_filepath = Path(output_filepath)
-    csv_filepath = (
-        output_filepath.parent
-        / f"stitch_shifts_{input_zarr_path.name.replace('.zarr', '.csv')}"
+
+    # Collect raw stage positions
+    print("Reading stage positions...")
+    fov_names = []
+    stage_position_array = []
+    for input_position_dirpath in input_position_dirpaths:
+        fov_names.append("/".join(input_position_dirpath.parts[-3:]))
+        with open_ome_zarr(input_position_dirpath) as input_position_dataset:
+            zyx_scale = input_position_dataset.scale[2:]
+            position_name = input_position_dataset.zattrs['omero']['name']
+        with open_ome_zarr(input_plate_path) as input_plate_dataset:
+            stage_positions = input_plate_dataset.zattrs["Summary"]["StagePositions"]
+            for stage_position in stage_positions:  # TODO: fail if this loop reaches the end
+                if stage_position["Label"] == position_name:
+
+                    # Read XY positions
+                    try:
+                        xy_stage_name = stage_position["DefaultXYStage"]
+                        if "DevicePositions" in stage_position.keys():
+                            for device in stage_position["DevicePositions"]:
+                                if device["Device"] == xy_stage_name:
+                                    xpos, ypos = device["Position_um"]
+                                    break
+                        else:
+                            xpos, ypos = stage_position[xy_stage_name]
+                    except KeyError:
+                        xpos, ypos = 0, 0
+                        pass
+
+                    # Read Z positions
+                    try:
+                        z_stage_name = stage_position["DefaultZStage"]
+                        if "DevicePositions" in stage_position.keys():
+                            for device in stage_position["DevicePositions"]:
+                                if device["Device"] == z_stage_name:
+                                    zpos = device["Position_um"][0]
+                                    break
+                        else:
+                            zpos = stage_position[z_stage_name]
+                    except KeyError:
+                        zpos = 0
+                        pass
+
+                    # Add to list
+                    stage_position_array.append([zpos, ypos, xpos])
+
+    # Split fov_names and stage_position_array by well
+    unique_well_names = set(["/".join(x.split("/")[:2]) for x in fov_names])
+    fov_names_by_well = []
+    stage_position_by_well = []
+    for unique_well_name in unique_well_names:
+        fov_name_list = []
+        stage_position_list = []
+        for fov_name, stage_position in zip(fov_names, stage_position_array):
+            if unique_well_name in fov_name:
+                fov_name_list.append(fov_name)
+                stage_position_list.append(stage_position)
+        fov_names_by_well.append(fov_name_list)
+        stage_position_by_well.append(stage_position_list)
+
+    # Prepare final
+    for i in range(len(unique_well_names)):
+        zyx_position_array = np.array(stage_position_by_well[i])
+
+        # Shift so that (0, 0, 0) is the lowermost corner
+        zyx_position_array -= np.min(zyx_position_array, axis=0)
+
+        # Scale to pixel coordinates
+        zyx_position_array /= zyx_scale
+
+        stage_position_by_well[i] = zyx_position_array
+
+    position_pixel_coordinates = np.concatenate(stage_position_by_well)
+
+    # Prepare final output
+    total_translation_dict = {}
+    for fov_name, position_pixel_coordinates in zip(fov_names, position_pixel_coordinates):
+        total_translation_dict[fov_name] = list(np.round(position_pixel_coordinates, 2))
+
+    # Validate and save
+    settings = StitchSettings(
+        channels=None,
+        preprocessing=ProcessingSettings(fliplr=fliplr, flipud=flipud, rot90=rot90),
+        postprocessing=ProcessingSettings(),
+        total_translation=total_translation_dict,
     )
-
-    with open_ome_zarr(input_position_dirpaths[0]) as dataset:
-        if channel not in dataset.channel_names:
-            raise ValueError(f"Channel {channel} not found in input zarr store")
-        tcz_idx = (0, dataset.channel_names.index(channel), dataset.data.shape[-3] // 2)
-        pixel_size_um = dataset.scale[-1]
-    if pixel_size_um == 1.0:
-        response = input(
-            'The pixel size is equal to the default value of 1.0 um. ',
-            'Inaccurate pixel size will affect stitching outlier removal. ',
-            'Continue? [y/N]: ',
-        )
-        if response.lower() != 'y':
-            return
-
-    # here we assume that all wells have the same fov grid
-    click.echo('Indexing input zarr store')
-    wells = list(set([Path(*p.parts[-3:-1]) for p in input_position_dirpaths]))
-    fov_names = set([p.name for p in input_position_dirpaths])
-    grid_rows, grid_cols = get_grid_rows_cols(fov_names)
-
-    # account for non-square grids
-    row_fov_pairs, col_fov_pairs = [], []
-    for col in grid_cols:
-        for row0, row1 in zip(grid_rows[:-1], grid_rows[1:]):
-            fov0 = col + row0
-            fov1 = col + row1
-            if fov0 in fov_names and fov1 in fov_names:
-                row_fov_pairs.append((fov0, fov1))
-    for row in grid_rows:
-        for col0, col1 in zip(grid_cols[:-1], grid_cols[1:]):
-            fov0 = col0 + row
-            fov1 = col1 + row
-            if fov0 in fov_names and fov1 in fov_names:
-                col_fov_pairs.append((fov0, fov1))
-
-    slurm_out_path = output_filepath.parent / "slurm_output"
-    csv_dirpath = (
-        output_filepath.parent / 'raw_shifts' / input_zarr_path.name.replace('.zarr', '')
-    )
-    csv_dirpath.mkdir(parents=True, exist_ok=False)
-
-    estimate_shift_params = {
-        "tcz_index": tcz_idx,
-        "percent_overlap": percent_overlap,
-        "fliplr": fliplr,
-        "flipud": flipud,
-        "rot90": rot90,
-        "add_offset": add_offset,
-    }
-
-    slurm_args = {
-        "slurm_job_name": "estimate-shift",
-        "slurm_mem_per_cpu": "8G",
-        "slurm_cpus_per_task": 1,
-        "slurm_array_parallelism": 100,  # process up to 100 positions at a time
-        "slurm_time": 10,
-        "slurm_partition": "preempted",
-    }
-
-    # Run locally or submit to SLURM
-    if local:
-        cluster = "local"
-    else:
-        cluster = "slurm"
-
-    click.echo('Estimating FOV shifts...')
-    executor = submitit.AutoExecutor(folder=slurm_out_path, cluster=cluster)
-    executor.update_parameters(**slurm_args)
-    estimate_jobs = []
-    with executor.batch():
-        for well_name in wells:
-            for direction, fovs in zip(("row", "col"), (row_fov_pairs, col_fov_pairs)):
-                for fov0, fov1 in fovs:
-                    fov0_zarr_path = Path(input_zarr_path, well_name, fov0)
-                    fov1_zarr_path = Path(input_zarr_path, well_name, fov1)
-                    estimate_jobs.append(
-                        executor.submit(
-                            estimate_zarr_fov_shifts,
-                            direction=direction,
-                            output_dirname=csv_dirpath,
-                            **estimate_shift_params,
-                            fov0_zarr_path=fov0_zarr_path,
-                            fov1_zarr_path=fov1_zarr_path,
-                        )
-                    )
-    estimate_job_ids = [job.job_id for job in estimate_jobs]
-
-    slurm_args = {
-        "slurm_job_name": "consolidate-shifts",
-        "slurm_mem_per_cpu": "8G",
-        "slurm_cpus_per_task": 1,
-        "slurm_time": 10,
-        "slurm_partition": "preempted",
-        "slurm_dependency": f"afterok:{estimate_job_ids[0]}:{estimate_job_ids[-1]}",
-    }
-
-    click.echo('Consolidating FOV shifts...')
-    executor = submitit.AutoExecutor(folder=slurm_out_path, cluster=cluster)
-    executor.update_parameters(**slurm_args)
-    consolidate_job_id = executor.submit(
-        consolidate_zarr_fov_shifts,
-        input_dirname=csv_dirpath,
-        output_filepath=csv_filepath,
-    ).job_id
-
-    slurm_args = {
-        "slurm_job_name": "cleanup-shifts",
-        "slurm_mem_per_cpu": "8G",
-        "slurm_cpus_per_task": 1,
-        "slurm_time": 10,
-        "slurm_partition": "preempted",
-        "slurm_dependency": f"afterok:{consolidate_job_id}",
-    }
-
-    executor = submitit.AutoExecutor(folder=slurm_out_path, cluster=cluster)
-    executor.update_parameters(**slurm_args)
-    executor.submit(
-        cleanup_and_write_shifts,
-        output_filepath,
-        channel,
-        fliplr,
-        flipud,
-        rot90,
-        csv_filepath,
-        pixel_size_um,
-    )
+    model_to_yaml(settings, output_filepath)
 
 
 if __name__ == "__main__":

--- a/biahub/estimate_stitch.py
+++ b/biahub/estimate_stitch.py
@@ -78,16 +78,16 @@ def estimate_stitch_cli(
     for input_position_dirpath in input_position_dirpaths:
         fov_name = "/".join(input_position_dirpath.parts[-3:])
 
-        # find position name from position-level omero metadata
+        # Find position name from position-level omero metadata
         with open_ome_zarr(input_position_dirpath) as input_position_dataset:
             position_name = input_position_dataset.zattrs['omero']['name']
 
-        # use position name to index into micromanager plate-level metadata
+        # Use position name to index into micromanager plate-level metadata
         with open_ome_zarr(input_plate_path) as input_plate_dataset:
             zyx_position = extract_stage_position(input_plate_dataset, position_name)
-            translation_dict[fov_name] = zyx_position
 
         print(f"Found metadata: {fov_name}: {zyx_position}")
+        translation_dict[fov_name] = zyx_position
 
     # Group by well
     grouped_wells = defaultdict(dict)

--- a/biahub/settings.py
+++ b/biahub/settings.py
@@ -347,10 +347,16 @@ class StitchSettings(MyBaseModel):
     postprocessing: Optional[ProcessingSettings] = None
     column_translation: Optional[list[float, float]] = None
     row_translation: Optional[list[float, float]] = None
-    total_translation: Optional[dict[str, list[float, float]]] = None
+    total_translation: Optional[dict[str, list[float, float, float]]] = None
     affine_transform: Optional[dict[str, list]] = None
 
     def __init__(self, **data):
+        # Adding a leading zero for zyx translation for backwards compatibility
+        if "total_translation" in data:
+            for key, value in data["total_translation"].items():
+                if len(value) == 2:
+                    data["total_translation"][key] = [0] + value
+
         if not any(
             (
                 data.get("total_translation"),

--- a/biahub/tests/conftest.py
+++ b/biahub/tests/conftest.py
@@ -50,6 +50,14 @@ def example_estimate_registration_settings():
 
 
 @pytest.fixture(scope="function")
+def example_stitch_settings():
+    settings_path = "./settings/example_stitch_settings.yml"
+    with open(settings_path) as file:
+        settings = yaml.safe_load(file)
+    yield settings_path, settings
+
+
+@pytest.fixture(scope="function")
 def example_plate(tmp_path):
     """
     Example HCS plate with 3 positions and 6 channels and float32 data

--- a/biahub/tests/test_example_settings.py
+++ b/biahub/tests/test_example_settings.py
@@ -8,6 +8,7 @@ from biahub.settings import (
     EstimateRegistrationSettings,
     RegistrationSettings,
     StabilizationSettings,
+    StitchSettings,
 )
 
 
@@ -79,3 +80,13 @@ def test_example_stabilize_timelapse_settings(example_stabilize_timelapse_settin
 def test_example_estimate_registration_settings(example_estimate_registration_settings):
     _, settings = example_estimate_registration_settings
     EstimateRegistrationSettings(**settings)
+
+
+def test_example_stitch_settings(example_stitch_settings):
+    _, settings = example_stitch_settings
+    validated_settings = StitchSettings(**settings)
+
+    # Check that leading z = 0 is added to total_translation
+    for value in validated_settings.total_translation.values():
+        assert len(value) == 3
+        assert value[0] == 0.0


### PR DESCRIPTION
This PR simplifies `estimate-stitch` to:

- read micromanager stage positions in x, y, and z
- scale the resulting shifts to pixel coordinates based on iohub scale metadata (easily modified with `iohub set-scale`)
- shift the results to (0,0,0) for each well 
- output a `.yaml` file with a 3D translation for each well