### PR TITLE
bug: fix num_workers → num_processes kwarg in deskew

### DIFF
--- a/biahub/concatenate.py
+++ b/biahub/concatenate.py
@@ -438,7 +438,7 @@ def concatenate(
                 output_channel_indices=output_channel_idx,
                 input_time_indices=input_time_indices,
                 output_time_indices=list(range(len(input_time_indices))),
-                num_workers=int(slurm_args["slurm_cpus_per_task"]),
+                num_processes=int(slurm_args["slurm_cpus_per_task"]),
                 **copy_n_paste_kwargs,
             )
             jobs.append(job)

--- a/biahub/deconvolve.py
+++ b/biahub/deconvolve.py
@@ -189,7 +189,7 @@ def deconvolve_cli(
                 deconvolve,
                 str(input_position_path),
                 str(output_position_path),
-                num_workers=int(slurm_args["slurm_cpus_per_task"]),
+                num_processes=int(slurm_args["slurm_cpus_per_task"]),
                 transfer_function_store_path=str(transfer_function_store_path),
                 regularization_strength=float(settings.regularization_strength),
             )

--- a/biahub/deskew.py
+++ b/biahub/deskew.py
@@ -686,7 +686,7 @@ def deskew(
                     _czyx_fast_deskew_data,
                     input_position_path,
                     output_position_path,
-                    num_workers=slurm_args["slurm_cpus_per_task"],
+                    num_processes=slurm_args["slurm_cpus_per_task"],
                     **deskew_args,
                 )
             )

--- a/biahub/flat_field_correction.py
+++ b/biahub/flat_field_correction.py
@@ -183,7 +183,7 @@ def flat_field(
                     _czyx_flat_field,
                     input_position_path,
                     output_position_path,
-                    num_workers=int(slurm_args["slurm_cpus_per_task"]),
+                    num_processes=int(slurm_args["slurm_cpus_per_task"]),
                     **flat_field_args,
                 )
             )

--- a/biahub/process_data.py
+++ b/biahub/process_data.py
@@ -309,7 +309,7 @@ def process_with_config(
                     input_time_indices=list(range(T)),
                     input_channel_indices=[list(range(C))],  # Process all channels
                     output_channel_indices=[list(range(C))],
-                    num_workers=slurm_args["slurm_cpus_per_task"],
+                    num_processes=slurm_args["slurm_cpus_per_task"],
                     **process_args,
                 )
             )

--- a/biahub/register.py
+++ b/biahub/register.py
@@ -570,7 +570,7 @@ def register_cli(
                     input_time_indices=time_indices,
                     input_channel_indices=[[source_channel_names.index(channel_name)]],
                     output_channel_indices=[[output_channel_names.index(channel_name)]],
-                    num_workers=int(slurm_args["slurm_cpus_per_task"]),
+                    num_processes=int(slurm_args["slurm_cpus_per_task"]),
                     **affine_transform_args,
                 )
                 affine_jobs.append(affine_job)
@@ -595,7 +595,7 @@ def register_cli(
                     input_time_indices=time_indices,
                     input_channel_indices=[[target_channel_names.index(channel_name)]],
                     output_channel_indices=[[output_channel_names.index(channel_name)]],
-                    num_workers=int(slurm_args["slurm_cpus_per_task"]),
+                    num_processes=int(slurm_args["slurm_cpus_per_task"]),
                     **copy_n_paste_kwargs,
                 )
                 copy_jobs.append(copy_job)

--- a/biahub/segment.py
+++ b/biahub/segment.py
@@ -247,7 +247,7 @@ def segment_cli(
                     output_position_path,
                     input_channel_indices=[list(range(C))],
                     output_channel_indices=[list(range(C_segment))],
-                    num_workers=np.min([20, int(num_cpus * 0.8)]),
+                    num_processes=np.min([20, int(num_cpus * 0.8)]),
                     segmentation_models=segment_args,
                 )
             )

--- a/biahub/stabilize.py
+++ b/biahub/stabilize.py
@@ -296,7 +296,7 @@ def stabilize(
                         output_shape=(Z, Y, X),
                         input_channel_indices=[[channel_names.index(channel_name)]],
                         output_channel_indices=[[channel_names.index(channel_name)]],
-                        num_workers=int(
+                        num_processes=int(
                             slurm_args["slurm_cpus_per_task"]
                         ),  # parallel processing over time
                         **stabilize_zyx_args,
@@ -310,7 +310,7 @@ def stabilize(
                         input_time_indices=time_indices,
                         input_channel_indices=[[channel_names.index(channel_name)]],
                         output_channel_indices=[[channel_names.index(channel_name)]],
-                        num_workers=int(slurm_args["slurm_cpus_per_task"]),
+                        num_processes=int(slurm_args["slurm_cpus_per_task"]),
                         **copy_n_paste_kwargs,
                     )
 


### PR DESCRIPTION
## Summary
- Commit 00cf0d9 (`Replace create_empty_hcs_zarr with iohub's create_empty_plate #215`) renamed `num_processes` to `num_workers` when calling `process_single_position`, but iohub's `process_single_position` expects `num_processes`.
- The mismatched kwarg leaked through `**kwargs` into the transform functions, causing **all SLURM jobs to fail** with errors like:
  ```
  TypeError: fast_deskew_zyx() got an unexpected keyword argument 'num_workers'
  TypeError: _czyx_flat_field() got an unexpected keyword argument 'num_workers'
  ```
- Fixed `num_workers` → `num_processes` in all affected modules:
  - `deskew.py`
  - `flat_field_correction.py`
  - `deconvolve.py`
  - `concatenate.py`
  - `register.py` (2 call sites)
  - `process_data.py`
  - `stabilize.py` (2 call sites)
  - `segment.py`

## Test plan
- [ ] Re-run deskew and flatfield SLURM jobs and verify they complete successfully