### PR TITLE
Preserve zarr version in register command

### DIFF
--- a/biahub/cli/utils.py
+++ b/biahub/cli/utils.py
@@ -47,6 +47,7 @@ def create_empty_hcs_zarr(
     scale: Tuple[float] = (1, 1, 1, 1, 1),
     dtype: DTypeLike = np.float32,
     max_chunk_size_bytes=500e6,
+    version: str = "0.4",
 ) -> None:
     """
     If the plate does not exist, create an empty zarr plate.
@@ -65,6 +66,8 @@ def create_empty_hcs_zarr(
     channel_names : list[str]
         Channel names, will append if not present in metadata.
     dtype : DTypeLike
+    version : str
+        OME-NGFF version ("0.4" or "0.5"), by default "0.4"
 
     Modifying from recOrder
     https://github.com/mehta-lab/recOrder/blob/d31ad910abf84c65ba927e34561f916651cbb3e8/recOrder/cli/utils.py#L12
@@ -88,7 +91,11 @@ def create_empty_hcs_zarr(
 
     # Create plate
     output_plate = open_ome_zarr(
-        str(store_path), layout="hcs", mode="a", channel_names=channel_names
+        str(store_path),
+        layout="hcs",
+        mode="a",
+        channel_names=channel_names,
+        version=version,
     )
     transform = [TransformationMeta(type="scale", scale=scale)]
 

--- a/biahub/cli/utils.py
+++ b/biahub/cli/utils.py
@@ -75,6 +75,10 @@ def create_empty_hcs_zarr(
     MAX_CHUNK_SIZE = max_chunk_size_bytes  # in bytes
     bytes_per_pixel = np.dtype(dtype).itemsize
 
+    # Convert shape and scale to native Python types for zarr v3 compatibility
+    shape = tuple(int(x) for x in shape)
+    scale = tuple(float(x) for x in scale)
+
     # Limiting the chunking to 500MB
     if chunks is None:
         chunk_zyx_shape = list(shape[-3:])
@@ -85,9 +89,13 @@ def create_empty_hcs_zarr(
             and np.prod(chunk_zyx_shape) * bytes_per_pixel > MAX_CHUNK_SIZE
         ):
             chunk_zyx_shape[-3] = np.ceil(chunk_zyx_shape[-3] / 2).astype(int)
-        chunk_zyx_shape = tuple(chunk_zyx_shape)
+        # Convert to native Python integers for zarr v3 compatibility
+        chunk_zyx_shape = tuple(int(x) for x in chunk_zyx_shape)
 
         chunks = 2 * (1,) + chunk_zyx_shape
+    else:
+        # Convert provided chunks to native Python integers for zarr v3 compatibility
+        chunks = tuple(int(x) for x in chunks)
 
     # Create plate
     output_plate = open_ome_zarr(
@@ -103,7 +111,9 @@ def create_empty_hcs_zarr(
     for position_key in position_keys:
         position_key_string = "/".join(position_key)
         # Check if position is already in the store, if not create it
-        if position_key_string not in output_plate.zgroup:
+        try:
+            position = output_plate[position_key_string]
+        except KeyError:
             position = output_plate.create_position(*position_key)
             _ = position.create_zeros(
                 name="0",
@@ -112,17 +122,15 @@ def create_empty_hcs_zarr(
                 dtype=dtype,
                 transform=transform,
             )
-        else:
-            position = output_plate[position_key_string]
 
-    # Check if channel_names are already in the store, if not append them
-    for channel_name in channel_names:
-        # Read channel names directly from metadata to avoid race conditions
-        metadata_channel_names = [
-            channel.label for channel in position.metadata.omero.channels
-        ]
-        if channel_name not in metadata_channel_names:
-            position.append_channel(channel_name, resize_arrays=True)
+        # Check if channel_names are already in the store, if not append them
+        for channel_name in channel_names:
+            # Read channel names directly from metadata to avoid race conditions
+            metadata_channel_names = [
+                channel.label for channel in position.metadata.omero.channels
+            ]
+            if channel_name not in metadata_channel_names:
+                position.append_channel(channel_name, resize_arrays=True)
 
 
 def get_output_paths(

--- a/biahub/register.py
+++ b/biahub/register.py
@@ -497,10 +497,21 @@ def register_cli(
         "dtype": np.float32,
     }
 
+    # Detect input zarr version to preserve it in output
+    input_version = "0.4"
+    try:
+        source_plate_path = Path(source_position_dirpaths[0]).parent.parent.parent
+        with open_ome_zarr(source_plate_path, mode="r") as input_plate:
+            input_version = input_plate.version
+    except (RuntimeError, FileNotFoundError):
+        # Position is not part of a plate, use default version
+        pass
+
     # Create the output zarr mirroring source_position_dirpaths
     create_empty_hcs_zarr(
         store_path=output_dirpath,
         position_keys=[p.parts[-3:] for p in source_position_dirpaths],
+        version=input_version,
         **output_metadata,
     )
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -166,6 +166,7 @@ def create_custom_plate():
         z_size=4,
         y_size=5,
         x_size=6,
+        version="0.4",
     ):
         """
         Create a plate with custom channel names
@@ -177,6 +178,7 @@ def create_custom_plate():
             z_size: Size of Z dimension (default: 4)
             y_size: Size of Y dimension (default: 5)
             x_size: Size of X dimension (default: 6)
+            version: OME-NGFF version ("0.4" or "0.5", default: "0.4")
 
         Returns:
             Tuple of (plate_path, plate_dataset)
@@ -189,6 +191,7 @@ def create_custom_plate():
             layout="hcs",
             mode="w",
             channel_names=channel_names,
+            version=version,
         )
 
         for row, col, fov in position_list:


### PR DESCRIPTION
Add version parameter to create_empty_hcs_zarr() and detect input zarr version in register_cli() to ensure output version matches input (v2→v2, v3→v3). This maintains compatibility with both OME-NGFF v0.4 (zarr v2) and v0.5 (zarr v3) datasets.

Changes follow the pattern from waveOrder PR#519:
- Add optional version parameter to create_empty_hcs_zarr (default "0.4")
- Pass version to open_ome_zarr when creating output plate
- Detect input version from source plate in register_cli
- Backward compatible: existing calls use default "0.4"

Pair-coded-with: Soorya Pradeep <@Soorya19Pradeep>