### PR TITLE
Raise `ValueError` when a `keep_overhang=False` deskew is going to return an empty array

### DIFF
--- a/biahub/deskew.py
+++ b/biahub/deskew.py
@@ -162,6 +162,12 @@ def get_deskewed_data_shape(
         Xp = int(np.ceil((Z / px_to_scan_ratio) + (Y * ct)))
     else:
         Xp = int(np.ceil((Z / px_to_scan_ratio) - (Y * ct)))
+        if Xp <= 0:
+            raise ValueError(
+                f"Dataset contains only overhang when keep_overhang=False. "
+                f"Computed Xp={Xp} <= 0. Either set keep_overhang=True or use a dataset "
+                f"with non-overhang content."
+            )
 
     output_shape = (Y, X, Xp)
     voxel_size = (average_n_slices * st * pixel_size_um, pixel_size_um, pixel_size_um)

--- a/biahub/tests/test_cli/test_deskew_cli.py
+++ b/biahub/tests/test_cli/test_deskew_cli.py
@@ -82,23 +82,20 @@ def test_deskew_cli(tmp_path, example_plate, example_deskew_settings, sbatch_fil
     assert output_path.exists()
     assert result.exit_code == 0
 
-    def test_deskew_overhang_only_dataset_error():
-        # Parameters that cause only overhang
-        shape = (10, 50, 100)
-        angle = 36
-        ratio = 0.1
 
-        with pytest.raises(ValueError, match="Dataset contains only overhang"):
-            deskew.get_deskewed_data_shape(shape, angle, ratio, keep_overhang=False)
+def test_deskew_overhang_only_dataset_error():
+    # Parameters that cause only overhang
+    shape = (10, 50, 100)
+    data = np.random.random(shape)
+    angle = 36
+    ratio = 0.1
 
-        # Should succeed with keep_overhang=True
-        out_shape, _ = deskew.get_deskewed_data_shape(shape, angle, ratio, keep_overhang=True)
-        assert out_shape[2] > 0
+    with pytest.raises(ValueError, match="Dataset contains only overhang"):
+        deskew.get_deskewed_data_shape(shape, angle, ratio, keep_overhang=False)
 
-    def test_deskew_function_overhang_only_dataset_error():
-        data = np.random.random((10, 50, 100))
-        angle = 36
-        ratio = 0.1
+    with pytest.raises(ValueError, match="Dataset contains only overhang"):
+        deskew.deskew(data, angle, ratio, keep_overhang=False)
 
-        with pytest.raises(ValueError, match="Dataset contains only overhang"):
-            deskew.deskew(data, angle, ratio, keep_overhang=False)
+    # Should succeed with keep_overhang=True
+    out_shape, _ = deskew.get_deskewed_data_shape(shape, angle, ratio, keep_overhang=True)
+    assert out_shape[2] > 0

--- a/biahub/tests/test_cli/test_deskew_cli.py
+++ b/biahub/tests/test_cli/test_deskew_cli.py
@@ -85,9 +85,9 @@ def test_deskew_cli(tmp_path, example_plate, example_deskew_settings, sbatch_fil
 
 def test_deskew_overhang_only_dataset_error():
     # Parameters that cause only overhang
-    shape = (10, 50, 100)
+    shape = (10, 500, 100)
     data = np.random.random(shape)
-    angle = 36
+    angle = 30
     ratio = 0.1
 
     with pytest.raises(ValueError, match="Dataset contains only overhang"):

--- a/biahub/tests/test_cli/test_deskew_cli.py
+++ b/biahub/tests/test_cli/test_deskew_cli.py
@@ -82,6 +82,7 @@ def test_deskew_cli(tmp_path, example_plate, example_deskew_settings, sbatch_fil
 
     assert output_path.exists()
     assert result.exit_code == 0
+
     def test_deskew_overhang_only_dataset_error():
         # Parameters that cause only overhang
         shape = (10, 50, 100)

--- a/biahub/tests/test_cli/test_deskew_cli.py
+++ b/biahub/tests/test_cli/test_deskew_cli.py
@@ -1,9 +1,11 @@
 import numpy as np
 
+
 from click.testing import CliRunner
 
 from biahub import deskew
 from biahub.cli.main import cli
+import pytest
 
 
 def test_average_n_slices():
@@ -80,3 +82,23 @@ def test_deskew_cli(tmp_path, example_plate, example_deskew_settings, sbatch_fil
 
     assert output_path.exists()
     assert result.exit_code == 0
+    def test_deskew_overhang_only_dataset_error():
+        # Parameters that cause only overhang
+        shape = (10, 50, 100)
+        angle = 36
+        ratio = 0.1
+
+        with pytest.raises(ValueError, match="Dataset contains only overhang"):
+            deskew.get_deskewed_data_shape(shape, angle, ratio, keep_overhang=False)
+
+        # Should succeed with keep_overhang=True
+        out_shape, _ = deskew.get_deskewed_data_shape(shape, angle, ratio, keep_overhang=True)
+        assert out_shape[2] > 0
+
+    def test_deskew_function_overhang_only_dataset_error():
+        data = np.random.random((10, 50, 100))
+        angle = 36
+        ratio = 0.1
+
+        with pytest.raises(ValueError, match="Dataset contains only overhang"):
+            deskew.deskew(data, angle, ratio, keep_overhang=False)

--- a/biahub/tests/test_cli/test_deskew_cli.py
+++ b/biahub/tests/test_cli/test_deskew_cli.py
@@ -1,11 +1,10 @@
 import numpy as np
-
+import pytest
 
 from click.testing import CliRunner
 
 from biahub import deskew
 from biahub.cli.main import cli
-import pytest
 
 
 def test_average_n_slices():


### PR DESCRIPTION
Fixes #108. 