### PR TITLE
Refactor flat-field to use iohub's process_single_position

### DIFF
--- a/biahub/flat_field_correction.py
+++ b/biahub/flat_field_correction.py
@@ -1,6 +1,3 @@
-import multiprocessing as mp
-
-from functools import partial
 from pathlib import Path
 
 import click
@@ -8,19 +5,21 @@ import numpy as np
 import submitit
 
 from iohub.ngff import open_ome_zarr
-from iohub.ngff.utils import create_empty_plate
+from iohub.ngff.utils import create_empty_plate, process_single_position
 
+from biahub.cli.monitor import monitor_jobs
 from biahub.cli.parsing import (
     config_filepath,
     input_position_dirpaths,
     local,
+    monitor,
     output_dirpath,
     sbatch_filepath,
     sbatch_to_submitit,
 )
 from biahub.cli.utils import (
-    _check_nan_n_zeros,
     estimate_resources,
+    get_output_paths,
     get_submitit_cluster,
     resolve_ome_zarr_version,
     yaml_to_model,
@@ -28,12 +27,8 @@ from biahub.cli.utils import (
 from biahub.settings import FlatFieldCorrectionSettings
 
 
-def flat_field_correction(
-    zyx_data: np.ndarray,
-    axis: int = 0,
-) -> tuple[np.ndarray, dict]:
-    """
-    Apply flat field correction by dividing out the median pattern along an axis.
+def flat_field_correction(zyx_data: np.ndarray, axis: int = 0) -> np.ndarray:
+    """Apply flat field correction by dividing out the median pattern along an axis.
 
     Parameters
     ----------
@@ -44,92 +39,28 @@ def flat_field_correction(
 
     Returns
     -------
-    Tuple[np.ndarray, dict]
-        A tuple containing the flat field corrected data and the static pattern statistics.
+    np.ndarray
+        Flat-field corrected data, normalised so the mean of the static pattern
+        is preserved.
     """
     static_pattern = np.median(zyx_data, axis=axis)
-    mean_val = static_pattern.mean()
-    static_dict = {
-        "mean": float(mean_val),
-        "min": float(static_pattern.min()),
-        "max": float(static_pattern.max()),
-        "std": float(static_pattern.std()),
-    }
-    return zyx_data / static_pattern * mean_val, static_dict
+    return zyx_data / static_pattern * static_pattern.mean()
 
 
-def _process_timepoint(
-    input_data_path: Path,
-    output_position_path: Path,
-    channel_names: list[str],
-    t_idx: int,
-):
-    """Process all channels for a single timepoint."""
-    with open_ome_zarr(input_data_path, mode="r") as input_dataset:
-        all_channel_names = input_dataset.channel_names
-        C = input_dataset.data.shape[1]
+def _czyx_flat_field(czyx_data: np.ndarray, target_indices: list[int]) -> np.ndarray:
+    """Apply flat-field correction to selected channels of a CZYX volume.
 
-        for c_idx in range(C):
-            channel_name = all_channel_names[c_idx]
-            zyx_data = np.asarray(input_dataset.data[t_idx, c_idx])
-
-            if _check_nan_n_zeros(zyx_data):
-                click.echo(f"[t={t_idx}, c={c_idx}] Skipped (all zeros or nans)")
-                continue
-
-            if channel_name in channel_names:
-                zyx_data, static_dict = flat_field_correction(zyx_data)
-            else:
-                zyx_data = np.asarray(zyx_data, dtype=np.float32)
-                static_dict = None
-
-            with open_ome_zarr(output_position_path, mode="r+") as output_dataset:
-                output_dataset[0][t_idx, c_idx] = zyx_data
-                if static_dict is not None:
-                    output_dataset.zattrs[f"flat-field-t{t_idx}-{channel_name}"] = static_dict
-
-    click.echo(f"[t={t_idx}] Done")
-
-
-def process_single_position_flat_field(
-    input_data_path: Path,
-    output_path: Path,
-    channel_names: list[str],
-    num_processes: int = mp.cpu_count(),
-):
-    """Apply flat field correction to a single position with multiprocessing over T.
-
-    Parameters
-    ----------
-    input_data_path : Path
-        Path to the input position.
-    output_path : Path
-        Path to the output zarr store.
-    channel_names : list[str]
-        Channel names to flat field correct.
-    num_processes : int
-        Number of parallel processes.
+    Channels listed in ``target_indices`` are corrected; the rest are
+    passed through unchanged (cast to float32 to match the output dtype).
     """
-    click.echo(f"Processing position: {input_data_path}")
-    position_key = input_data_path.parts[-3:]
-    output_position_path = output_path / Path(*position_key)
-
-    with open_ome_zarr(input_data_path, mode="r") as input_dataset:
-        T = input_dataset.data.shape[0]
-
-    click.echo(f"Starting multiprocess pool with {num_processes} processes")
-    with mp.Pool(num_processes) as pool:
-        pool.map(
-            partial(
-                _process_timepoint,
-                input_data_path,
-                output_position_path,
-                channel_names,
-            ),
-            range(T),
-        )
-
-    click.echo(f"Completed position: {input_data_path}")
+    out = np.empty_like(czyx_data, dtype=np.float32)
+    target = set(target_indices)
+    for c in range(czyx_data.shape[0]):
+        if c in target:
+            out[c] = flat_field_correction(czyx_data[c])
+        else:
+            out[c] = czyx_data[c].astype(np.float32)
+    return out
 
 
 def flat_field(
@@ -138,9 +69,9 @@ def flat_field(
     output_dirpath: str,
     sbatch_filepath: str = None,
     local: bool = False,
+    monitor: bool = True,
 ):
-    """
-    Apply flat field correction across T and selected C axes.
+    """Apply flat field correction across T and selected C axes.
 
     Parameters
     ----------
@@ -150,13 +81,17 @@ def flat_field(
         Path to the configuration file.
     output_dirpath : str
         Path to the output directory.
-    sbatch_filepath : str
-        Path to the sbatch file.
-    local : bool
-        If True, run locally.
+    sbatch_filepath : str, optional
+        Path to the SLURM batch file.
+    local : bool, optional
+        If True, run locally instead of submitting to SLURM.
+    monitor : bool, optional
+        If True, monitor the submitted jobs.
     """
     output_dirpath = Path(output_dirpath)
     slurm_out_path = output_dirpath.parent / "slurm_output"
+
+    output_position_paths = get_output_paths(input_position_dirpaths, output_dirpath)
 
     # Load settings
     settings = yaml_to_model(config_filepath, FlatFieldCorrectionSettings)
@@ -169,7 +104,7 @@ def flat_field(
 
     # Determine which channels to flat field correct
     if settings.channel_names is None:
-        channel_names = all_channel_names
+        target_channel_names = all_channel_names
         click.echo(f"Flat fielding ALL channels: {all_channel_names}")
     elif settings.channel_names:
         for name in settings.channel_names:
@@ -178,14 +113,16 @@ def flat_field(
                     f"Channel '{name}' not found in input dataset. "
                     f"Available channels: {all_channel_names}"
                 )
-        channel_names = settings.channel_names
+        target_channel_names = settings.channel_names
         click.echo(f"Input channels: {all_channel_names}")
-        click.echo(f"Flat field channels: {channel_names}")
+        click.echo(f"Flat field channels: {target_channel_names}")
         click.echo("Other channels will be copied as-is")
     else:
         raise click.ClickException(
             "Must specify either 'channel_names' or set channel_names to null in config."
         )
+
+    target_indices = [all_channel_names.index(name) for name in target_channel_names]
 
     # Create output zarr with all channels
     create_empty_plate(
@@ -200,6 +137,11 @@ def flat_field(
         ),
         dtype=np.float32,
     )
+
+    flat_field_args = {
+        "target_indices": target_indices,
+        "extra_metadata": {"flat_field_correction": settings.model_dump()},
+    }
 
     # Estimate resources
     num_cpus, gb_ram = estimate_resources(
@@ -229,17 +171,22 @@ def flat_field(
     executor = submitit.AutoExecutor(folder=slurm_out_path, cluster=cluster)
     executor.update_parameters(**slurm_args)
 
-    click.echo("Submitting jobs...")
+    click.echo("Submitting SLURM jobs...")
     jobs = []
     with submitit.helpers.clean_env(), executor.batch():
-        for input_position_path in input_position_dirpaths:
+        for input_position_path, output_position_path in zip(
+            input_position_dirpaths, output_position_paths, strict=True
+        ):
             jobs.append(
                 executor.submit(
-                    process_single_position_flat_field,
+                    process_single_position,
+                    _czyx_flat_field,
                     input_position_path,
-                    output_dirpath,
-                    channel_names,
-                    num_processes=slurm_args["slurm_cpus_per_task"],
+                    output_position_path,
+                    input_channel_indices=[list(range(C))],
+                    output_channel_indices=[list(range(C))],
+                    num_workers=int(slurm_args["slurm_cpus_per_task"]),
+                    **flat_field_args,
                 )
             )
 
@@ -250,7 +197,8 @@ def flat_field(
     with log_path.open("w") as log_file:
         log_file.write("\n".join(job_ids))
 
-    click.echo(f"Submitted {len(jobs)} jobs ({len(input_position_dirpaths)} positions)")
+    if monitor:
+        monitor_jobs(jobs, input_position_dirpaths)
 
 
 @click.command("flat-field")
@@ -259,12 +207,14 @@ def flat_field(
 @output_dirpath()
 @sbatch_filepath()
 @local()
+@monitor()
 def flat_field_correction_cli(
     input_position_dirpaths: list[str],
     config_filepath: Path,
     output_dirpath: str,
     sbatch_filepath: str = None,
     local: bool = False,
+    monitor: bool = True,
 ):
     """Apply flat field correction across T and selected C axes.
 
@@ -279,6 +229,7 @@ def flat_field_correction_cli(
         output_dirpath=output_dirpath,
         sbatch_filepath=sbatch_filepath,
         local=local,
+        monitor=monitor,
     )
 
 


### PR DESCRIPTION
## Summary
- Replaces the hand-rolled `mp.Pool` flow in `biahub/flat_field_correction.py` with the same `iohub.ngff.utils.process_single_position` pattern used by `biahub/deskew.py`.
- Channel selection moves into a `_czyx_flat_field` wrapper that processes target channels and passes others through; all channels are sent in a single batch so the wrapper can map indices.
- Drops per-(t, c) `static_dict` zattrs (no analog in deskew); settings are now written via `extra_metadata`.
- Adds `monitor` flag + `monitor_jobs` call and switches to `get_output_paths`, matching deskew.

Closes #242

## Test plan
- [x] `biahub flat-field -i ./input.zarr/*/*/* -c ./flat_field_params.yml -o ./output.zarr` against a real dataset (subset of channels)
- [x] Same, with `channel_names: null` in the config (all channels)
- [x] Confirm `extra_metadata` is written to the output store and contains the flat-field settings
- [x] Confirm non-target channels in the output match the input (cast to float32)

🤖 Generated with [Claude Code](https://claude.com/claude-code)