### PR TITLE
Add cellpose segmentation and waveorder focus finding to tracking

### DIFF
--- a/biahub/cli/nf.py
+++ b/biahub/cli/nf.py
@@ -527,6 +527,68 @@ def rename_channels(input_zarr: str, position: str, prefix: str, suffix: str):
     click.echo(f"Renamed channels: {position}")
 
 
+@nf_cli.command("rename-channels-map")
+@click.option("--input-zarr", "-i", required=True, type=click.Path(exists=True))
+@click.option("--position", "-p", required=True)
+@click.option(
+    "--config",
+    "-c",
+    default=None,
+    type=click.Path(exists=True),
+    help="YAML config with rename rules. If not provided, applies default rules.",
+)
+def rename_channels_map(input_zarr: str, position: str, config: str | None):
+    """Rename channels using a mapping config (metadata-only, no data copy).
+
+    Default rules (when no config is provided):
+    - 'BF - Oblique' -> 'BF'
+    - 'Phase3D*' -> 'Phase3D'
+    - All other channels get 'raw ' prefix
+
+    Config YAML format::
+
+        rename_exact:
+          "BF - Oblique": "BF"
+        rename_startswith:
+          "Phase3D": "Phase3D"
+        raw_prefix_exclude:
+          - "BF - Oblique"
+          - "Phase3D"
+          - "nuclei_prediction"
+          - "membrane_prediction"
+    """
+    import yaml
+
+    if config:
+        with open(config) as f:
+            rules = yaml.safe_load(f)
+        rename_exact = rules.get("rename_exact", {})
+        rename_startswith = rules.get("rename_startswith", {})
+        raw_exclude = set(rules.get("raw_prefix_exclude", []))
+    else:
+        rename_exact = {"BF - Oblique": "BF"}
+        rename_startswith = {"Phase3D": "Phase3D"}
+        raw_exclude = {"BF - Oblique", "nuclei_prediction", "membrane_prediction"}
+
+    position_path = Path(input_zarr) / position
+    with open_ome_zarr(str(position_path), mode="r+") as pos:
+        for old_name in list(pos.channel_names):
+            if old_name in rename_exact:
+                new_name = rename_exact[old_name]
+            elif any(old_name.startswith(prefix) for prefix in rename_startswith):
+                new_name = next(
+                    v for k, v in rename_startswith.items() if old_name.startswith(k)
+                )
+            elif old_name not in raw_exclude and not old_name.startswith("raw "):
+                new_name = f"raw {old_name}"
+            else:
+                continue
+            pos.rename_channel(old_name, new_name)
+            click.echo(f"  '{old_name}' -> '{new_name}'")
+
+    click.echo(f"Renamed channels: {position}")
+
+
 # ---------------------------------------------------------------------------
 # Tracking
 # ---------------------------------------------------------------------------
@@ -624,7 +686,9 @@ def run_track(
 
     tracking_config = update_model(MainConfig(), settings.tracking_config)
 
-    cellpose_cfg = settings.cellpose_config if settings.segmentation_method == "cellpose" else None
+    cellpose_cfg = (
+        settings.cellpose_config if settings.segmentation_method == "cellpose" else None
+    )
 
     track_one_position(
         position_key=position_key,

--- a/biahub/cli/nf.py
+++ b/biahub/cli/nf.py
@@ -624,6 +624,8 @@ def run_track(
 
     tracking_config = update_model(MainConfig(), settings.tracking_config)
 
+    cellpose_cfg = settings.cellpose_config if settings.segmentation_method == "cellpose" else None
+
     track_one_position(
         position_key=position_key,
         input_images=settings.input_images,
@@ -632,6 +634,8 @@ def run_track(
         blank_frames_path=blank_path,
         z_slices=z_slices,
         scale=track_scale,
+        cellpose_config=cellpose_cfg,
+        focus_config=settings.focus_config,
     )
 
     click.echo(f"Tracking done: {position}")

--- a/biahub/settings.py
+++ b/biahub/settings.py
@@ -58,14 +58,39 @@ class ProcessingInputChannel(MyBaseModel):
         return v
 
 
+class CellposeConfig(MyBaseModel):
+    """Configuration for Cellpose segmentation used as input to tracking."""
+
+    model_type: str = "nuclei"
+    diameter: float = 80
+    cellprob_threshold: float = 0.0
+    flow_threshold: float = 0.4
+    gpu: bool = True
+    min_size: int = 500
+    input_channel: str = "nuclei_prediction"
+    labels_sigma: float = 5.0
+
+
+class FocusConfig(MyBaseModel):
+    """Optical parameters for waveorder focus finding."""
+
+    NA_det: float = 1.35
+    lambda_ill: float = 0.500
+    pixel_size: float = 0.1133
+    z_window: int = 40
+
+
 class TrackingSettings(MyBaseModel):
     target_channel: str = "nuclei_prediction"
     fov: str = "*/*/*"
     blank_frames_path: str = None
     mode: Literal["2D", "3D"] = "2D"
     z_range: tuple[int, int] | None = None
+    focus_config: FocusConfig | None = None
     input_images: list[ProcessingInputChannel]
     tracking_config: dict[str, Any] = {}
+    segmentation_method: Literal["foreground_contour", "cellpose"] = "foreground_contour"
+    cellpose_config: CellposeConfig | None = None
     # When None, preserve the OME-Zarr version of the input store.
     output_ome_zarr_version: Literal["0.4", "0.5"] | None = None
 

--- a/biahub/track.py
+++ b/biahub/track.py
@@ -18,12 +18,11 @@ import pandas as pd
 import submitit
 import toml
 
-
+from cellpose import models as cp_models
 from iohub import open_ome_zarr
 from iohub.ngff.utils import create_empty_plate
 from numpy.typing import ArrayLike
-from cellpose import models as cp_models
-
+from tqdm import tqdm
 
 from biahub.cli.parsing import (
     config_filepath,
@@ -40,8 +39,12 @@ from biahub.cli.utils import (
     update_model,
     yaml_to_model,
 )
-from biahub.settings import CellposeConfig, FocusConfig, ProcessingInputChannel, TrackingSettings
-from tqdm import tqdm
+from biahub.settings import (
+    CellposeConfig,
+    FocusConfig,
+    ProcessingInputChannel,
+    TrackingSettings,
+)
 
 # Lazy imports for ultrack - imported only when needed in specific functions
 
@@ -478,38 +481,24 @@ def run_cellpose_per_frame(
         labels[t] = mask
     return labels
 
+
 def run_ultrack(
     tracking_config: MainConfig,
-    scale: tuple[float, float] | tuple[float, float, float],
     database_path,
-    foreground_mask: ArrayLike | None = None,
-    contour_gradient_map: ArrayLike | None = None,
-    cellpose_labels: ArrayLike | None = None,
-    labels_sigma: float = 5.0,
+    **track_kwargs,
 ):
     """
     Run object tracking using the Ultrack library.
-
-    Supports two modes:
-    - **foreground+contour**: pass ``foreground_mask`` and ``contour_gradient_map``.
-    - **cellpose labels**: pass ``cellpose_labels`` (and optionally ``labels_sigma``).
 
     Parameters
     ----------
     tracking_config : MainConfig
         Ultrack configuration object.
-    scale : tuple of float
-        Physical resolution scale in (Y, X) or (Z, Y, X).
     database_path : Path
         Directory for tracking results and configuration files.
-    foreground_mask : ArrayLike, optional
-        Binary foreground mask. Required for foreground+contour mode.
-    contour_gradient_map : ArrayLike, optional
-        Edge/gradient map. Required for foreground+contour mode.
-    cellpose_labels : ArrayLike, optional
-        Integer label array from cellpose. Required for cellpose mode.
-    labels_sigma : float, optional
-        Gaussian sigma for ``labels_to_contours`` conversion. Default 5.0.
+    **track_kwargs
+        Keyword arguments forwarded to ``Tracker.track()``.
+        E.g. ``detection``, ``edges``, ``scale``, ``labels``, ``sigma``, ``overwrite``.
 
     Returns
     -------
@@ -530,21 +519,7 @@ def run_ultrack(
     print(cfg)
 
     tracker = Tracker(cfg)
-
-    if cellpose_labels is not None:
-        tracker.track(
-            labels=cellpose_labels,
-            sigma=labels_sigma,
-            scale=scale,
-            overwrite=True,
-        )
-    else:
-        tracker.track(
-            detection=foreground_mask,
-            edges=contour_gradient_map,
-            scale=scale,
-            overwrite=True,
-        )
+    tracker.track(**track_kwargs)
 
     tracks_df, graph = tracker.to_tracks_layer()
     labels = tracker.to_zarr(
@@ -751,7 +726,7 @@ def fill_empty_frames_from_csv(
     return data_dict
 
 
-def data_preprocessing(
+def foreground_preprocessing(
     position_key: str,
     input_images: list[ProcessingInputChannel],
     z_slices: slice,
@@ -796,7 +771,7 @@ def data_preprocessing(
     Examples
     --------
     >>> z_slice = slice(10, 15)
-    >>> foreground, contour = data_preprocessing(
+    >>> foreground, contour = foreground_preprocessing(
     ...     position_key="A_1_3",
     ...     input_images=config.input_images,
     ...     z_slices=z_slice,
@@ -965,24 +940,26 @@ def track_one_position(
         click.echo("Tracking with cellpose labels...")
         tracking_labels, tracks_df, _ = run_ultrack(
             tracking_config=tracking_config,
-            scale=scale,
             database_path=database_path,
-            cellpose_labels=cellpose_labels,
-            labels_sigma=cellpose_config.labels_sigma,
+            labels=cellpose_labels,
+            sigma=cellpose_config.labels_sigma,
+            scale=scale,
+            overwrite=True,
         )
     else:
         # Foreground + contour mode
-        foreground_mask, contour_gradient_map = data_preprocessing(
+        foreground_mask, contour_gradient_map = foreground_preprocessing(
             position_key, input_images, z_slices, blank_frames_path
         )
 
         click.echo("Tracking with foreground + contour...")
         tracking_labels, tracks_df, _ = run_ultrack(
             tracking_config=tracking_config,
-            scale=scale,
             database_path=database_path,
-            foreground_mask=foreground_mask,
-            contour_gradient_map=contour_gradient_map,
+            detection=foreground_mask,
+            edges=contour_gradient_map,
+            scale=scale,
+            overwrite=True,
         )
 
     # Save the tracks graph to a CSV file
@@ -1155,7 +1132,9 @@ def track(
     click.echo("Submitting SLURM jobs...")
     jobs = []
 
-    cellpose_cfg = settings.cellpose_config if settings.segmentation_method == "cellpose" else None
+    cellpose_cfg = (
+        settings.cellpose_config if settings.segmentation_method == "cellpose" else None
+    )
 
     with submitit.helpers.clean_env(), executor.batch():
         for position_key in position_keys:

--- a/biahub/track.py
+++ b/biahub/track.py
@@ -18,9 +18,12 @@ import pandas as pd
 import submitit
 import toml
 
+
 from iohub import open_ome_zarr
 from iohub.ngff.utils import create_empty_plate
 from numpy.typing import ArrayLike
+from cellpose import models as cp_models
+
 
 from biahub.cli.parsing import (
     config_filepath,
@@ -37,7 +40,8 @@ from biahub.cli.utils import (
     update_model,
     yaml_to_model,
 )
-from biahub.settings import ProcessingInputChannel, TrackingSettings
+from biahub.settings import CellposeConfig, FocusConfig, ProcessingInputChannel, TrackingSettings
+from tqdm import tqdm
 
 # Lazy imports for ultrack - imported only when needed in specific functions
 
@@ -342,82 +346,205 @@ def resolve_z_slice(z_range: tuple[int, int], z_shape: int) -> tuple[slice, int]
     return z_slices, Z
 
 
+def find_focus_per_timepoint(
+    im_data,
+    NA_det: float,
+    lambda_ill: float,
+    pixel_size: float,
+) -> np.ndarray:
+    """Find the in-focus z-slice for each timepoint using waveorder.
+
+    Parameters
+    ----------
+    im_data : array-like
+        Image data of shape (T, C, Z, Y, X).
+    NA_det : float
+        Numerical aperture of the detection objective.
+    lambda_ill : float
+        Illumination wavelength in micrometers.
+    pixel_size : float
+        Pixel size in micrometers.
+
+    Returns
+    -------
+    np.ndarray
+        Array of shape (T,) with the in-focus z-index per timepoint.
+    """
+    from waveorder.focus import focus_from_transverse_band
+
+    T = im_data.shape[0]
+    Z = im_data.shape[2]
+    z_focus = np.zeros(T, dtype=int)
+    for t in tqdm(range(T), desc="Finding focus"):
+        zyx = np.asarray(im_data[t, 0, :, :, :])
+        z_f = focus_from_transverse_band(
+            zyx,
+            NA_det=NA_det,
+            lambda_ill=lambda_ill,
+            pixel_size=pixel_size,
+        )
+        if z_f is None:
+            z_f = Z // 2
+        z_focus[t] = int(np.clip(z_f, 0, Z - 1))
+    return z_focus
+
+
+def resolve_focus_z_slice(
+    position_key: tuple[str, ...],
+    input_images: list[ProcessingInputChannel],
+    focus_config: FocusConfig,
+) -> tuple[slice, int]:
+    """Find in-focus z using waveorder and build an asymmetric window.
+
+    Uses 1/3 of ``z_window`` below focus and 2/3 above, matching the
+    dynacell convention from test_tracking.py.
+
+    Parameters
+    ----------
+    position_key : tuple of str
+        (plate, well, position) identifying the FOV.
+    input_images : list of ProcessingInputChannel
+        Input image configuration (first non-null path is used).
+    focus_config : FocusConfig
+        Optical parameters and z_window size.
+
+    Returns
+    -------
+    slice
+        Z-slice range centered on the detected focus.
+    int
+        Number of Z-planes in the selected range.
+    """
+    # Find the first input path
+    vs_path = None
+    for image in input_images:
+        if image.path is not None:
+            vs_path = image.path / Path(*position_key)
+            break
+    if vs_path is None:
+        raise ValueError("No input path found for focus finding.")
+
+    with open_ome_zarr(str(vs_path), mode="r") as ds:
+        Z = ds.data.shape[2]
+        z_focus = find_focus_per_timepoint(
+            ds.data,
+            NA_det=focus_config.NA_det,
+            lambda_ill=focus_config.lambda_ill,
+            pixel_size=focus_config.pixel_size,
+        )
+
+    z_median = int(np.median(z_focus))
+    z_window = focus_config.z_window
+    z_below = z_window // 3
+    z_above = z_window - z_below - 1
+    z_start = max(0, z_median - z_below)
+    z_stop = min(Z, z_median + z_above + 1)
+    z_slicing = slice(z_start, z_stop)
+
+    click.echo(
+        f"Focus z-slicing: {z_slicing} "
+        f"(median focus z={z_median}, {z_below} below / {z_above} above, "
+        f"range=[{z_focus.min()}, {z_focus.max()}])"
+    )
+    return z_slicing, z_stop - z_start
+
+
+def run_cellpose_per_frame(
+    images: np.ndarray,
+    model_type: str = "nuclei",
+    diameter: float = 80,
+    cellprob_threshold: float = 0.0,
+    flow_threshold: float = 0.4,
+    gpu: bool = True,
+    min_size: int = 500,
+) -> np.ndarray:
+    """Run cellpose on each 2D frame of a (T, Y, X) array.
+
+    Returns an integer label array of shape (T, Y, X).
+    """
+    model = cp_models.CellposeModel(model_type=model_type, gpu=gpu)
+
+    T = images.shape[0]
+    labels = np.zeros_like(images, dtype=np.int32)
+    for t in tqdm(range(T), desc="Cellpose segmentation"):
+        mask, _, _ = model.eval(
+            images[t],
+            diameter=diameter,
+            channels=[0, 0],  # grayscale
+            cellprob_threshold=cellprob_threshold,
+            flow_threshold=flow_threshold,
+            min_size=min_size,
+        )
+        labels[t] = mask
+    return labels
+
 def run_ultrack(
     tracking_config: MainConfig,
-    foreground_mask: ArrayLike,
-    contour_gradient_map: ArrayLike,
     scale: tuple[float, float] | tuple[float, float, float],
     database_path,
+    foreground_mask: ArrayLike | None = None,
+    contour_gradient_map: ArrayLike | None = None,
+    cellpose_labels: ArrayLike | None = None,
+    labels_sigma: float = 5.0,
 ):
     """
     Run object tracking using the Ultrack library.
 
-    Note: ultrack is imported lazily within this function.
-
-    This function performs object tracking on time-series image data using a binary
-    foreground mask and a contour gradient map. It outputs labeled segmentation results,
-    a track DataFrame, and a graph representing object trajectories over time.
+    Supports two modes:
+    - **foreground+contour**: pass ``foreground_mask`` and ``contour_gradient_map``.
+    - **cellpose labels**: pass ``cellpose_labels`` (and optionally ``labels_sigma``).
 
     Parameters
     ----------
     tracking_config : MainConfig
-        Ultrack configuration object defining segmentation, linking, and optimization parameters.
-    foreground_mask : ArrayLike
-        Binary mask (0 or 1) indicating detected object regions over time.
-        Shape is typically (T, Z, Y, X) or (T, Y, X).
-    contour_gradient_map : ArrayLike
-        Gradient map or edge score map used to refine object boundaries and define connectivity
-        for linking detected objects between timepoints.
+        Ultrack configuration object.
     scale : tuple of float
-        Physical resolution scale in either (Y, X) or (Z, Y, X) depending on whether the data is 2D or 3D.
+        Physical resolution scale in (Y, X) or (Z, Y, X).
     database_path : Path
-        Directory where tracking results, configuration files, and output data will be saved.
+        Directory for tracking results and configuration files.
+    foreground_mask : ArrayLike, optional
+        Binary foreground mask. Required for foreground+contour mode.
+    contour_gradient_map : ArrayLike, optional
+        Edge/gradient map. Required for foreground+contour mode.
+    cellpose_labels : ArrayLike, optional
+        Integer label array from cellpose. Required for cellpose mode.
+    labels_sigma : float, optional
+        Gaussian sigma for ``labels_to_contours`` conversion. Default 5.0.
 
     Returns
     -------
     labels : np.ndarray
-        Labeled segmentation array of shape (T, Z, Y, X) or (T, Y, X), where each object instance
-        is assigned a unique integer label across time.
+        Labeled segmentation array.
     tracks_df : pandas.DataFrame
-        DataFrame with tracking metadata including object ID, frame index, spatial coordinates,
-        and parent-child relationships.
-    graph : networkx.Graph
-        Directed graph representing tracked object lineages. Nodes correspond to objects and
-        edges represent links between objects across frames.
-
-    Notes
-    -----
-    - `foreground_mask` must be a binary mask (e.g., after thresholding a probability map).
-    - This function modifies `tracking_config` to set the working directory (`working_dir`).
-    - The configuration used is saved to `config.toml` under the `database_path`.
-
-    Examples
-    --------
-    >>> labels, tracks_df, graph = run_ultrack(
-    ...     tracking_config=cfg,
-    ...     foreground_mask=binary_mask,
-    ...     contour_gradient_map=gradient_map,
-    ...     scale=(0.5, 0.5, 1.0),
-    ...     database_path=Path("results/posA"),
-    ... )
+        Tracking metadata.
+    graph : dict
+        Directed graph of tracked object lineages.
     """
     from ultrack import Tracker
 
     _patch_ultrack_readonly_buffer()
 
     cfg: MainConfig = tracking_config
-
     cfg.data_config.working_dir = database_path
 
     print(cfg)
 
     tracker = Tracker(cfg)
-    tracker.track(
-        detection=foreground_mask,
-        edges=contour_gradient_map,
-        scale=scale,
-        overwrite=True,
-    )
+
+    if cellpose_labels is not None:
+        tracker.track(
+            labels=cellpose_labels,
+            sigma=labels_sigma,
+            scale=scale,
+            overwrite=True,
+        )
+    else:
+        tracker.track(
+            detection=foreground_mask,
+            edges=contour_gradient_map,
+            scale=scale,
+            overwrite=True,
+        )
 
     tracks_df, graph = tracker.to_tracks_layer()
     labels = tracker.to_zarr(
@@ -701,6 +828,82 @@ def data_preprocessing(
     return foreground_mask, contour_gradient_map
 
 
+def cellpose_preprocessing(
+    position_key: str,
+    input_images: list[ProcessingInputChannel],
+    z_slices: slice,
+    blank_frames_path: Path = None,
+    cellpose_config: CellposeConfig = None,
+) -> np.ndarray:
+    """
+    Load data, fill empty frames, and run cellpose segmentation.
+
+    Returns an integer label array of shape (T, Y, X) ready to pass
+    directly to ``run_ultrack(..., cellpose_labels=...)``.
+
+    Parameters
+    ----------
+    position_key : str
+        FOV key (plate, well, position).
+    input_images : list of ProcessingInputChannel
+        Channel loading configuration.
+    z_slices : slice
+        Z-planes to load.
+    blank_frames_path : Path, optional
+        CSV of blank frames.
+    cellpose_config : CellposeConfig
+        Cellpose model parameters including ``input_channel``.
+    """
+    fov = "/".join(position_key)
+
+    data_dict = load_data(
+        position_key=position_key,
+        input_images=input_images,
+        z_slices=z_slices,
+    )
+    data_dict = run_preprocessing_pipeline(data_dict, input_images)
+    data_dict = fill_empty_frames_from_csv(fov, data_dict, blank_frames_path)
+
+    # Get the channel to segment
+    channel_name = cellpose_config.input_channel
+    if channel_name not in data_dict:
+        raise ValueError(
+            f"Cellpose input channel '{channel_name}' not found in data. "
+            f"Available: {list(data_dict.keys())}"
+        )
+
+    images = data_dict[channel_name]
+    if isinstance(images, da.Array):
+        images = images.compute()
+    images = np.asarray(images)
+
+    # Project Z if needed (T, Z, Y, X) -> (T, Y, X)
+    if images.ndim == 4:
+        click.echo(f"Projecting Z-dimension via mean: {images.shape} -> (T, Y, X)")
+        images = images.mean(axis=1)
+
+    click.echo(
+        f"Running cellpose ({cellpose_config.model_type}, "
+        f"diameter={cellpose_config.diameter}) on channel '{channel_name}'..."
+    )
+    cellpose_labels = run_cellpose_per_frame(
+        images,
+        model_type=cellpose_config.model_type,
+        diameter=cellpose_config.diameter,
+        cellprob_threshold=cellpose_config.cellprob_threshold,
+        flow_threshold=cellpose_config.flow_threshold,
+        gpu=cellpose_config.gpu,
+        min_size=cellpose_config.min_size,
+    )
+
+    n_cells = [len(np.unique(cellpose_labels[t])) - 1 for t in range(cellpose_labels.shape[0])]
+    click.echo(
+        f"Cellpose cells per frame: mean={np.mean(n_cells):.1f}, "
+        f"min={np.min(n_cells)}, max={np.max(n_cells)}"
+    )
+    return cellpose_labels
+
+
 def track_one_position(
     position_key: str,
     input_images: list[ProcessingInputChannel],
@@ -709,81 +912,78 @@ def track_one_position(
     blank_frames_path: Path = None,
     z_slices: tuple[int, int] = (0, 0),
     scale: tuple[float, float, float, float, float] = (1, 1, 1, 1, 1),
+    cellpose_config: CellposeConfig | None = None,
+    focus_config: FocusConfig | None = None,
 ) -> None:
     """
-    Run tracking on a single field of view using foreground and contour channel data.
+    Run tracking on a single field of view.
 
-    This function loads image data, applies a preprocessing pipeline, fills blank frames if needed,
-    and uses the Ultrack library to compute object tracks. It is agnostic to the imaging source —
-    as long as the pipeline produces a binary foreground mask and a corresponding contour map.
+    Supports two segmentation modes:
+    - **foreground+contour** (default): preprocessing must produce 'foreground' and 'contour' channels.
+    - **cellpose**: runs cellpose per-frame on a specified channel and passes labels directly to ultrack.
 
     Parameters
     ----------
     position_key : str
-        A string identifier for the field of view (e.g., "A_1_3"), typically composed of
-        Plate, Well, and Position joined by underscores.
+        FOV identifier (e.g., ``("A", "1", "3")``).
     input_images : list of ProcessingInputChannel
-        Configuration describing which channels to load and how to preprocess them.
+        Channels to load and preprocess.
     output_dirpath : Path
-        Output directory where labeled Zarr volumes and track CSVs will be stored.
+        Output Zarr store for labels and tracks.
     tracking_config : MainConfig
-        Ultrack configuration containing segmentation, linking, and optimization settings.
+        Ultrack configuration.
     blank_frames_path : Path, optional
-        Path to CSV file indicating empty frames for the current FOV. If None, blank frame
-        filling is skipped.
+        CSV of empty frames per FOV.
     z_slices : tuple of int, optional
-        Tuple specifying the range of Z-slices to load. If (0, 0), the central slice range
-        will be auto-resolved. Default is (0, 0).
+        Z-range to load. Default ``(0, 0)`` triggers auto central slicing.
     scale : tuple of float, optional
-        Physical scale of the dataset in (T, C, Z, Y, X) order. Tracking uses either the
-        (Z, Y, X) or (Y, X) portion depending on dimensionality. Default is (1, 1, 1, 1, 1).
-
-    Returns
-    -------
-    None
-        Outputs are saved directly to disk:
-        - Tracked object labels in Zarr format
-        - CSV file containing the track graph (IDs, positions, parents)
-
-    Notes
-    -----
-    - Output is saved to `{output_dirpath}/{position_key}/tracks_{position_key}.csv`.
-    - The Ultrack config is also saved as TOML in a `_config_tracking/{FOV}/` subdirectory.
-    - If required input channels ("foreground" and "contour") are missing, a ValueError is raised.
-
-    Examples
-    --------
-    >>> track_one_position(
-    ...     position_key="A_1_3",
-    ...     input_images=config.input_images,
-    ...     output_dirpath=Path("output.zarr"),
-    ...     tracking_config=cfg,
-    ...     blank_frames_path=Path("blank_frames.csv"),
-    ...     z_slices=(10, 15),
-    ...     scale=(1, 1, 0.5, 0.2, 0.2),
-    ... )
+        Physical scale ``(T, C, Z, Y, X)``.
+    cellpose_config : CellposeConfig, optional
+        If provided, uses cellpose segmentation instead of foreground+contour.
+    focus_config : FocusConfig, optional
+        If provided, uses waveorder focus finding to determine z-slicing
+        (overrides z_slices).
     """
     fov = "_".join(position_key)
     click.echo(f"Processing FOV: {fov.replace('_', '/')}")
-    # tracking input images
-    foreground_mask, contour_gradient_map = data_preprocessing(
-        position_key, input_images, z_slices, blank_frames_path
-    )
+
+    # Override z_slices with focus-based slicing when configured
+    if focus_config is not None:
+        z_slices, _ = resolve_focus_z_slice(position_key, input_images, focus_config)
 
     # Define path to save the tracking database and graph
     filename = output_dirpath.stem
     database_path = output_dirpath.parent / f"{filename}_config_tracking" / f"{fov}"
     os.makedirs(database_path, exist_ok=True)
 
-    # Perform tracking
-    click.echo("Tracking...")
-    tracking_labels, tracks_df, _ = run_ultrack(
-        tracking_config=tracking_config,
-        foreground_mask=foreground_mask,
-        contour_gradient_map=contour_gradient_map,
-        scale=scale,
-        database_path=database_path,
-    )
+    if cellpose_config is not None:
+        # Cellpose mode: load data, fill blanks, run cellpose, pass labels to ultrack
+        cellpose_labels = cellpose_preprocessing(
+            position_key, input_images, z_slices, blank_frames_path, cellpose_config
+        )
+
+        click.echo("Tracking with cellpose labels...")
+        tracking_labels, tracks_df, _ = run_ultrack(
+            tracking_config=tracking_config,
+            scale=scale,
+            database_path=database_path,
+            cellpose_labels=cellpose_labels,
+            labels_sigma=cellpose_config.labels_sigma,
+        )
+    else:
+        # Foreground + contour mode
+        foreground_mask, contour_gradient_map = data_preprocessing(
+            position_key, input_images, z_slices, blank_frames_path
+        )
+
+        click.echo("Tracking with foreground + contour...")
+        tracking_labels, tracks_df, _ = run_ultrack(
+            tracking_config=tracking_config,
+            scale=scale,
+            database_path=database_path,
+            foreground_mask=foreground_mask,
+            contour_gradient_map=contour_gradient_map,
+        )
 
     # Save the tracks graph to a CSV file
     csv_path = output_dirpath / Path(*position_key) / f"tracks_{fov}.csv"
@@ -955,6 +1155,8 @@ def track(
     click.echo("Submitting SLURM jobs...")
     jobs = []
 
+    cellpose_cfg = settings.cellpose_config if settings.segmentation_method == "cellpose" else None
+
     with submitit.helpers.clean_env(), executor.batch():
         for position_key in position_keys:
             job = executor.submit(
@@ -966,6 +1168,8 @@ def track(
                 blank_frames_path=settings.blank_frames_path,
                 z_slices=z_slices,
                 scale=track_scale,
+                cellpose_config=cellpose_cfg,
+                focus_config=settings.focus_config,
             )
 
             jobs.append(job)

--- a/biahub/track.py
+++ b/biahub/track.py
@@ -478,7 +478,7 @@ def run_cellpose_per_frame(
             flow_threshold=flow_threshold,
             min_size=min_size,
         )
-        labels[t] = mask
+        labels[t] = np.asarray(mask)
     return labels
 
 

--- a/nextflow/mantis-v2-timelapse.nf
+++ b/nextflow/mantis-v2-timelapse.nf
@@ -12,6 +12,7 @@ params.track_config        = null
 params.concatenate_config  = null
 params.rename_prefix       = null
 params.rename_suffix       = null
+params.rename_config       = null
 params.biahub_project      = null
 params.viscy_project       = null
 params.work_dir            = null
@@ -28,7 +29,7 @@ include { flat_field_wf }     from './modules/flat_field'
 include { deskew_wf }         from './modules/deskew'
 include { reconstruct_wf }    from './modules/reconstruct'
 include { virtual_stain_wf }  from './modules/virtual_stain'
-include { rename_wf }         from './modules/rename_channels'
+include { rename_wf; rename_channels_map_wf } from './modules/rename_channels'
 include { track_wf }          from './modules/tracking'
 include { assemble_wf_mantisv2 } from './modules/assembly'
 include { qc_stage_wf as qc_post_flatfield }      from './modules/qc'
@@ -124,9 +125,12 @@ workflow full {
     dk_done  = deskew_wf(all_positions, ff_done.done)
     rc_done  = reconstruct_wf(all_positions, dk_done.done)
     vs_done  = virtual_stain_wf(all_positions, rc_done.done)
-    pre_asm  = (params.rename_prefix || params.rename_suffix)
+    pre_rename = (params.rename_prefix || params.rename_suffix)
         ? rename_wf(all_positions, vs_done.done).done
         : vs_done.done
+    pre_asm  = params.rename_config
+        ? rename_channels_map_wf(all_positions, pre_rename).done
+        : pre_rename
     asm_done = assemble_wf_mantisv2(all_positions, pre_asm)
     tk_done  = track_wf(all_positions, asm_done.done)
 
@@ -159,9 +163,12 @@ workflow from_deskew {
     dk_done  = deskew_wf(all_positions, trigger)
     rc_done  = reconstruct_wf(all_positions, dk_done.done)
     vs_done  = virtual_stain_wf(all_positions, rc_done.done)
-    pre_asm  = (params.rename_prefix || params.rename_suffix)
+    pre_rename = (params.rename_prefix || params.rename_suffix)
         ? rename_wf(all_positions, vs_done.done).done
         : vs_done.done
+    pre_asm  = params.rename_config
+        ? rename_channels_map_wf(all_positions, pre_rename).done
+        : pre_rename
     asm_done = assemble_wf_mantisv2(all_positions, pre_asm)
     tk_done  = track_wf(all_positions, asm_done.done)
 
@@ -191,9 +198,12 @@ workflow from_reconstruct {
 
     rc_done  = reconstruct_wf(all_positions, trigger)
     vs_done  = virtual_stain_wf(all_positions, rc_done.done)
-    pre_asm  = (params.rename_prefix || params.rename_suffix)
+    pre_rename = (params.rename_prefix || params.rename_suffix)
         ? rename_wf(all_positions, vs_done.done).done
         : vs_done.done
+    pre_asm  = params.rename_config
+        ? rename_channels_map_wf(all_positions, pre_rename).done
+        : pre_rename
     asm_done = assemble_wf_mantisv2(all_positions, pre_asm)
     tk_done  = track_wf(all_positions, asm_done.done)
 
@@ -220,9 +230,12 @@ workflow from_virtual_stain {
     trigger = Channel.value(true)
 
     vs_done  = virtual_stain_wf(all_positions, trigger)
-    pre_asm  = (params.rename_prefix || params.rename_suffix)
+    pre_rename = (params.rename_prefix || params.rename_suffix)
         ? rename_wf(all_positions, vs_done.done).done
         : vs_done.done
+    pre_asm  = params.rename_config
+        ? rename_channels_map_wf(all_positions, pre_rename).done
+        : pre_rename
     asm_done = assemble_wf_mantisv2(all_positions, pre_asm)
     tk_done  = track_wf(all_positions, asm_done.done)
 
@@ -308,6 +321,14 @@ workflow only_virtual_stain {
     all_positions = collect_positions()
     trigger = Channel.value(true)
     virtual_stain_wf(all_positions, trigger)
+}
+
+workflow only_rename_channels_map {
+    if (!params.output_dir) error "Provide --output_dir"
+
+    all_positions = collect_positions()
+    trigger = Channel.value(true)
+    rename_channels_map_wf(all_positions, trigger)
 }
 
 workflow only_tracking {

--- a/nextflow/mantis-v2-timelapse.nf
+++ b/nextflow/mantis-v2-timelapse.nf
@@ -124,11 +124,11 @@ workflow full {
     dk_done  = deskew_wf(all_positions, ff_done.done)
     rc_done  = reconstruct_wf(all_positions, dk_done.done)
     vs_done  = virtual_stain_wf(all_positions, rc_done.done)
-    tk_done  = track_wf(all_positions, vs_done.done)
     pre_asm  = (params.rename_prefix || params.rename_suffix)
-        ? rename_wf(all_positions, tk_done.done).done
-        : tk_done.done
+        ? rename_wf(all_positions, vs_done.done).done
+        : vs_done.done
     asm_done = assemble_wf_mantisv2(all_positions, pre_asm)
+    tk_done  = track_wf(all_positions, asm_done.done)
 
     run_qc(all_positions, [
         ff_done:  ff_done.done,
@@ -159,11 +159,11 @@ workflow from_deskew {
     dk_done  = deskew_wf(all_positions, trigger)
     rc_done  = reconstruct_wf(all_positions, dk_done.done)
     vs_done  = virtual_stain_wf(all_positions, rc_done.done)
-    tk_done  = track_wf(all_positions, vs_done.done)
     pre_asm  = (params.rename_prefix || params.rename_suffix)
-        ? rename_wf(all_positions, tk_done.done).done
-        : tk_done.done
+        ? rename_wf(all_positions, vs_done.done).done
+        : vs_done.done
     asm_done = assemble_wf_mantisv2(all_positions, pre_asm)
+    tk_done  = track_wf(all_positions, asm_done.done)
 
     run_qc(all_positions, [
         dk_done:  dk_done.done,
@@ -191,11 +191,11 @@ workflow from_reconstruct {
 
     rc_done  = reconstruct_wf(all_positions, trigger)
     vs_done  = virtual_stain_wf(all_positions, rc_done.done)
-    tk_done  = track_wf(all_positions, vs_done.done)
     pre_asm  = (params.rename_prefix || params.rename_suffix)
-        ? rename_wf(all_positions, tk_done.done).done
-        : tk_done.done
+        ? rename_wf(all_positions, vs_done.done).done
+        : vs_done.done
     asm_done = assemble_wf_mantisv2(all_positions, pre_asm)
+    tk_done  = track_wf(all_positions, asm_done.done)
 
     run_qc(all_positions, [
         rc_done:  rc_done.done,
@@ -220,11 +220,11 @@ workflow from_virtual_stain {
     trigger = Channel.value(true)
 
     vs_done  = virtual_stain_wf(all_positions, trigger)
-    tk_done  = track_wf(all_positions, vs_done.done)
     pre_asm  = (params.rename_prefix || params.rename_suffix)
-        ? rename_wf(all_positions, tk_done.done).done
-        : tk_done.done
+        ? rename_wf(all_positions, vs_done.done).done
+        : vs_done.done
     asm_done = assemble_wf_mantisv2(all_positions, pre_asm)
+    tk_done  = track_wf(all_positions, asm_done.done)
 
     run_qc(all_positions, [
         vs_done:  vs_done.done,
@@ -234,32 +234,7 @@ workflow from_virtual_stain {
 
 
 // ---------------------------------------------------------------------------
-//  Entry: from tracking (assumes through 3-virtual-stain exist)
-//  Usage: nextflow run ... -entry from_tracking
-// ---------------------------------------------------------------------------
-
-workflow from_tracking {
-    if (!params.output_dir)          error "Provide --output_dir"
-    if (!params.track_config)        error "Provide --track_config"
-    if (!params.concatenate_config)  error "Provide --concatenate_config"
-
-    all_positions = collect_positions()
-    trigger = Channel.value(true)
-
-    tk_done  = track_wf(all_positions, trigger)
-    pre_asm  = (params.rename_prefix || params.rename_suffix)
-        ? rename_wf(all_positions, tk_done.done).done
-        : tk_done.done
-    asm_done = assemble_wf_mantisv2(all_positions, pre_asm)
-
-    run_qc(all_positions, [
-        asm_done: asm_done.done,
-    ])
-}
-
-
-// ---------------------------------------------------------------------------
-//  Entry: from assembly (assumes through rename exist)
+//  Entry: from assembly (assumes through 3-virtual-stain exist)
 //  Usage: nextflow run ... -entry from_assembly
 // ---------------------------------------------------------------------------
 
@@ -275,6 +250,22 @@ workflow from_assembly {
     run_qc(all_positions, [
         asm_done: asm_done.done,
     ])
+}
+
+
+// ---------------------------------------------------------------------------
+//  Entry: from tracking (assumes through 5-assemble exist)
+//  Usage: nextflow run ... -entry from_tracking
+// ---------------------------------------------------------------------------
+
+workflow from_tracking {
+    if (!params.output_dir)          error "Provide --output_dir"
+    if (!params.track_config)        error "Provide --track_config"
+
+    all_positions = collect_positions()
+    trigger = Channel.value(true)
+
+    tk_done  = track_wf(all_positions, trigger)
 }
 
 

--- a/nextflow/mantis-v2-timelapse.nf
+++ b/nextflow/mantis-v2-timelapse.nf
@@ -279,6 +279,66 @@ workflow from_assembly {
 
 
 // ---------------------------------------------------------------------------
+//  Standalone entries: rerun a single step only
+//  Usage: nextflow run ... -entry only_flat_field
+// ---------------------------------------------------------------------------
+
+workflow only_flat_field {
+    if (!params.input_zarr)        error "Provide --input_zarr"
+    if (!params.output_dir)        error "Provide --output_dir"
+    if (!params.flat_field_config) error "Provide --flat_field_config"
+
+    all_positions = collect_positions()
+    flat_field_wf(all_positions)
+}
+
+workflow only_deskew {
+    if (!params.output_dir)    error "Provide --output_dir"
+    if (!params.deskew_config) error "Provide --deskew_config"
+
+    all_positions = collect_positions()
+    trigger = Channel.value(true)
+    deskew_wf(all_positions, trigger)
+}
+
+workflow only_reconstruct {
+    if (!params.output_dir)          error "Provide --output_dir"
+    if (!params.reconstruct_config)  error "Provide --reconstruct_config"
+
+    all_positions = collect_positions()
+    trigger = Channel.value(true)
+    reconstruct_wf(all_positions, trigger)
+}
+
+workflow only_virtual_stain {
+    if (!params.output_dir)      error "Provide --output_dir"
+    if (!params.predict_config)  error "Provide --predict_config"
+
+    all_positions = collect_positions()
+    trigger = Channel.value(true)
+    virtual_stain_wf(all_positions, trigger)
+}
+
+workflow only_tracking {
+    if (!params.output_dir)    error "Provide --output_dir"
+    if (!params.track_config)  error "Provide --track_config"
+
+    all_positions = collect_positions()
+    trigger = Channel.value(true)
+    track_wf(all_positions, trigger)
+}
+
+workflow only_assembly {
+    if (!params.output_dir)          error "Provide --output_dir"
+    if (!params.concatenate_config)  error "Provide --concatenate_config"
+
+    all_positions = collect_positions()
+    trigger = Channel.value(true)
+    assemble_wf_mantisv2(all_positions, trigger)
+}
+
+
+// ---------------------------------------------------------------------------
 //  Default entry (anonymous workflow delegates to full)
 // ---------------------------------------------------------------------------
 

--- a/nextflow/modules/rename_channels.nf
+++ b/nextflow/modules/rename_channels.nf
@@ -61,3 +61,56 @@ workflow rename_wf {
     emit:
     done = rn_done
 }
+
+
+// ---------------------------------------------------------------------------
+// Rename channels using a mapping config (runs on multiple zarrs)
+// ---------------------------------------------------------------------------
+
+process rename_channels_map_process {
+    tag "${position} @ ${zarr_path}"
+    label 'cpu_local'
+    time '10m'
+
+    input:
+    tuple val(position), val(zarr_path), val(config_flag)
+
+    output:
+    val position
+
+    script:
+    """
+    ${biahub_cmd()} nf rename-channels-map \
+        -i "${zarr_path}" \
+        -p "${position}" \
+        ${config_flag}
+    """
+}
+
+workflow rename_channels_map_wf {
+    take:
+    positions
+    prev_done
+
+    main:
+    def config_flag = params.rename_config
+        ? "-c ${params.rename_config}"
+        : ""
+
+    // Apply to deskew, reconstruct, and virtual-stain zarrs
+    def zarr_paths = [
+        "${params.output_dir}/1-deskew/${dataset_name()}.zarr",
+        "${params.output_dir}/2-reconstruct/${dataset_name()}.zarr",
+        "${params.output_dir}/3-virtual-stain/${dataset_name()}.zarr",
+    ]
+
+    rn_done = prev_done.map { 'done' }
+        | combine( positions.flatMap { it } )
+        | map { trigger, pos -> pos }
+        | flatMap { pos -> zarr_paths.collect { zarr -> [pos, zarr, config_flag] } }
+        | rename_channels_map_process
+        | collect
+
+    emit:
+    done = rn_done
+}

--- a/settings/example_track_settings.yml
+++ b/settings/example_track_settings.yml
@@ -2,18 +2,39 @@
 mode: "2D"
 
 fov: "*/*/*"
-# Z-slice range to extract. Use [-1, -1] to auto-compute a centered slice. If None, all planes are returned or the user-defined range is used.
-z_range: [-1, -1]
+# Z-slice range to extract. Use [-1, -1] to auto-compute a centered slice.
+# Set to null when using focus_config (waveorder focus finding).
+z_range: null
 
 # Name of the target channel used to name the tracking output label channel.
 target_channel: nuclei_prediction
 blank_frames_path: blank_frames.csv
 
+# Waveorder focus finding (overrides z_range when set).
+# Finds the in-focus z-plane per timepoint and extracts a window around it.
+focus_config:
+  NA_det: 1.35
+  lambda_ill: 0.500
+  pixel_size: 0.1133
+  z_window: 40
+
+# Segmentation method: "foreground_contour" or "cellpose"
+segmentation_method: cellpose
+
+cellpose_config:
+  model_type: nuclei
+  diameter: 80
+  cellprob_threshold: 0.0
+  flow_threshold: 0.4
+  gpu: true
+  min_size: 2500
+  input_channel: nuclei_prediction
+  labels_sigma: 5.0
+
 # Input image configurations.
 # Each entry defines one dataset with its path and channels to process.
 input_images:
 
-  # First input: predicted nuclei and membrane channels.
   - path: /path/to/virtual_staining.zarr
     channels:
       nuclei_prediction:
@@ -21,45 +42,36 @@ input_images:
         - function: np.mean
           kwargs:
             axis: 1
-          per_timepoint: False
+          per_timepoint: false
 
-        # Normalize intensity with gamma correction
-        - function: ultrack.imgproc.normalize
-          kwargs:
-            gamma: 0.7
-
-      membrane_prediction:
-        - function: np.mean
-          kwargs:
-            axis: 1
-          per_timepoint: False
-
-        - function: ultrack.imgproc.normalize
-          kwargs:
-            gamma: 0.7
-
-  # # Optional: load label masks directly with or without processing.
-  # - path: /path/to/segmentation.zarr
+  # Uncomment below for foreground_contour segmentation method:
+  #     - function: ultrack.imgproc.normalize
+  #       kwargs:
+  #         gamma: 0.7
+  #
+  #   membrane_prediction:
+  #     - function: np.mean
+  #       kwargs:
+  #         axis: 1
+  #       per_timepoint: false
+  #     - function: ultrack.imgproc.normalize
+  #       kwargs:
+  #         gamma: 0.7
+  #
+  # - path: null
   #   channels:
-  #     nuclei_prediction_labels: []
-
-  # Virtual channel: computed dynamically using prior outputs.
-  # if path is null, the channel is computed dynamically using the prior outputs.
-  - path: null
-    channels:
-      foreground:
-        - function: ultrack.imgproc.detect_foreground
-          input_channels:
-            - nuclei_prediction
-          kwargs:
-            sigma: 90
-
-      contour:
-        - function: biahub.cli.track.mem_nuc_contour
-          input_channels:
-            - nuclei_prediction
-            - membrane_prediction
-          kwargs: {}
+  #     foreground:
+  #       - function: ultrack.imgproc.detect_foreground
+  #         input_channels:
+  #           - nuclei_prediction
+  #         kwargs:
+  #           sigma: 90
+  #     contour:
+  #       - function: biahub.track.mem_nuc_contour
+  #         input_channels:
+  #           - nuclei_prediction
+  #           - membrane_prediction
+  #         kwargs: {}
 
 # Configuration for Ultrack tracking algorithm.
 # See: https://royerlab.github.io/ultrack/
@@ -68,11 +80,11 @@ tracking_config:
 
   # Segmentation parameters: controls object detection from foreground/contour maps.
   segmentation_config:
-    min_area: 2100            # Minimum object area (pixels)
+    min_area: 2500            # Minimum object area (pixels)
     max_area: 80000           # Maximum object area (pixels)
     n_workers: 10             # Number of CPU threads for segmentation
-    min_frontier: 0.4         # Minimum frontier strength for boundaries
-    max_noise: 0.05           # Maximum tolerated noise in segmentation
+    min_frontier: 0.5         # Minimum frontier strength for boundaries
+    max_noise: 0.00           # Maximum tolerated noise in segmentation
 
   # Linking parameters: controls how detections are connected across timepoints.
   linking_config:
@@ -87,3 +99,4 @@ tracking_config:
     disappear_weight: -0.0001  # Penalty for object disappearance
     appear_weight: -0.001      # Penalty for new object appearance
     division_weight: -0.0001   # Penalty (or reward) for cell division events
+    bias: 0.0001

--- a/settings/nextflow_templates/mantis_v2_track.yml
+++ b/settings/nextflow_templates/mantis_v2_track.yml
@@ -1,7 +1,27 @@
 mode: "2D"
 fov: "*/*/*"
-z_range: [-1, -1]
+z_range: null
 target_channel: nuclei_prediction
+
+# Waveorder focus finding (overrides z_range when set)
+focus_config:
+  NA_det: 1.35
+  lambda_ill: 0.500
+  pixel_size: 0.1133
+  z_window: 40
+
+# Segmentation method: "foreground_contour" or "cellpose"
+segmentation_method: cellpose
+
+cellpose_config:
+  model_type: nuclei
+  diameter: 80
+  cellprob_threshold: 0.0
+  flow_threshold: 0.4
+  gpu: true
+  min_size: 2500
+  input_channel: nuclei_prediction
+  labels_sigma: 5.0
 
 input_images:
   - path: null  # overridden by --input-images-path at runtime
@@ -11,32 +31,34 @@ input_images:
           kwargs:
             axis: 1
           per_timepoint: false
-        - function: ultrack.imgproc.normalize
-          kwargs:
-            gamma: 0.7
-      membrane_prediction:
-        - function: np.mean
-          kwargs:
-            axis: 1
-          per_timepoint: false
-        - function: ultrack.imgproc.normalize
-          kwargs:
-            gamma: 0.7
 
-  - path: null
-    channels:
-      foreground:
-        - function: ultrack.imgproc.detect_foreground
-          input_channels:
-            - nuclei_prediction
-          kwargs:
-            sigma: 80
-      contour:
-        - function: biahub.track.mem_nuc_contour
-          input_channels:
-            - nuclei_prediction
-            - membrane_prediction
-          kwargs: {}
+  # Uncomment below for foreground_contour segmentation method
+  #     - function: ultrack.imgproc.normalize
+  #       kwargs:
+  #         gamma: 0.7
+  #   membrane_prediction:
+  #     - function: np.mean
+  #       kwargs:
+  #         axis: 1
+  #       per_timepoint: false
+  #     - function: ultrack.imgproc.normalize
+  #       kwargs:
+  #         gamma: 0.7
+  #
+  # - path: null
+  #   channels:
+  #     foreground:
+  #       - function: ultrack.imgproc.detect_foreground
+  #         input_channels:
+  #           - nuclei_prediction
+  #         kwargs:
+  #           sigma: 80
+  #     contour:
+  #       - function: biahub.track.mem_nuc_contour
+  #         input_channels:
+  #           - nuclei_prediction
+  #           - membrane_prediction
+  #         kwargs: {}
 
 tracking_config:
   segmentation_config:


### PR DESCRIPTION
## Summary
- Add cellpose segmentation mode to tracking as alternative to foreground+contour
- Add waveorder-based focus finding (`FocusConfig`) for automatic z-slice selection with `z_window`
- Add `CellposeConfig` and `FocusConfig` settings, wired through CLI and SLURM submission

## Test plan
- [x] Run `biahub nf run-track` with cellpose config on single FOV
- [x] Verify waveorder focus finding selects correct z range
- [x] Run full pipeline on all positions