### PR TITLE
Nextflow: standalone step entry points, rename-channels CLI, assembly-before-tracking reorder

### DIFF
--- a/biahub/cli/nf.py
+++ b/biahub/cli/nf.py
@@ -527,6 +527,68 @@ def rename_channels(input_zarr: str, position: str, prefix: str, suffix: str):
     click.echo(f"Renamed channels: {position}")
 
 
+@nf_cli.command("rename-channels-map")
+@click.option("--input-zarr", "-i", required=True, type=click.Path(exists=True))
+@click.option("--position", "-p", required=True)
+@click.option(
+    "--config",
+    "-c",
+    default=None,
+    type=click.Path(exists=True),
+    help="YAML config with rename rules. If not provided, applies default rules.",
+)
+def rename_channels_map(input_zarr: str, position: str, config: str | None):
+    """Rename channels using a mapping config (metadata-only, no data copy).
+
+    Default rules (when no config is provided):
+    - 'BF - Oblique' -> 'BF'
+    - 'Phase3D*' -> 'Phase3D'
+    - All other channels get 'raw ' prefix
+
+    Config YAML format::
+
+        rename_exact:
+          "BF - Oblique": "BF"
+        rename_startswith:
+          "Phase3D": "Phase3D"
+        raw_prefix_exclude:
+          - "BF - Oblique"
+          - "Phase3D"
+          - "nuclei_prediction"
+          - "membrane_prediction"
+    """
+    import yaml
+
+    if config:
+        with open(config) as f:
+            rules = yaml.safe_load(f)
+        rename_exact = rules.get("rename_exact", {})
+        rename_startswith = rules.get("rename_startswith", {})
+        raw_exclude = set(rules.get("raw_prefix_exclude", []))
+    else:
+        rename_exact = {"BF - Oblique": "BF"}
+        rename_startswith = {"Phase3D": "Phase3D"}
+        raw_exclude = {"BF - Oblique", "nuclei_prediction", "membrane_prediction"}
+
+    position_path = Path(input_zarr) / position
+    with open_ome_zarr(str(position_path), mode="r+") as pos:
+        for old_name in list(pos.channel_names):
+            if old_name in rename_exact:
+                new_name = rename_exact[old_name]
+            elif any(old_name.startswith(prefix) for prefix in rename_startswith):
+                new_name = next(
+                    v for k, v in rename_startswith.items() if old_name.startswith(k)
+                )
+            elif old_name not in raw_exclude and not old_name.startswith("raw "):
+                new_name = f"raw {old_name}"
+            else:
+                continue
+            pos.rename_channel(old_name, new_name)
+            click.echo(f"  '{old_name}' -> '{new_name}'")
+
+    click.echo(f"Renamed channels: {position}")
+
+
 # ---------------------------------------------------------------------------
 # Tracking
 # ---------------------------------------------------------------------------

--- a/biahub/cli/nf.py
+++ b/biahub/cli/nf.py
@@ -23,6 +23,21 @@ from biahub.cli.utils import (
 logger = logging.getLogger(__name__)
 
 
+def _remove_existing_path(path: Path, label: str = "output path"):
+    """Remove an existing file or directory before recreating step outputs."""
+    import shutil
+
+    if not path.exists():
+        return
+
+    if path.is_dir():
+        shutil.rmtree(path)
+    else:
+        path.unlink()
+
+    click.echo(f"Removed existing {label}: {path}")
+
+
 @click.group("nf")
 def nf_cli():
     """Nextflow-oriented commands for single-unit-of-work processing.
@@ -80,6 +95,8 @@ def init_flat_field(input_zarr: str, output_zarr: str, config: str):
                 raise click.ClickException(
                     f"Channel '{ch}' not found. Available: {channel_names}"
                 )
+
+    _remove_existing_path(Path(output_zarr), label="output zarr")
 
     create_empty_plate(
         store_path=Path(output_zarr),
@@ -179,6 +196,8 @@ def init_deskew(input_zarr: str, output_zarr: str, config: str):
         settings.average_n_slices,
         settings.pixel_size_um,
     )
+
+    _remove_existing_path(Path(output_zarr), label="output zarr")
 
     create_empty_plate(
         store_path=Path(output_zarr),
@@ -317,6 +336,8 @@ def init_reconstruct(input_zarr: str, output_zarr: str, config: str):
     output_metadata = get_reconstruction_output_metadata(first_position_path, resolved_config)
     output_metadata.pop("plate_metadata", None)
 
+    _remove_existing_path(Path(output_zarr), label="output zarr")
+
     create_empty_plate(
         store_path=Path(output_zarr),
         position_keys=position_keys,
@@ -351,6 +372,8 @@ def compute_transfer_function(input_zarr: str, tf_path: str, config: str):
     if not position_keys:
         raise click.ClickException(f"Input plate '{input_zarr}' contains no positions.")
     first_position_path = Path(input_zarr) / "/".join(position_keys[0])
+
+    _remove_existing_path(tf_zarr, label="transfer function zarr")
 
     click.echo(f"Computing transfer function from {first_position_path}")
     compute_transfer_function_cli(first_position_path, config_path, tf_zarr)
@@ -458,6 +481,8 @@ def init_virtual_stain(input_zarr: str, output_zarr: str, config: str):
 
     position_keys, _, shape, scale = read_plate_metadata(input_zarr)
     T, _, Z, Y, X = shape
+
+    _remove_existing_path(Path(output_zarr), label="output zarr")
 
     create_empty_plate(
         store_path=Path(output_zarr),
@@ -613,6 +638,8 @@ def init_track(input_zarr: str, output_zarr: str, config: str):
         output_shape = (T, 1, 1, Y, X)
     else:
         output_shape = (T, 1, Z_out, Y, X)
+
+    _remove_existing_path(Path(output_zarr), label="output zarr")
 
     create_empty_plate(
         store_path=Path(output_zarr),

--- a/nextflow/mantis-v2-timelapse.nf
+++ b/nextflow/mantis-v2-timelapse.nf
@@ -12,6 +12,7 @@ params.track_config        = null
 params.concatenate_config  = null
 params.rename_prefix       = null
 params.rename_suffix       = null
+params.rename_config       = null
 params.biahub_project      = null
 params.viscy_project       = null
 params.work_dir            = null
@@ -28,7 +29,7 @@ include { flat_field_wf }     from './modules/flat_field'
 include { deskew_wf }         from './modules/deskew'
 include { reconstruct_wf }    from './modules/reconstruct'
 include { virtual_stain_wf }  from './modules/virtual_stain'
-include { rename_wf }         from './modules/rename_channels'
+include { rename_wf; rename_channels_map_wf } from './modules/rename_channels'
 include { track_wf }          from './modules/tracking'
 include { assemble_wf_mantisv2 } from './modules/assembly'
 include { qc_stage_wf as qc_post_flatfield }      from './modules/qc'
@@ -124,9 +125,12 @@ workflow full {
     dk_done  = deskew_wf(all_positions, ff_done.done)
     rc_done  = reconstruct_wf(all_positions, dk_done.done)
     vs_done  = virtual_stain_wf(all_positions, rc_done.done)
-    pre_asm  = (params.rename_prefix || params.rename_suffix)
+    pre_rename = (params.rename_prefix || params.rename_suffix)
         ? rename_wf(all_positions, vs_done.done).done
         : vs_done.done
+    pre_asm  = params.rename_config
+        ? rename_channels_map_wf(all_positions, pre_rename).done
+        : pre_rename
     asm_done = assemble_wf_mantisv2(all_positions, pre_asm)
     tk_done  = track_wf(all_positions, asm_done.done)
 
@@ -159,9 +163,12 @@ workflow from_deskew {
     dk_done  = deskew_wf(all_positions, trigger)
     rc_done  = reconstruct_wf(all_positions, dk_done.done)
     vs_done  = virtual_stain_wf(all_positions, rc_done.done)
-    pre_asm  = (params.rename_prefix || params.rename_suffix)
+    pre_rename = (params.rename_prefix || params.rename_suffix)
         ? rename_wf(all_positions, vs_done.done).done
         : vs_done.done
+    pre_asm  = params.rename_config
+        ? rename_channels_map_wf(all_positions, pre_rename).done
+        : pre_rename
     asm_done = assemble_wf_mantisv2(all_positions, pre_asm)
     tk_done  = track_wf(all_positions, asm_done.done)
 
@@ -191,9 +198,12 @@ workflow from_reconstruct {
 
     rc_done  = reconstruct_wf(all_positions, trigger)
     vs_done  = virtual_stain_wf(all_positions, rc_done.done)
-    pre_asm  = (params.rename_prefix || params.rename_suffix)
+    pre_rename = (params.rename_prefix || params.rename_suffix)
         ? rename_wf(all_positions, vs_done.done).done
         : vs_done.done
+    pre_asm  = params.rename_config
+        ? rename_channels_map_wf(all_positions, pre_rename).done
+        : pre_rename
     asm_done = assemble_wf_mantisv2(all_positions, pre_asm)
     tk_done  = track_wf(all_positions, asm_done.done)
 
@@ -220,9 +230,12 @@ workflow from_virtual_stain {
     trigger = Channel.value(true)
 
     vs_done  = virtual_stain_wf(all_positions, trigger)
-    pre_asm  = (params.rename_prefix || params.rename_suffix)
+    pre_rename = (params.rename_prefix || params.rename_suffix)
         ? rename_wf(all_positions, vs_done.done).done
         : vs_done.done
+    pre_asm  = params.rename_config
+        ? rename_channels_map_wf(all_positions, pre_rename).done
+        : pre_rename
     asm_done = assemble_wf_mantisv2(all_positions, pre_asm)
     tk_done  = track_wf(all_positions, asm_done.done)
 
@@ -308,6 +321,14 @@ workflow only_virtual_stain {
     all_positions = collect_positions()
     trigger = Channel.value(true)
     virtual_stain_wf(all_positions, trigger)
+}
+
+workflow only_rename_channels_map {
+    if (!params.output_dir) error "Provide --output_dir"
+
+    all_positions = collect_positions()
+    trigger = Channel.value(true)
+    rename_channels_map_wf(all_positions, trigger)
 }
 
 workflow only_tracking {

--- a/nextflow/mantis-v2-timelapse.nf
+++ b/nextflow/mantis-v2-timelapse.nf
@@ -124,11 +124,11 @@ workflow full {
     dk_done  = deskew_wf(all_positions, ff_done.done)
     rc_done  = reconstruct_wf(all_positions, dk_done.done)
     vs_done  = virtual_stain_wf(all_positions, rc_done.done)
-    tk_done  = track_wf(all_positions, vs_done.done)
     pre_asm  = (params.rename_prefix || params.rename_suffix)
-        ? rename_wf(all_positions, tk_done.done).done
-        : tk_done.done
+        ? rename_wf(all_positions, vs_done.done).done
+        : vs_done.done
     asm_done = assemble_wf_mantisv2(all_positions, pre_asm)
+    tk_done  = track_wf(all_positions, asm_done.done)
 
     run_qc(all_positions, [
         ff_done:  ff_done.done,
@@ -159,11 +159,11 @@ workflow from_deskew {
     dk_done  = deskew_wf(all_positions, trigger)
     rc_done  = reconstruct_wf(all_positions, dk_done.done)
     vs_done  = virtual_stain_wf(all_positions, rc_done.done)
-    tk_done  = track_wf(all_positions, vs_done.done)
     pre_asm  = (params.rename_prefix || params.rename_suffix)
-        ? rename_wf(all_positions, tk_done.done).done
-        : tk_done.done
+        ? rename_wf(all_positions, vs_done.done).done
+        : vs_done.done
     asm_done = assemble_wf_mantisv2(all_positions, pre_asm)
+    tk_done  = track_wf(all_positions, asm_done.done)
 
     run_qc(all_positions, [
         dk_done:  dk_done.done,
@@ -191,11 +191,11 @@ workflow from_reconstruct {
 
     rc_done  = reconstruct_wf(all_positions, trigger)
     vs_done  = virtual_stain_wf(all_positions, rc_done.done)
-    tk_done  = track_wf(all_positions, vs_done.done)
     pre_asm  = (params.rename_prefix || params.rename_suffix)
-        ? rename_wf(all_positions, tk_done.done).done
-        : tk_done.done
+        ? rename_wf(all_positions, vs_done.done).done
+        : vs_done.done
     asm_done = assemble_wf_mantisv2(all_positions, pre_asm)
+    tk_done  = track_wf(all_positions, asm_done.done)
 
     run_qc(all_positions, [
         rc_done:  rc_done.done,
@@ -220,11 +220,11 @@ workflow from_virtual_stain {
     trigger = Channel.value(true)
 
     vs_done  = virtual_stain_wf(all_positions, trigger)
-    tk_done  = track_wf(all_positions, vs_done.done)
     pre_asm  = (params.rename_prefix || params.rename_suffix)
-        ? rename_wf(all_positions, tk_done.done).done
-        : tk_done.done
+        ? rename_wf(all_positions, vs_done.done).done
+        : vs_done.done
     asm_done = assemble_wf_mantisv2(all_positions, pre_asm)
+    tk_done  = track_wf(all_positions, asm_done.done)
 
     run_qc(all_positions, [
         vs_done:  vs_done.done,
@@ -234,32 +234,7 @@ workflow from_virtual_stain {
 
 
 // ---------------------------------------------------------------------------
-//  Entry: from tracking (assumes through 3-virtual-stain exist)
-//  Usage: nextflow run ... -entry from_tracking
-// ---------------------------------------------------------------------------
-
-workflow from_tracking {
-    if (!params.output_dir)          error "Provide --output_dir"
-    if (!params.track_config)        error "Provide --track_config"
-    if (!params.concatenate_config)  error "Provide --concatenate_config"
-
-    all_positions = collect_positions()
-    trigger = Channel.value(true)
-
-    tk_done  = track_wf(all_positions, trigger)
-    pre_asm  = (params.rename_prefix || params.rename_suffix)
-        ? rename_wf(all_positions, tk_done.done).done
-        : tk_done.done
-    asm_done = assemble_wf_mantisv2(all_positions, pre_asm)
-
-    run_qc(all_positions, [
-        asm_done: asm_done.done,
-    ])
-}
-
-
-// ---------------------------------------------------------------------------
-//  Entry: from assembly (assumes through rename exist)
+//  Entry: from assembly (assumes through 3-virtual-stain exist)
 //  Usage: nextflow run ... -entry from_assembly
 // ---------------------------------------------------------------------------
 
@@ -275,6 +250,22 @@ workflow from_assembly {
     run_qc(all_positions, [
         asm_done: asm_done.done,
     ])
+}
+
+
+// ---------------------------------------------------------------------------
+//  Entry: from tracking (assumes through 5-assemble exist)
+//  Usage: nextflow run ... -entry from_tracking
+// ---------------------------------------------------------------------------
+
+workflow from_tracking {
+    if (!params.output_dir)          error "Provide --output_dir"
+    if (!params.track_config)        error "Provide --track_config"
+
+    all_positions = collect_positions()
+    trigger = Channel.value(true)
+
+    tk_done  = track_wf(all_positions, trigger)
 }
 
 

--- a/nextflow/mantis-v2-timelapse.nf
+++ b/nextflow/mantis-v2-timelapse.nf
@@ -293,7 +293,11 @@ workflow only_flat_field {
     if (!params.flat_field_config) error "Provide --flat_field_config"
 
     all_positions = collect_positions()
-    flat_field_wf(all_positions)
+    ff_done = flat_field_wf(all_positions)
+
+    run_qc(all_positions, [
+        ff_done: ff_done.done,
+    ])
 }
 
 workflow only_deskew {
@@ -302,7 +306,11 @@ workflow only_deskew {
 
     all_positions = collect_positions()
     trigger = Channel.value(true)
-    deskew_wf(all_positions, trigger)
+    dk_done = deskew_wf(all_positions, trigger)
+
+    run_qc(all_positions, [
+        dk_done: dk_done.done,
+    ])
 }
 
 workflow only_reconstruct {
@@ -311,7 +319,11 @@ workflow only_reconstruct {
 
     all_positions = collect_positions()
     trigger = Channel.value(true)
-    reconstruct_wf(all_positions, trigger)
+    rc_done = reconstruct_wf(all_positions, trigger)
+
+    run_qc(all_positions, [
+        rc_done: rc_done.done,
+    ])
 }
 
 workflow only_virtual_stain {
@@ -320,7 +332,11 @@ workflow only_virtual_stain {
 
     all_positions = collect_positions()
     trigger = Channel.value(true)
-    virtual_stain_wf(all_positions, trigger)
+    vs_done = virtual_stain_wf(all_positions, trigger)
+
+    run_qc(all_positions, [
+        vs_done: vs_done.done,
+    ])
 }
 
 workflow only_rename_channels_map {
@@ -346,7 +362,11 @@ workflow only_assembly {
 
     all_positions = collect_positions()
     trigger = Channel.value(true)
-    assemble_wf_mantisv2(all_positions, trigger)
+    asm_done = assemble_wf_mantisv2(all_positions, trigger)
+
+    run_qc(all_positions, [
+        asm_done: asm_done.done,
+    ])
 }
 
 

--- a/nextflow/mantis-v2-timelapse.nf
+++ b/nextflow/mantis-v2-timelapse.nf
@@ -279,6 +279,66 @@ workflow from_assembly {
 
 
 // ---------------------------------------------------------------------------
+//  Standalone entries: rerun a single step only
+//  Usage: nextflow run ... -entry only_flat_field
+// ---------------------------------------------------------------------------
+
+workflow only_flat_field {
+    if (!params.input_zarr)        error "Provide --input_zarr"
+    if (!params.output_dir)        error "Provide --output_dir"
+    if (!params.flat_field_config) error "Provide --flat_field_config"
+
+    all_positions = collect_positions()
+    flat_field_wf(all_positions)
+}
+
+workflow only_deskew {
+    if (!params.output_dir)    error "Provide --output_dir"
+    if (!params.deskew_config) error "Provide --deskew_config"
+
+    all_positions = collect_positions()
+    trigger = Channel.value(true)
+    deskew_wf(all_positions, trigger)
+}
+
+workflow only_reconstruct {
+    if (!params.output_dir)          error "Provide --output_dir"
+    if (!params.reconstruct_config)  error "Provide --reconstruct_config"
+
+    all_positions = collect_positions()
+    trigger = Channel.value(true)
+    reconstruct_wf(all_positions, trigger)
+}
+
+workflow only_virtual_stain {
+    if (!params.output_dir)      error "Provide --output_dir"
+    if (!params.predict_config)  error "Provide --predict_config"
+
+    all_positions = collect_positions()
+    trigger = Channel.value(true)
+    virtual_stain_wf(all_positions, trigger)
+}
+
+workflow only_tracking {
+    if (!params.output_dir)    error "Provide --output_dir"
+    if (!params.track_config)  error "Provide --track_config"
+
+    all_positions = collect_positions()
+    trigger = Channel.value(true)
+    track_wf(all_positions, trigger)
+}
+
+workflow only_assembly {
+    if (!params.output_dir)          error "Provide --output_dir"
+    if (!params.concatenate_config)  error "Provide --concatenate_config"
+
+    all_positions = collect_positions()
+    trigger = Channel.value(true)
+    assemble_wf_mantisv2(all_positions, trigger)
+}
+
+
+// ---------------------------------------------------------------------------
 //  Default entry (anonymous workflow delegates to full)
 // ---------------------------------------------------------------------------
 

--- a/nextflow/modules/rename_channels.nf
+++ b/nextflow/modules/rename_channels.nf
@@ -61,3 +61,56 @@ workflow rename_wf {
     emit:
     done = rn_done
 }
+
+
+// ---------------------------------------------------------------------------
+// Rename channels using a mapping config (runs on multiple zarrs)
+// ---------------------------------------------------------------------------
+
+process rename_channels_map_process {
+    tag "${position} @ ${zarr_path}"
+    label 'cpu_local'
+    time '10m'
+
+    input:
+    tuple val(position), val(zarr_path), val(config_flag)
+
+    output:
+    val position
+
+    script:
+    """
+    ${biahub_cmd()} nf rename-channels-map \
+        -i "${zarr_path}" \
+        -p "${position}" \
+        ${config_flag}
+    """
+}
+
+workflow rename_channels_map_wf {
+    take:
+    positions
+    prev_done
+
+    main:
+    def config_flag = params.rename_config
+        ? "-c ${params.rename_config}"
+        : ""
+
+    // Apply to deskew, reconstruct, and virtual-stain zarrs
+    def zarr_paths = [
+        "${params.output_dir}/1-deskew/${dataset_name()}.zarr",
+        "${params.output_dir}/2-reconstruct/${dataset_name()}.zarr",
+        "${params.output_dir}/3-virtual-stain/${dataset_name()}.zarr",
+    ]
+
+    rn_done = prev_done.map { 'done' }
+        | combine( positions.flatMap { it } )
+        | map { trigger, pos -> pos }
+        | flatMap { pos -> zarr_paths.collect { zarr -> [pos, zarr, config_flag] } }
+        | rename_channels_map_process
+        | collect
+
+    emit:
+    done = rn_done
+}

--- a/nextflow/modules/tracking.nf
+++ b/nextflow/modules/tracking.nf
@@ -14,7 +14,7 @@ process init_track {
     """
     mkdir -p "${slurm_log_dir('track')}"
     ${biahub_cmd()} nf init-track \
-        -i "${params.output_dir}/2-reconstruct/${dataset_name()}.zarr" \
+        -i "${params.output_dir}/5-assemble/${dataset_name()}.zarr" \
         -o "${params.output_dir}/4-track/${dataset_name()}.zarr" \
         -c "${params.track_config}"
     """

--- a/nextflow/modules/tracking.nf
+++ b/nextflow/modules/tracking.nf
@@ -44,7 +44,7 @@ process run_track {
         -o "${params.output_dir}/4-track/${dataset_name()}.zarr" \
         -p "${position}" \
         -c "${params.track_config}" \
-        --input-images-path "${params.output_dir}/3-virtual-stain/${dataset_name()}.zarr"
+        --input-images-path "${params.output_dir}/5-assemble/${dataset_name()}.zarr"
     """
 }
 

--- a/nextflow/nextflow.config
+++ b/nextflow/nextflow.config
@@ -53,7 +53,6 @@ profiles {
             }
             withLabel: 'gpu' {
                 queue = 'gpu'
-                clusterOptions = '--gres=gpu:1'
             }
         }
     }

--- a/tests/test_cli/test_nf_cli.py
+++ b/tests/test_cli/test_nf_cli.py
@@ -78,6 +78,50 @@ def test_init_flat_field(tmp_path, example_plate):
     assert "RESOURCES:" in result.output
 
 
+def test_init_flat_field_overwrites_existing_output(tmp_path, example_plate):
+    plate_path, _ = example_plate
+    output_path = tmp_path / "output.zarr"
+    config_path = tmp_path / "ff_config.yml"
+    config_path.write_text(yaml.dump({"channel_names": None}))
+
+    runner = CliRunner()
+    first = runner.invoke(
+        cli,
+        [
+            "nf",
+            "init-flat-field",
+            "-i",
+            str(plate_path),
+            "-o",
+            str(output_path),
+            "-c",
+            str(config_path),
+        ],
+    )
+    assert first.exit_code == 0, first.output
+
+    junk = output_path / "stale.txt"
+    junk.write_text("stale")
+
+    second = runner.invoke(
+        cli,
+        [
+            "nf",
+            "init-flat-field",
+            "-i",
+            str(plate_path),
+            "-o",
+            str(output_path),
+            "-c",
+            str(config_path),
+        ],
+    )
+
+    assert second.exit_code == 0, second.output
+    assert not junk.exists()
+    assert "Removed existing output zarr" in second.output
+
+
 # ---------------------------------------------------------------------------
 # rename-channels
 # ---------------------------------------------------------------------------
@@ -263,6 +307,51 @@ def test_init_track(tmp_path, example_plate):
         assert pos.data.dtype == np.uint32
         assert len(pos.channel_names) == 1
         assert "label" in pos.channel_names[0].lower() or "GFP" in pos.channel_names[0]
+
+
+def test_init_track_overwrites_existing_output(tmp_path, example_plate):
+    plate_path, plate_dataset = example_plate
+    plate_dataset.close()
+
+    output_path = tmp_path / "track_output.zarr"
+    config_path = _make_tracking_config(tmp_path, plate_path)
+
+    runner = CliRunner()
+    first = runner.invoke(
+        cli,
+        [
+            "nf",
+            "init-track",
+            "-i",
+            str(plate_path),
+            "-o",
+            str(output_path),
+            "-c",
+            str(config_path),
+        ],
+    )
+    assert first.exit_code == 0, first.output
+
+    junk = output_path / "stale.txt"
+    junk.write_text("stale")
+
+    second = runner.invoke(
+        cli,
+        [
+            "nf",
+            "init-track",
+            "-i",
+            str(plate_path),
+            "-o",
+            str(output_path),
+            "-c",
+            str(config_path),
+        ],
+    )
+
+    assert second.exit_code == 0, second.output
+    assert not junk.exists()
+    assert "Removed existing output zarr" in second.output
 
 
 @requires_ultrack


### PR DESCRIPTION
## Summary
- Add standalone Nextflow entry points so individual pipeline steps (deskew, reconstruct, virtual-stain, rename, assemble, track, QC) can be rerun without the full pipeline
- Reorder pipeline so assembly runs before tracking; tracking now reads input from the assembled zarr
- Add `rename-channels-map` CLI and a Nextflow `rename_channels` module for flexible channel renaming
- Drop config-level GPU `clusterOptions` that was overriding per-process log settings
- Reset standalone step outputs and rerun QC

## Changes
- `biahub/cli/nf.py` — CLI surface for standalone step invocation
- `nextflow/mantis-v2-timelapse.nf` — reordered DAG, standalone entry points
- `nextflow/modules/rename_channels.nf` — new module
- `nextflow/modules/tracking.nf` — read from assembled zarr
- `nextflow/nextflow.config` — drop overriding gpu clusterOptions
- `tests/test_cli/test_nf_cli.py` — tests for new CLI

## Test plan
- [ ] Run full pipeline end-to-end on an active dataset
- [ ] Run each standalone entry point individually and confirm outputs
- [ ] Verify tracking reads the assembled zarr (not pre-assembly inputs)
- [ ] Confirm rename-channels-map renames channels on a test zarr
- [ ] Verify per-process logs are written (regression for gpu clusterOptions fix)
- [ ] pytest tests/test_cli/test_nf_cli.py