### PR TITLE
Preserve OME-Zarr version across pipelines, with override knob

### DIFF
--- a/biahub/cli/utils.py
+++ b/biahub/cli/utils.py
@@ -1,6 +1,7 @@
 import os
 
 from pathlib import Path
+from typing import Literal
 
 import numpy as np
 import yaml
@@ -15,6 +16,21 @@ def get_submitit_cluster(local: bool = False) -> str:
     if os.environ.get("CI") == "true":
         return "debug"
     return "local" if local else "slurm"
+
+
+def resolve_ome_zarr_version(
+    reference_store_path: Path,
+    override: Literal["0.4", "0.5"] | None,
+) -> Literal["0.4", "0.5"]:
+    """Pick the OME-Zarr version to use for an output store.
+
+    When ``override`` is set it wins; otherwise the version is read from
+    ``reference_store_path`` so the output preserves the input's version.
+    """
+    if override is not None:
+        return override
+    with open_ome_zarr(str(reference_store_path), mode="r") as dataset:
+        return dataset.version
 
 
 def update_model(model_instance, update_dict):

--- a/biahub/concatenate.py
+++ b/biahub/concatenate.py
@@ -24,6 +24,7 @@ from biahub.cli.utils import (
     estimate_resources,
     get_output_paths,
     get_submitit_cluster,
+    resolve_ome_zarr_version,
     yaml_to_model,
 )
 from biahub.settings import ConcatenateSettings
@@ -366,7 +367,9 @@ def concatenate(
         "shape": (len(input_time_indices), len(all_channel_names)) + tuple(cropped_shape_zyx),
         "chunks": chunk_size,
         "shards_ratio": settings.shards_ratio,
-        "version": settings.output_ome_zarr_version,
+        "version": resolve_ome_zarr_version(
+            all_data_paths[0], settings.output_ome_zarr_version
+        ),
         "scale": (1,) * 2 + tuple(output_voxel_size),
         "channel_names": all_channel_names,
         "dtype": dtype,

--- a/biahub/deconvolve.py
+++ b/biahub/deconvolve.py
@@ -25,6 +25,7 @@ from biahub.cli.utils import (
     estimate_resources,
     get_output_paths,
     get_submitit_cluster,
+    resolve_ome_zarr_version,
     yaml_to_model,
 )
 from biahub.settings import DeconvolveSettings
@@ -125,6 +126,9 @@ def deconvolve_cli(
         channel_names=channel_names,
         shape=shape,
         scale=scale,
+        version=resolve_ome_zarr_version(
+            input_position_dirpaths[0], settings.output_ome_zarr_version
+        ),
     )
 
     # Compute transfer function

--- a/biahub/deskew.py
+++ b/biahub/deskew.py
@@ -22,7 +22,12 @@ from biahub.cli.parsing import (
     sbatch_filepath,
     sbatch_to_submitit,
 )
-from biahub.cli.utils import estimate_resources, get_submitit_cluster, yaml_to_model
+from biahub.cli.utils import (
+    estimate_resources,
+    get_submitit_cluster,
+    resolve_ome_zarr_version,
+    yaml_to_model,
+)
 from biahub.settings import DeskewSettings
 
 # Needed for multiprocessing with GPUs
@@ -388,6 +393,9 @@ def deskew(
         channel_names=channel_names,
         shape=(T, C) + deskewed_shape,
         scale=(1, 1) + voxel_size,
+        version=resolve_ome_zarr_version(
+            input_position_dirpaths[0], settings.output_ome_zarr_version
+        ),
     )
 
     deskew_args = {

--- a/biahub/flat_field_correction.py
+++ b/biahub/flat_field_correction.py
@@ -22,6 +22,7 @@ from biahub.cli.utils import (
     _check_nan_n_zeros,
     estimate_resources,
     get_submitit_cluster,
+    resolve_ome_zarr_version,
     yaml_to_model,
 )
 from biahub.settings import FlatFieldCorrectionSettings
@@ -194,7 +195,9 @@ def flat_field(
         shape=(T, C, Z, Y, X),
         chunks=None,
         scale=scale,
-        version="0.5",
+        version=resolve_ome_zarr_version(
+            input_position_dirpaths[0], settings.output_ome_zarr_version
+        ),
         dtype=np.float32,
     )
 

--- a/biahub/process_data.py
+++ b/biahub/process_data.py
@@ -24,6 +24,7 @@ from biahub.cli.utils import (
     estimate_resources,
     get_output_paths,
     get_submitit_cluster,
+    resolve_ome_zarr_version,
     yaml_to_model,
 )
 from biahub.settings import ProcessingFunctions, ProcessingImportFuncSettings
@@ -250,6 +251,9 @@ def process_with_config(
         "scale": new_scale,
         "channel_names": channel_names,
         "dtype": np.float32,
+        "version": resolve_ome_zarr_version(
+            input_position_dirpaths[0], settings.output_ome_zarr_version
+        ),
     }
 
     # Create the output zarr mirroring input_position_dirpaths

--- a/biahub/register.py
+++ b/biahub/register.py
@@ -26,6 +26,7 @@ from biahub.cli.utils import (
     copy_n_paste_czyx,
     estimate_resources,
     get_submitit_cluster,
+    resolve_ome_zarr_version,
     yaml_to_model,
 )
 from biahub.settings import RegistrationSettings
@@ -493,6 +494,9 @@ def register_cli(
         "scale": (1,) * 2 + tuple(output_voxel_size),
         "channel_names": output_channel_names,
         "dtype": np.float32,
+        "version": resolve_ome_zarr_version(
+            source_position_dirpaths[0], settings.output_ome_zarr_version
+        ),
     }
 
     # Create the output zarr mirroring source_position_dirpaths

--- a/biahub/segment.py
+++ b/biahub/segment.py
@@ -19,7 +19,12 @@ from biahub.cli.parsing import (
     sbatch_filepath,
     sbatch_to_submitit,
 )
-from biahub.cli.utils import estimate_resources, get_submitit_cluster, yaml_to_model
+from biahub.cli.utils import (
+    estimate_resources,
+    get_submitit_cluster,
+    resolve_ome_zarr_version,
+    yaml_to_model,
+)
 from biahub.settings import SegmentationSettings
 
 
@@ -198,6 +203,9 @@ def segment_cli(
         shape=segmentation_shape,
         chunks=None,
         scale=scale,
+        version=resolve_ome_zarr_version(
+            input_position_dirpaths[0], settings.output_ome_zarr_version
+        ),
     )
 
     # Estimate resources

--- a/biahub/settings.py
+++ b/biahub/settings.py
@@ -603,6 +603,8 @@ class StitchSettings(BaseModel):
     channels: list[str] | None = None
     total_translation: dict[str, list[float, float, float]] | None = None
     affine_transform: dict[str, list] | None = None
+    # When None, preserve the OME-Zarr version of the input store.
+    output_ome_zarr_version: Literal["0.4", "0.5"] | None = None
 
     def __init__(self, **data):
         # Adding a leading zero for zyx translation for backwards compatibility

--- a/biahub/settings.py
+++ b/biahub/settings.py
@@ -39,6 +39,8 @@ class ProcessingFunctions(MyBaseModel):
 
 class ProcessingImportFuncSettings(MyBaseModel):
     processing_functions: list[ProcessingFunctions] = []
+    # When None, preserve the OME-Zarr version of the input store.
+    output_ome_zarr_version: Literal["0.4", "0.5"] | None = None
 
 
 class ProcessingInputChannel(MyBaseModel):
@@ -64,6 +66,8 @@ class TrackingSettings(MyBaseModel):
     z_range: tuple[int, int] | None = None
     input_images: list[ProcessingInputChannel]
     tracking_config: dict[str, Any] = {}
+    # When None, preserve the OME-Zarr version of the input store.
+    output_ome_zarr_version: Literal["0.4", "0.5"] | None = None
 
     @field_validator("blank_frames_path")
     @classmethod
@@ -281,6 +285,8 @@ class EstimateStabilizationSettings(MyBaseModel):
 
 class FlatFieldCorrectionSettings(MyBaseModel):
     channel_names: list[str] | None = None
+    # When None, preserve the OME-Zarr version of the input store.
+    output_ome_zarr_version: Literal["0.4", "0.5"] | None = None
 
 
 class ProcessingSettings(MyBaseModel):
@@ -297,6 +303,8 @@ class DeskewSettings(MyBaseModel):
     keep_overhang: bool = False
     overhang_fill: Literal["zero", "mean"] = "zero"
     average_n_slices: PositiveInt = 3
+    # When None, preserve the OME-Zarr version of the input store.
+    output_ome_zarr_version: Literal["0.4", "0.5"] | None = None
 
     @field_validator("ls_angle_deg")
     @classmethod
@@ -332,6 +340,8 @@ class RegistrationSettings(MyBaseModel):
     interpolation: str = "linear"
     time_indices: NonNegativeInt | list[NonNegativeInt] | Literal["all"] = "all"
     verbose: bool = False
+    # When None, preserve the OME-Zarr version of the input store.
+    output_ome_zarr_version: Literal["0.4", "0.5"] | None = None
 
     @field_validator("affine_transform_zyx")
     @classmethod
@@ -362,6 +372,8 @@ class PsfFromBeadsSettings(MyBaseModel):
 
 class DeconvolveSettings(MyBaseModel):
     regularization_strength: PositiveFloat = 0.001
+    # When None, preserve the OME-Zarr version of the input store.
+    output_ome_zarr_version: Literal["0.4", "0.5"] | None = None
 
 
 class CharacterizeSettings(MyBaseModel):
@@ -396,7 +408,10 @@ class ConcatenateSettings(MyBaseModel):
     chunks_czyx: Literal[None] | list[int] = None
     shards_ratio: list[int] | None = None
     ensure_unique_positions: bool | None = False
-    output_ome_zarr_version: Literal["0.4", "0.5"] = "0.4"
+    # Concatenate is the migration path into v0.5 stores, so it defaults to
+    # "0.5". Set to None to preserve the input store's OME-Zarr version, or
+    # to "0.4" / "0.5" to force a specific output version.
+    output_ome_zarr_version: Literal["0.4", "0.5"] | None = "0.5"
 
     @field_validator("concat_data_paths")
     @classmethod
@@ -567,6 +582,8 @@ class StabilizationSettings(MyBaseModel):
     output_voxel_size: list[
         PositiveFloat, PositiveFloat, PositiveFloat, PositiveFloat, PositiveFloat
     ] = [1.0, 1.0, 1.0, 1.0, 1.0]
+    # When None, preserve the OME-Zarr version of the input store.
+    output_ome_zarr_version: Literal["0.4", "0.5"] | None = None
 
     @field_validator("affine_transform_zyx_list")
     @classmethod
@@ -662,4 +679,6 @@ class SegmentationModel(BaseModel):
 
 class SegmentationSettings(BaseModel):
     models: dict[str, SegmentationModel]
+    # When None, preserve the OME-Zarr version of the input store.
+    output_ome_zarr_version: Literal["0.4", "0.5"] | None = None
     model_config = {"extra": "forbid", "protected_namespaces": ()}

--- a/biahub/stabilize.py
+++ b/biahub/stabilize.py
@@ -25,6 +25,7 @@ from biahub.cli.utils import (
     copy_n_paste_czyx,
     estimate_resources,
     get_submitit_cluster,
+    resolve_ome_zarr_version,
     yaml_to_model,
 )
 from biahub.register import convert_transform_to_ants
@@ -217,6 +218,9 @@ def stabilize(
         "scale": settings.output_voxel_size,
         "channel_names": channel_names,
         "dtype": np.float32,
+        "version": resolve_ome_zarr_version(
+            input_position_dirpaths[0], settings.output_ome_zarr_version
+        ),
     }
 
     # Create the output zarr mirroring input_position_dirpaths

--- a/biahub/stitch.py
+++ b/biahub/stitch.py
@@ -21,7 +21,12 @@ from biahub.cli.parsing import (
     sbatch_filepath,
     sbatch_to_submitit,
 )
-from biahub.cli.utils import estimate_resources, get_submitit_cluster, yaml_to_model
+from biahub.cli.utils import (
+    estimate_resources,
+    get_submitit_cluster,
+    resolve_ome_zarr_version,
+    yaml_to_model,
+)
 from biahub.settings import StitchSettings
 
 
@@ -361,9 +366,18 @@ def stitch_cli(
     if not all(channel in input_channels for channel in settings.channels):
         raise ValueError("Invalid channel(s) provided.")
 
-    # Create output store
+    # Create output store. Per-well output shapes differ, so we open the
+    # plate directly rather than going through `create_empty_plate`, but we
+    # still route the OME-Zarr version through `resolve_ome_zarr_version`
+    # so the output matches the input (or the settings override).
     output_plate = open_ome_zarr(
-        output_dirpath, layout="hcs", mode="w", channel_names=settings.channels
+        output_dirpath,
+        layout="hcs",
+        mode="w",
+        channel_names=settings.channels,
+        version=resolve_ome_zarr_version(
+            input_position_dirpaths[0], settings.output_ome_zarr_version
+        ),
     )
 
     # Group shift metadata by well

--- a/biahub/track.py
+++ b/biahub/track.py
@@ -33,6 +33,7 @@ from biahub.cli.resolve_function import resolve_function
 from biahub.cli.utils import (
     estimate_resources,
     get_submitit_cluster,
+    resolve_ome_zarr_version,
     update_model,
     yaml_to_model,
 )
@@ -859,6 +860,9 @@ def track(
         "scale": scale,
         "channel_names": [f"{settings.target_channel}_labels"],
         "dtype": np.uint32,
+        "version": resolve_ome_zarr_version(
+            input_position_dirpaths[0], settings.output_ome_zarr_version
+        ),
     }
 
     # Create the output zarr mirroring input_position_dirpaths


### PR DESCRIPTION
## Summary
- Add `output_ome_zarr_version: Literal["0.4", "0.5"] | None` to biahub settings classes that drive output zarr creation. Default is `None` (preserve the input store's version). Set `"0.4"` / `"0.5"` to force.
- `ConcatenateSettings` keeps a non-None default of `"0.5"` since concatenate is the migration path into v0.5 stores (but `None` is now accepted too).
- New helper `biahub.cli.utils.resolve_ome_zarr_version(reference_store, override)` returns the override when set, otherwise reads `.version` off the reference store.
- Each consumer (`concatenate`, `register`, `stabilize`, `deskew`, `flat_field_correction`, `deconvolve`, `track`, `process_data`, `segment`) now threads the resolved version into `create_empty_plate(..., version=...)`.
- `flat_field_correction.py`: replaces the previously hard-coded `version=\"0.5\"` with the resolved value.
- Reconstruction (`apply_inverse_transfer_function.py`) already preserves the input version via `waveorder.get_reconstruction_output_metadata`, so no biahub settings field is added there (follow-up).

## Test plan
- [x] `uv run pytest` — 98 passed, 1 skipped locally.
- [x] Verify a v0.4 input produces a v0.4 output for at least one non-concatenate pipeline on real data.
- [x] Verify a v0.5 input produces a v0.5 output.
- [x] Verify the override works (`output_ome_zarr_version: "0.5"` on a v0.4 input produces a v0.5 output).
- [x] Custom implementation for `stitch.py` which does not use `create_empty_plate`

🤖 Generated with [Claude Code](https://claude.com/claude-code)