### PR TITLE
Only validate the first input path

### DIFF
--- a/biahub/cli/parsing.py
+++ b/biahub/cli/parsing.py
@@ -14,12 +14,11 @@ def _validate_and_process_paths(
 ) -> list[Path]:
     # Sort and validate the input paths
     input_paths = [Path(path) for path in natsorted(value)]
-    for path in input_paths:
-        with open_ome_zarr(path, mode='r') as dataset:
-            if isinstance(dataset, Plate):
-                raise ValueError(
-                    "Please supply a single position instead of an HCS plate. Likely fix: replace 'input.zarr' with 'input.zarr/0/0/0'"
-                )
+    with open_ome_zarr(input_paths[0], mode='r') as dataset:
+        if isinstance(dataset, Plate):
+            raise ValueError(
+                "Please supply a single position instead of an HCS plate. Likely fix: replace 'input.zarr' with 'input.zarr/0/0/0'"
+            )
     return input_paths
 
 


### PR DESCRIPTION
Almost all of `biahub`'s CLI calls take an `-i` option, which accepts a list of position paths (typically using a `*/*/*` glob). 

We validate this input with `_validate_and_process_paths`, which loops through the positions, opens each one with `open_ome_zarr`, and checks that none of them are a `Plate`. 

Each check takes ~35 ms, which is barely noticeable in testing, but quickly adds up to a large dead time **before you get any feedback from the CLI**. For example, OPS dataset can includes 450 positions, which is ~15 second of dead time. 

This fix only checks the first position of the list. This check will still catch the most common issue: that the user accidentally provides a plate and we want to prompt them to provide an list of positions instead. 

