### PR TITLE
Nextflow: register Airtable metadata after tracking

### DIFF
--- a/nextflow/README.md
+++ b/nextflow/README.md
@@ -151,6 +151,29 @@ Pass the env path to the pipeline:
 --viscy_project /path/to/viscy-env
 ```
 
+### Airtable Dataset Registry
+
+The optional Airtable registry hook uses the existing VisCy Airtable CLI after tracking completes. It runs:
+
+```bash
+register /path/to/output_dir/5-assemble/<dataset>.zarr/*/*/*
+write    /path/to/output_dir/5-assemble/<dataset>.zarr/*/*/*
+```
+
+against the VisCy monorepo's `applications/airtable` project. This requires:
+
+```bash
+export AIRTABLE_API_KEY=...
+export AIRTABLE_BASE_ID=...
+```
+
+and a VisCy checkout with the Airtable app available:
+
+```bash
+--airtable_project /path/to/VisCy
+--airtable_registry_after_tracking true
+```
+
 ### imaging-qc-pipeline (QC stages + Quarto)
 
 The QC processes in `modules/qc.nf` shell out to the `imaging-qc` CLI — they do **not** import Nextflow subworkflows or Python code from `imaging-qc-pipeline`. All orchestration (fan-out, chunking, merging) is defined here in biahub; `imaging-qc-pipeline` is a black-box CLI dependency. This means changes to the internal Nextflow or Python orchestration in `imaging-qc-pipeline` (DAG resolution, dispatch, subworkflows) do not affect this pipeline as long as the CLI contract is stable.
@@ -236,6 +259,7 @@ Use `-profile local` instead of `-profile slurm` for local execution.
 | `--rename_suffix` | Suffix for channel renaming (optional) |
 | `--biahub_project` | Path to biahub repo root for `uv run` (optional; see [Environment setup](#environment-setup)) |
 | `--viscy_project` | Path to viscy-env wrapper project for `uv run` (optional; see [VisCy setup](#viscy-virtual-staining)) |
+| `--airtable_project` | Path to the VisCy monorepo root containing `applications/airtable` (optional; required for Airtable registry integration) |
 | `--max_positions` | Limit fan-out to first N positions (default: 0 = all positions) |
 | `--work_dir` | Nextflow work directory for intermediate files (default: `work/` in current directory) |
 | `--qc_config_dir` | Directory containing per-stage QC YAML configs (optional; enables QC stages) |
@@ -243,6 +267,9 @@ Use `-profile local` instead of `-profile slurm` for local execution.
 | `--qc_report_dir` | Directory for the final QC report (default: `<output_dir>/qc/report`) |
 | `--qc_report_static` | Generate static PNG-only report instead of interactive Quarto/Plotly (default: `false`) |
 | `--quarto_bin` | Path to directory containing the `quarto` binary (required for interactive reports on Slurm, where `~/.bashrc` is not sourced) |
+| `--airtable_registry_after_tracking` | After tracking finishes, run VisCy Airtable `register` + `write` on the assembled zarr positions (default: `false`) |
+| `--airtable_registry_dataset` | Optional Airtable dataset name override passed to the registration CLI (default: zarr stem) |
+| `--airtable_registry_dry_run` | Log Airtable registry actions without writing to Airtable or zarr metadata (default: `false`) |
 
 ## Output
 

--- a/nextflow/mantis-v2-timelapse.nf
+++ b/nextflow/mantis-v2-timelapse.nf
@@ -15,6 +15,7 @@ params.rename_suffix       = null
 params.rename_config       = null
 params.biahub_project      = null
 params.viscy_project       = null
+params.airtable_project    = null
 params.work_dir            = null
 params.max_positions       = 0
 params.qc_config_dir       = null
@@ -23,8 +24,12 @@ params.qc_report_dir       = null
 params.qc_report_static    = false
 params.quarto_bin          = null
 params.clean_intermediates = false
+params.airtable_registry_after_tracking = false
+params.airtable_registry_dataset        = null
+params.airtable_registry_dry_run        = false
 
 include { list_positions; dataset_name } from './modules/common'
+include { airtable_registry_wf } from './modules/airtable_registry'
 include { flat_field_wf }     from './modules/flat_field'
 include { deskew_wf }         from './modules/deskew'
 include { reconstruct_wf }    from './modules/reconstruct'
@@ -56,7 +61,7 @@ def collect_positions() {
 }
 
 def run_qc(all_positions, Map stages) {
-    if (!params.qc_config_dir) return
+    if (!params.qc_config_dir) return Channel.value(true)
 
     def qc_dir   = params.qc_config_dir
     def ff_zarr  = "${params.output_dir}/0-flatfield/${dataset_name()}.zarr"
@@ -99,8 +104,17 @@ def run_qc(all_positions, Map stages) {
         all_summaries = qc_summary_list.inject { a, b -> a.mix(b) } | collect
 
         def report_dir = params.qc_report_dir ?: "${params.output_dir}/qc/report"
-        qc_report_wf(all_qc, all_summaries, asm_zarr, [ff_zarr, dk_zarr, rc_zarr, vs_zarr], params.output_dir, report_dir)
+        return qc_report_wf(
+            all_qc,
+            all_summaries,
+            asm_zarr,
+            [ff_zarr, dk_zarr, rc_zarr, vs_zarr],
+            params.output_dir,
+            report_dir,
+        ).done
     }
+
+    return Channel.value(true)
 }
 
 
@@ -133,14 +147,15 @@ workflow full {
         : pre_rename
     asm_done = assemble_wf_mantisv2(all_positions, pre_asm)
     tk_done  = track_wf(all_positions, asm_done.done)
-
-    run_qc(all_positions, [
+    qc_done = run_qc(all_positions, [
         ff_done:  ff_done.done,
         dk_done:  dk_done.done,
         rc_done:  rc_done.done,
         vs_done:  vs_done.done,
         asm_done: asm_done.done,
     ])
+    registry_trigger = tk_done.done.combine(qc_done).map { _, _ -> true }
+    airtable_registry_wf(registry_trigger)
 }
 
 
@@ -171,13 +186,14 @@ workflow from_deskew {
         : pre_rename
     asm_done = assemble_wf_mantisv2(all_positions, pre_asm)
     tk_done  = track_wf(all_positions, asm_done.done)
-
-    run_qc(all_positions, [
+    qc_done = run_qc(all_positions, [
         dk_done:  dk_done.done,
         rc_done:  rc_done.done,
         vs_done:  vs_done.done,
         asm_done: asm_done.done,
     ])
+    registry_trigger = tk_done.done.combine(qc_done).map { _, _ -> true }
+    airtable_registry_wf(registry_trigger)
 }
 
 
@@ -206,12 +222,13 @@ workflow from_reconstruct {
         : pre_rename
     asm_done = assemble_wf_mantisv2(all_positions, pre_asm)
     tk_done  = track_wf(all_positions, asm_done.done)
-
-    run_qc(all_positions, [
+    qc_done = run_qc(all_positions, [
         rc_done:  rc_done.done,
         vs_done:  vs_done.done,
         asm_done: asm_done.done,
     ])
+    registry_trigger = tk_done.done.combine(qc_done).map { _, _ -> true }
+    airtable_registry_wf(registry_trigger)
 }
 
 
@@ -238,11 +255,12 @@ workflow from_virtual_stain {
         : pre_rename
     asm_done = assemble_wf_mantisv2(all_positions, pre_asm)
     tk_done  = track_wf(all_positions, asm_done.done)
-
-    run_qc(all_positions, [
+    qc_done = run_qc(all_positions, [
         vs_done:  vs_done.done,
         asm_done: asm_done.done,
     ])
+    registry_trigger = tk_done.done.combine(qc_done).map { _, _ -> true }
+    airtable_registry_wf(registry_trigger)
 }
 
 
@@ -279,6 +297,9 @@ workflow from_tracking {
     trigger = Channel.value(true)
 
     tk_done  = track_wf(all_positions, trigger)
+    qc_done = run_qc(all_positions, [:])
+    registry_trigger = tk_done.done.combine(qc_done).map { _, _ -> true }
+    airtable_registry_wf(registry_trigger)
 }
 
 
@@ -353,7 +374,10 @@ workflow only_tracking {
 
     all_positions = collect_positions()
     trigger = Channel.value(true)
-    track_wf(all_positions, trigger)
+    tk_done = track_wf(all_positions, trigger)
+    qc_done = run_qc(all_positions, [:])
+    registry_trigger = tk_done.done.combine(qc_done).map { _, _ -> true }
+    airtable_registry_wf(registry_trigger)
 }
 
 workflow only_assembly {

--- a/nextflow/mantis-v2-timelapse.nf
+++ b/nextflow/mantis-v2-timelapse.nf
@@ -154,7 +154,7 @@ workflow full {
         vs_done:  vs_done.done,
         asm_done: asm_done.done,
     ])
-    registry_trigger = tk_done.done.combine(qc_done).map { _, _ -> true }
+    registry_trigger = tk_done.done.combine(qc_done).map { tk, qc -> true }
     airtable_registry_wf(registry_trigger)
 }
 
@@ -192,7 +192,7 @@ workflow from_deskew {
         vs_done:  vs_done.done,
         asm_done: asm_done.done,
     ])
-    registry_trigger = tk_done.done.combine(qc_done).map { _, _ -> true }
+    registry_trigger = tk_done.done.combine(qc_done).map { tk, qc -> true }
     airtable_registry_wf(registry_trigger)
 }
 
@@ -227,7 +227,7 @@ workflow from_reconstruct {
         vs_done:  vs_done.done,
         asm_done: asm_done.done,
     ])
-    registry_trigger = tk_done.done.combine(qc_done).map { _, _ -> true }
+    registry_trigger = tk_done.done.combine(qc_done).map { tk, qc -> true }
     airtable_registry_wf(registry_trigger)
 }
 
@@ -259,7 +259,7 @@ workflow from_virtual_stain {
         vs_done:  vs_done.done,
         asm_done: asm_done.done,
     ])
-    registry_trigger = tk_done.done.combine(qc_done).map { _, _ -> true }
+    registry_trigger = tk_done.done.combine(qc_done).map { tk, qc -> true }
     airtable_registry_wf(registry_trigger)
 }
 
@@ -298,7 +298,7 @@ workflow from_tracking {
 
     tk_done  = track_wf(all_positions, trigger)
     qc_done = run_qc(all_positions, [:])
-    registry_trigger = tk_done.done.combine(qc_done).map { _, _ -> true }
+    registry_trigger = tk_done.done.combine(qc_done).map { tk, qc -> true }
     airtable_registry_wf(registry_trigger)
 }
 
@@ -376,7 +376,7 @@ workflow only_tracking {
     trigger = Channel.value(true)
     tk_done = track_wf(all_positions, trigger)
     qc_done = run_qc(all_positions, [:])
-    registry_trigger = tk_done.done.combine(qc_done).map { _, _ -> true }
+    registry_trigger = tk_done.done.combine(qc_done).map { tk, qc -> true }
     airtable_registry_wf(registry_trigger)
 }
 

--- a/nextflow/mantis-v2-timelapse.nf
+++ b/nextflow/mantis-v2-timelapse.nf
@@ -154,7 +154,7 @@ workflow full {
         vs_done:  vs_done.done,
         asm_done: asm_done.done,
     ])
-    registry_trigger = tk_done.done.combine(qc_done).map { tk, qc -> true }
+    registry_trigger = tk_done.done.mix(qc_done).collect().map { true }
     airtable_registry_wf(registry_trigger)
 }
 
@@ -192,7 +192,7 @@ workflow from_deskew {
         vs_done:  vs_done.done,
         asm_done: asm_done.done,
     ])
-    registry_trigger = tk_done.done.combine(qc_done).map { tk, qc -> true }
+    registry_trigger = tk_done.done.mix(qc_done).collect().map { true }
     airtable_registry_wf(registry_trigger)
 }
 
@@ -227,7 +227,7 @@ workflow from_reconstruct {
         vs_done:  vs_done.done,
         asm_done: asm_done.done,
     ])
-    registry_trigger = tk_done.done.combine(qc_done).map { tk, qc -> true }
+    registry_trigger = tk_done.done.mix(qc_done).collect().map { true }
     airtable_registry_wf(registry_trigger)
 }
 
@@ -259,7 +259,7 @@ workflow from_virtual_stain {
         vs_done:  vs_done.done,
         asm_done: asm_done.done,
     ])
-    registry_trigger = tk_done.done.combine(qc_done).map { tk, qc -> true }
+    registry_trigger = tk_done.done.mix(qc_done).collect().map { true }
     airtable_registry_wf(registry_trigger)
 }
 
@@ -298,7 +298,7 @@ workflow from_tracking {
 
     tk_done  = track_wf(all_positions, trigger)
     qc_done = run_qc(all_positions, [:])
-    registry_trigger = tk_done.done.combine(qc_done).map { tk, qc -> true }
+    registry_trigger = tk_done.done.mix(qc_done).collect().map { true }
     airtable_registry_wf(registry_trigger)
 }
 
@@ -376,7 +376,7 @@ workflow only_tracking {
     trigger = Channel.value(true)
     tk_done = track_wf(all_positions, trigger)
     qc_done = run_qc(all_positions, [:])
-    registry_trigger = tk_done.done.combine(qc_done).map { tk, qc -> true }
+    registry_trigger = tk_done.done.mix(qc_done).collect().map { true }
     airtable_registry_wf(registry_trigger)
 }
 

--- a/nextflow/modules/airtable_registry.nf
+++ b/nextflow/modules/airtable_registry.nf
@@ -1,0 +1,49 @@
+include { dataset_name; airtable_cmd; slurm_log_dir } from './common'
+
+
+process register_airtable_after_tracking {
+    label 'cpu_local'
+
+    input:
+    val trigger
+
+    output:
+    val true
+
+    script:
+    def assembled_zarr = "${params.output_dir}/5-assemble/${dataset_name()}.zarr"
+    def dry_run_flag = params.airtable_registry_dry_run ? "--dry-run" : ""
+    def dataset_flag = params.airtable_registry_dataset ?
+        "--dataset \"${params.airtable_registry_dataset}\"" : ""
+    """
+    mkdir -p "${slurm_log_dir('airtable_registry')}"
+
+    shopt -s nullglob
+    positions=( "${assembled_zarr}"/*/*/* )
+    if [ \${#positions[@]} -eq 0 ]; then
+        echo "No assembled positions found under ${assembled_zarr}" >&2
+        exit 1
+    fi
+
+    ${airtable_cmd()} register ${dry_run_flag} ${dataset_flag} "\${positions[@]}"
+    ${airtable_cmd()} write ${dry_run_flag} "\${positions[@]}"
+    """
+}
+
+
+workflow airtable_registry_wf {
+    take:
+    trigger
+
+    main:
+    if (params.airtable_registry_after_tracking && !params.airtable_project) {
+        error "Provide --airtable_project when --airtable_registry_after_tracking is enabled"
+    }
+
+    registry_done = params.airtable_registry_after_tracking
+        ? register_airtable_after_tracking(trigger)
+        : trigger
+
+    emit:
+    done = registry_done
+}

--- a/nextflow/modules/common.nf
+++ b/nextflow/modules/common.nf
@@ -26,6 +26,14 @@ def biahub_cmd() {
         "uv run --project ${params.biahub_project} biahub" : "biahub"
 }
 
+def airtable_cmd() {
+    if (!params.airtable_project) {
+        error "Provide --airtable_project when Airtable registry integration is enabled"
+    }
+    def script = "${params.airtable_project}/applications/airtable/scripts/write_experiment_metadata.py"
+    return "uv run --project ${params.airtable_project} --package airtable-utils ${script}"
+}
+
 process init_chunks {
     label 'cpu_local'
 


### PR DESCRIPTION
## Summary
- Add Airtable registry step that runs after tracking to register dataset metadata
- New \`airtable_registry\` Nextflow module + shared helpers in \`common.nf\`
- README updates documenting the new step

Stacked on #250 (nextflow-features). Rebase onto wire-nextflow once #250 merges.

## Changes
- \`nextflow/modules/airtable_registry.nf\` — new module
- \`nextflow/modules/common.nf\` — shared helpers used by the registry trigger
- \`nextflow/mantis-v2-timelapse.nf\` — wire registry step into DAG after tracking
- \`nextflow/README.md\` — document Airtable registry step

## Test plan
- [ ] Run full pipeline on an active dataset and confirm Airtable record is created/updated after tracking
- [ ] Verify \`registry_trigger\` channel does not flatten lists (regression for c9e678f)
- [ ] Confirm closure params no longer shadow each other (regression for ccc087e)
- [ ] Check that failure in registry step does not break upstream tracking outputs