### PR TITLE
Improve CLI Startup Performance with Lazy Command Loading

### DIFF
--- a/biahub/cli/main.py
+++ b/biahub/cli/main.py
@@ -25,113 +25,127 @@ def lazy_import_command(import_path):
     return callback
 
 
-# Command list: (name, import_path, help)
 COMMANDS = [
-    (
-        "estimate_bleaching",
-        "biahub.estimate_bleaching.estimate_bleaching_cli",
-        "Estimate bleaching from raw data",
-    ),
-    (
-        "estimate_deskew",
-        "biahub.estimate_deskew.estimate_deskew_cli",
-        "Routine for estimating deskewing parameters",
-    ),
-    ("deskew", "biahub.deskew.deskew_cli", "Deskew a single position across T and C axes"),
-    (
-        "estimate_registration",
-        "biahub.estimate_registration.estimate_registration_cli",
-        "Estimate affine transform between timepoints or arms",
-    ),
-    (
-        "optimize_registration",
-        "biahub.optimize_registration.optimize_registration_cli",
-        "Optimize transform based on match filtering",
-    ),
-    (
-        "register",
-        "biahub.register.register_cli",
-        "Apply an affine transformation to a single position",
-    ),
-    (
-        "estimate_stitch",
-        "biahub.estimate_stitch.estimate_stitch_cli",
-        "Estimate stitching parameters for positions",
-    ),
-    ("stitch", "biahub.stitch.stitch_cli", "Stitch positions in wells of a zarr store"),
-    (
-        "concatenate",
-        "biahub.concatenate.concatenate_cli",
-        "Concatenate datasets (with optional cropping)",
-    ),
-    (
-        "estimate_stabilization",
-        "biahub.estimate_stabilization.estimate_stabilization_cli",
-        "Estimate translation matrices for XYZ stabilization",
-    ),
-    (
-        "stabilize",
-        "biahub.stabilize.stabilize_cli",
-        "Apply stabilization transforms to dataset",
-    ),
-    (
-        "estimate_crop",
-        "biahub.estimate_crop.estimate_crop_cli",
-        "Estimate crop region for dual-channel alignment",
-    ),
-    (
-        "compute_transfer_function",
-        "biahub.compute_transfer_function.compute_transfer_function_cli",
-        "Compute transfer function using PSF",
-    ),
-    (
-        "apply_inverse_transfer_function",
-        "biahub.apply_inverse_transfer_function.apply_inverse_transfer_function_cli",
-        "Apply inverse transfer function to dataset",
-    ),
-    (
-        "reconstruct",
-        "biahub.reconstruct.reconstruct_cli",
-        "Reconstruct a dataset using config",
-    ),
-    (
-        "estimate_psf",
-        "biahub.estimate_psf.estimate_psf_cli",
-        "Estimate point spread function from beads",
-    ),
-    (
-        "deconvolve",
-        "biahub.deconvolve.deconvolve_cli",
-        "Deconvolve across T and C axes using a PSF",
-    ),
-    (
-        "characterize_psf",
-        "biahub.characterize_psf.characterize_psf_cli",
-        "Characterize point spread function (PSF)",
-    ),
-    (
-        "segment",
-        "biahub.segment.segment_cli",
-        "Segment a position using pretrained model or pipeline",
-    ),
-    ("virtual_stain", "biahub.virtual_stain.virtual_stain_cli", "Run VisCy virtual staining"),
-    (
-        "process_with_config",
-        "biahub.process_data.process_with_config_cli",
-        "Process data with YAML-defined functions",
-    ),
-    ("track", "biahub.track.track_cli", "Track objects in 2D/3D time-lapse microscopy"),
+    {
+        "name": "estimate_bleaching",
+        "import_path": "biahub.estimate_bleaching.estimate_bleaching_cli",
+        "help": "Estimate bleaching from raw data",
+    },
+    {
+        "name": "estimate_deskew",
+        "import_path": "biahub.estimate_deskew.estimate_deskew_cli",
+        "help": "Routine for estimating deskewing parameters",
+    },
+    {
+        "name": "deskew",
+        "import_path": "biahub.deskew.deskew_cli",
+        "help": "Deskew a single position across T and C axes",
+    },
+    {
+        "name": "estimate_registration",
+        "import_path": "biahub.estimate_registration.estimate_registration_cli",
+        "help": "Estimate affine transform between timepoints or arms",
+    },
+    {
+        "name": "optimize_registration",
+        "import_path": "biahub.optimize_registration.optimize_registration_cli",
+        "help": "Optimize transform based on match filtering",
+    },
+    {
+        "name": "register",
+        "import_path": "biahub.register.register_cli",
+        "help": "Apply an affine transformation to a single position",
+    },
+    {
+        "name": "estimate_stitch",
+        "import_path": "biahub.estimate_stitch.estimate_stitch_cli",
+        "help": "Estimate stitching parameters for positions",
+    },
+    {
+        "name": "stitch",
+        "import_path": "biahub.stitch.stitch_cli",
+        "help": "Stitch positions in wells of a zarr store",
+    },
+    {
+        "name": "concatenate",
+        "import_path": "biahub.concatenate.concatenate_cli",
+        "help": "Concatenate datasets (with optional cropping)",
+    },
+    {
+        "name": "estimate_stabilization",
+        "import_path": "biahub.estimate_stabilization.estimate_stabilization_cli",
+        "help": "Estimate translation matrices for XYZ stabilization",
+    },
+    {
+        "name": "stabilize",
+        "import_path": "biahub.stabilize.stabilize_cli",
+        "help": "Apply stabilization transforms to dataset",
+    },
+    {
+        "name": "estimate_crop",
+        "import_path": "biahub.estimate_crop.estimate_crop_cli",
+        "help": "Estimate crop region for dual-channel alignment",
+    },
+    {
+        "name": "compute_transfer_function",
+        "import_path": "biahub.compute_transfer_function.compute_transfer_function_cli",
+        "help": "Compute transfer function using PSF",
+    },
+    {
+        "name": "apply_inverse_transfer_function",
+        "import_path": "biahub.apply_inverse_transfer_function.apply_inverse_transfer_function_cli",
+        "help": "Apply inverse transfer function to dataset",
+    },
+    {
+        "name": "reconstruct",
+        "import_path": "biahub.reconstruct.reconstruct_cli",
+        "help": "Reconstruct a dataset using config",
+    },
+    {
+        "name": "estimate_psf",
+        "import_path": "biahub.estimate_psf.estimate_psf_cli",
+        "help": "Estimate point spread function from beads",
+    },
+    {
+        "name": "deconvolve",
+        "import_path": "biahub.deconvolve.deconvolve_cli",
+        "help": "Deconvolve across T and C axes using a PSF",
+    },
+    {
+        "name": "characterize_psf",
+        "import_path": "biahub.characterize_psf.characterize_psf_cli",
+        "help": "Characterize point spread function (PSF)",
+    },
+    {
+        "name": "segment",
+        "import_path": "biahub.segment.segment_cli",
+        "help": "Segment a position using pretrained model or pipeline",
+    },
+    {
+        "name": "virtual_stain",
+        "import_path": "biahub.virtual_stain.virtual_stain_cli",
+        "help": "Run VisCy virtual staining",
+    },
+    {
+        "name": "process_with_config",
+        "import_path": "biahub.process_data.process_with_config_cli",
+        "help": "Process data with YAML-defined functions",
+    },
+    {
+        "name": "track",
+        "import_path": "biahub.track.track_cli",
+        "help": "Track objects in 2D/3D time-lapse microscopy",
+    },
 ]
 
 
-# Register lazy commands
-for name, import_path, help_text in COMMANDS:
+for cmd in COMMANDS:
     cli.add_command(
         click.Command(
-            name=name,
-            callback=lazy_import_command(import_path),
-            help=help_text,
-            short_help=help_text.split(".")[0],
+            name=cmd["name"],
+            callback=lazy_import_command(cmd["import_path"]),
+            help=cmd["help"],
+            short_help=cmd["help"].split(".")[0],
         )
     )
 

--- a/biahub/cli/main.py
+++ b/biahub/cli/main.py
@@ -1,35 +1,12 @@
+import importlib
 import click
-
-from biahub.apply_inverse_transfer_function import apply_inverse_transfer_function_cli
-from biahub.characterize_psf import characterize_psf_cli
-from biahub.compute_transfer_function import compute_transfer_function_cli
-from biahub.concatenate import concatenate_cli
-from biahub.deconvolve import deconvolve_cli
-from biahub.deskew import deskew_cli
-from biahub.estimate_bleaching import estimate_bleaching_cli
-from biahub.estimate_crop import estimate_crop_cli
-from biahub.estimate_deskew import estimate_deskew_cli
-from biahub.estimate_psf import estimate_psf_cli
-from biahub.estimate_registration import estimate_registration_cli
-from biahub.estimate_stabilization import estimate_stabilization_cli
-from biahub.estimate_stitch import estimate_stitch_cli
-from biahub.optimize_registration import optimize_registration_cli
-from biahub.process_data import process_with_config_cli
-from biahub.reconstruct import reconstruct_cli
-from biahub.register import register_cli
-from biahub.segment import segment_cli
-from biahub.stabilize import stabilize_cli
-from biahub.stitch import stitch_cli
-from biahub.track import track_cli
-from biahub.virtual_stain import virtual_stain_cli
 
 CONTEXT = {"help_option_names": ["-h", "--help"]}
 
 
-# `biahub -h` will show subcommands in the order they are added
 class NaturalOrderGroup(click.Group):
     def list_commands(self, ctx):
-        return self.commands.keys()
+        return list(self.commands.keys())
 
 
 @click.group(context_settings=CONTEXT, cls=NaturalOrderGroup)
@@ -37,25 +14,53 @@ def cli():
     """command-line tools for biahub"""
 
 
-cli.add_command(estimate_bleaching_cli)
-cli.add_command(estimate_deskew_cli)
-cli.add_command(deskew_cli)
-cli.add_command(estimate_registration_cli)
-cli.add_command(optimize_registration_cli)
-cli.add_command(register_cli)
-cli.add_command(estimate_stitch_cli)
-cli.add_command(stitch_cli)
-cli.add_command(concatenate_cli)
-cli.add_command(estimate_stabilization_cli)
-cli.add_command(stabilize_cli)
-cli.add_command(estimate_crop_cli)
-cli.add_command(compute_transfer_function_cli)
-cli.add_command(apply_inverse_transfer_function_cli)
-cli.add_command(reconstruct_cli)
-cli.add_command(estimate_psf_cli)
-cli.add_command(deconvolve_cli)
-cli.add_command(characterize_psf_cli)
-cli.add_command(segment_cli)
-cli.add_command(virtual_stain_cli)
-cli.add_command(process_with_config_cli)
-cli.add_command(track_cli)
+def lazy_import_command(import_path):
+    def callback(*args, **kwargs):
+        module_path, attr_name = import_path.rsplit(".", 1)
+        module = importlib.import_module(module_path)
+        command = getattr(module, attr_name)
+        return command.main(args=args, standalone_mode=True)
+    return callback
+
+
+# Command list: (name, import_path, help)
+COMMANDS = [
+    ("estimate_bleaching", "biahub.estimate_bleaching.estimate_bleaching_cli", "Estimate bleaching from raw data"),
+    ("estimate_deskew", "biahub.estimate_deskew.estimate_deskew_cli", "Routine for estimating deskewing parameters"),
+    ("deskew", "biahub.deskew.deskew_cli", "Deskew a single position across T and C axes"),
+    ("estimate_registration", "biahub.estimate_registration.estimate_registration_cli", "Estimate affine transform between timepoints or arms"),
+    ("optimize_registration", "biahub.optimize_registration.optimize_registration_cli", "Optimize transform based on match filtering"),
+    ("register", "biahub.register.register_cli", "Apply an affine transformation to a single position"),
+    ("estimate_stitch", "biahub.estimate_stitch.estimate_stitch_cli", "Estimate stitching parameters for positions"),
+    ("stitch", "biahub.stitch.stitch_cli", "Stitch positions in wells of a zarr store"),
+    ("concatenate", "biahub.concatenate.concatenate_cli", "Concatenate datasets (with optional cropping)"),
+    ("estimate_stabilization", "biahub.estimate_stabilization.estimate_stabilization_cli", "Estimate translation matrices for XYZ stabilization"),
+    ("stabilize", "biahub.stabilize.stabilize_cli", "Apply stabilization transforms to dataset"),
+    ("estimate_crop", "biahub.estimate_crop.estimate_crop_cli", "Estimate crop region for dual-channel alignment"),
+    ("compute_transfer_function", "biahub.compute_transfer_function.compute_transfer_function_cli", "Compute transfer function using PSF"),
+    ("apply_inverse_transfer_function", "biahub.apply_inverse_transfer_function.apply_inverse_transfer_function_cli", "Apply inverse transfer function to dataset"),
+    ("reconstruct", "biahub.reconstruct.reconstruct_cli", "Reconstruct a dataset using config"),
+    ("estimate_psf", "biahub.estimate_psf.estimate_psf_cli", "Estimate point spread function from beads"),
+    ("deconvolve", "biahub.deconvolve.deconvolve_cli", "Deconvolve across T and C axes using a PSF"),
+    ("characterize_psf", "biahub.characterize_psf.characterize_psf_cli", "Characterize point spread function (PSF)"),
+    ("segment", "biahub.segment.segment_cli", "Segment a position using pretrained model or pipeline"),
+    ("virtual_stain", "biahub.virtual_stain.virtual_stain_cli", "Run VisCy virtual staining"),
+    ("process_with_config", "biahub.process_data.process_with_config_cli", "Process data with YAML-defined functions"),
+    ("track", "biahub.track.track_cli", "Track objects in 2D/3D time-lapse microscopy"),
+]
+
+
+# Register lazy commands
+for name, import_path, help_text in COMMANDS:
+    cli.add_command(
+        click.Command(
+            name=name,
+            callback=lazy_import_command(import_path),
+            help=help_text,
+            short_help=help_text.split(".")[0]
+        )
+    )
+
+
+if __name__ == "__main__":
+    cli()

--- a/biahub/cli/main.py
+++ b/biahub/cli/main.py
@@ -1,4 +1,5 @@
 import importlib
+
 import click
 
 CONTEXT = {"help_option_names": ["-h", "--help"]}
@@ -20,32 +21,105 @@ def lazy_import_command(import_path):
         module = importlib.import_module(module_path)
         command = getattr(module, attr_name)
         return command.main(args=args, standalone_mode=True)
+
     return callback
 
 
 # Command list: (name, import_path, help)
 COMMANDS = [
-    ("estimate_bleaching", "biahub.estimate_bleaching.estimate_bleaching_cli", "Estimate bleaching from raw data"),
-    ("estimate_deskew", "biahub.estimate_deskew.estimate_deskew_cli", "Routine for estimating deskewing parameters"),
+    (
+        "estimate_bleaching",
+        "biahub.estimate_bleaching.estimate_bleaching_cli",
+        "Estimate bleaching from raw data",
+    ),
+    (
+        "estimate_deskew",
+        "biahub.estimate_deskew.estimate_deskew_cli",
+        "Routine for estimating deskewing parameters",
+    ),
     ("deskew", "biahub.deskew.deskew_cli", "Deskew a single position across T and C axes"),
-    ("estimate_registration", "biahub.estimate_registration.estimate_registration_cli", "Estimate affine transform between timepoints or arms"),
-    ("optimize_registration", "biahub.optimize_registration.optimize_registration_cli", "Optimize transform based on match filtering"),
-    ("register", "biahub.register.register_cli", "Apply an affine transformation to a single position"),
-    ("estimate_stitch", "biahub.estimate_stitch.estimate_stitch_cli", "Estimate stitching parameters for positions"),
+    (
+        "estimate_registration",
+        "biahub.estimate_registration.estimate_registration_cli",
+        "Estimate affine transform between timepoints or arms",
+    ),
+    (
+        "optimize_registration",
+        "biahub.optimize_registration.optimize_registration_cli",
+        "Optimize transform based on match filtering",
+    ),
+    (
+        "register",
+        "biahub.register.register_cli",
+        "Apply an affine transformation to a single position",
+    ),
+    (
+        "estimate_stitch",
+        "biahub.estimate_stitch.estimate_stitch_cli",
+        "Estimate stitching parameters for positions",
+    ),
     ("stitch", "biahub.stitch.stitch_cli", "Stitch positions in wells of a zarr store"),
-    ("concatenate", "biahub.concatenate.concatenate_cli", "Concatenate datasets (with optional cropping)"),
-    ("estimate_stabilization", "biahub.estimate_stabilization.estimate_stabilization_cli", "Estimate translation matrices for XYZ stabilization"),
-    ("stabilize", "biahub.stabilize.stabilize_cli", "Apply stabilization transforms to dataset"),
-    ("estimate_crop", "biahub.estimate_crop.estimate_crop_cli", "Estimate crop region for dual-channel alignment"),
-    ("compute_transfer_function", "biahub.compute_transfer_function.compute_transfer_function_cli", "Compute transfer function using PSF"),
-    ("apply_inverse_transfer_function", "biahub.apply_inverse_transfer_function.apply_inverse_transfer_function_cli", "Apply inverse transfer function to dataset"),
-    ("reconstruct", "biahub.reconstruct.reconstruct_cli", "Reconstruct a dataset using config"),
-    ("estimate_psf", "biahub.estimate_psf.estimate_psf_cli", "Estimate point spread function from beads"),
-    ("deconvolve", "biahub.deconvolve.deconvolve_cli", "Deconvolve across T and C axes using a PSF"),
-    ("characterize_psf", "biahub.characterize_psf.characterize_psf_cli", "Characterize point spread function (PSF)"),
-    ("segment", "biahub.segment.segment_cli", "Segment a position using pretrained model or pipeline"),
+    (
+        "concatenate",
+        "biahub.concatenate.concatenate_cli",
+        "Concatenate datasets (with optional cropping)",
+    ),
+    (
+        "estimate_stabilization",
+        "biahub.estimate_stabilization.estimate_stabilization_cli",
+        "Estimate translation matrices for XYZ stabilization",
+    ),
+    (
+        "stabilize",
+        "biahub.stabilize.stabilize_cli",
+        "Apply stabilization transforms to dataset",
+    ),
+    (
+        "estimate_crop",
+        "biahub.estimate_crop.estimate_crop_cli",
+        "Estimate crop region for dual-channel alignment",
+    ),
+    (
+        "compute_transfer_function",
+        "biahub.compute_transfer_function.compute_transfer_function_cli",
+        "Compute transfer function using PSF",
+    ),
+    (
+        "apply_inverse_transfer_function",
+        "biahub.apply_inverse_transfer_function.apply_inverse_transfer_function_cli",
+        "Apply inverse transfer function to dataset",
+    ),
+    (
+        "reconstruct",
+        "biahub.reconstruct.reconstruct_cli",
+        "Reconstruct a dataset using config",
+    ),
+    (
+        "estimate_psf",
+        "biahub.estimate_psf.estimate_psf_cli",
+        "Estimate point spread function from beads",
+    ),
+    (
+        "deconvolve",
+        "biahub.deconvolve.deconvolve_cli",
+        "Deconvolve across T and C axes using a PSF",
+    ),
+    (
+        "characterize_psf",
+        "biahub.characterize_psf.characterize_psf_cli",
+        "Characterize point spread function (PSF)",
+    ),
+    (
+        "segment",
+        "biahub.segment.segment_cli",
+        "Segment a position using pretrained model or pipeline",
+    ),
     ("virtual_stain", "biahub.virtual_stain.virtual_stain_cli", "Run VisCy virtual staining"),
-    ("process_with_config", "biahub.process_data.process_with_config_cli", "Process data with YAML-defined functions"),
+    (
+        "process_with_config",
+        "biahub.process_data.process_with_config_cli",
+        "Process data with YAML-defined functions",
+    ),
     ("track", "biahub.track.track_cli", "Track objects in 2D/3D time-lapse microscopy"),
 ]
 
@@ -57,7 +131,7 @@ for name, import_path, help_text in COMMANDS:
             name=name,
             callback=lazy_import_command(import_path),
             help=help_text,
-            short_help=help_text.split(".")[0]
+            short_help=help_text.split(".")[0],
         )
     )
 


### PR DESCRIPTION
###Overview
This PR introduces lazy loading of subcommands in the biahub CLI to significantly reduce startup time. Instead of importing all subcommands and their dependencies at once, each command is now loaded only when invoked.

### Problem Before
Previously, the top-level CLI eagerly imported all command modules:

```python
from biahub.track import track_cli
from biahub.segment import segment_cli
cli.add_command(track_cli)
cli.add_command(segment_cli)
```

This meant that running even a simple command like biahub --help triggered import of all dependencies (e.g. torch, numpy, zarr, etc.), resulting in:

```bash
time biahub --help
real    0m18.0s
```

### Solution
We now use lazy registration of commands via `click.Command` and `importlib`. Each command is registered with a short help string and a stub callback that imports and invokes the actual command only when needed.

**Key changes**

- COMMANDS is now a list of dictionaries (name, import_path, help)
- lazy_import_command() defers importing the real command until runtime
- biahub --help now runs in ~0.2s instead of 18s
