### PR TITLE
Move GUI deps (napari, PyQt6) to optional dependency group

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ classifiers = [
 
 # list package dependencies here
 dependencies = [
-  "iohub[tensorstore]>=0.3.0a5,<0.4",
+  "iohub[tensorstore] @ git+https://github.com/czbiohub-sf/iohub.git@xarray-integration",
   "stitch @ git+https://github.com/ahillsley/stitching@jen",
   "matplotlib",
   "natsort",
@@ -60,7 +60,7 @@ build = ["build", "twine"]
 all = ["biahub[segment,track,shard,build,gui]"]
 
 dev = [
-  "biahub[all]",
+  "biahub[segment,track,shard,build]",
   "black==25.1",
   "flake8==7.2",
   "isort==6.0",


### PR DESCRIPTION
## Summary
- Moves `napari`, `PyQt6`, and `napari-animation` from core dependencies to a new `gui` optional dependency group
- `pip install -e .` no longer requires Qt/GUI libraries, fixing install on headless/HPC systems
- GUI users install with `pip install -e ".[gui]"` (also included in `.[all]`)
- Pins `iohub` to git `xarray-integration` branch to match `waveorder`'s requirement, fixing the dependency conflict
- Excludes `gui` from `dev` extra so CI doesn't fail building PyQt6 on headless runners

Fixes #206