### PR TITLE
Add JobRunner executor abstraction and nest deskew settings

### DIFF
--- a/biahub/cli/job_runner.py
+++ b/biahub/cli/job_runner.py
@@ -1,0 +1,177 @@
+import os
+
+from collections.abc import Callable, Iterable
+from pathlib import Path
+
+import click
+
+from biahub.cli.slurm import SlurmExecutor
+
+# The execution backends ``JobRunner`` dispatches over. The kernel (``fn``) and its
+# per-job call signature are identical across all three -- only the wrapping differs
+# (direct call vs. submitit local subprocess vs. submitit SLURM job).
+EXECUTORS = ("sequential", "local", "slurm")
+
+
+class JobRunner:
+    """
+    Run one ``fn`` across a batch of jobs on a chosen backend.
+
+    A job is ``fn(*item, **fn_args)``: ``fn`` and ``fn_args`` are constant across the
+    whole batch, and ``items`` is the fan-out axis -- one job per element. Each element
+    supplies that job's *varying* positional args (a tuple is unpacked; a scalar is
+    passed as a single argument). Bind any constant *leading* positional args into
+    ``fn`` with :func:`functools.partial`::
+
+        # deskew: kernel + kwargs constant, (input, output) paths vary
+        JobRunner(
+            partial(process_single_position, deskew_kernel),
+            zip(inputs, outputs, strict=True),
+            kernel_kwargs,
+            executor="slurm",
+            output_dirpath=output_dirpath,
+            slurm_args=slurm_args,
+        ).execute(monitor_paths=inputs)
+
+        # estimate: everything constant except the timepoint index
+        JobRunner(
+            estimate_tzyx, range(T), shared_kwargs, executor="slurm", output_dirpath=...
+        ).execute(finalize="wait")
+
+    ``fn`` and its call signature are *identical* across all backends; only the
+    wrapping differs. No backend may substitute a different kernel or call shape, which
+    makes the "two parallel implementations drift apart" bug structurally impossible.
+
+    Backends (``executor``):
+
+    - ``"sequential"`` -- in-process, one job at a time, fail-fast. No SLURM, no
+      submitit, no monitoring. For debugging and for orchestrators that already own
+      the fan-out (e.g. a Nextflow worker processing a single position).
+    - ``"local"`` -- parallel subprocesses on this machine via submitit.
+    - ``"slurm"`` -- parallel jobs on a SLURM cluster via submitit.
+
+    Parameters
+    ----------
+    fn : Callable
+        The callable run for every job. Constant across the batch.
+    items : Iterable
+        The fan-out axis: one job per element. Each element is that job's varying
+        positional args -- a tuple is unpacked into ``fn``, anything else is passed
+        as a single positional argument.
+    fn_args : dict, optional
+        Constant keyword arguments passed to ``fn`` on every job.
+    executor : {"sequential", "local", "slurm"}, optional
+        Execution backend. Default ``"slurm"``.
+    output_dirpath : Union[str, Path], optional
+        The run's output store (submitit backends only). submitit logs and the job-id
+        file are written to a ``slurm_output`` directory beside it.
+    slurm_args : dict, optional
+        Parameters for ``executor.update_parameters`` (submitit backends only).
+        Ignored (with a log line) for ``"sequential"``.
+    sbatch_filepath : Union[str, Path], optional
+        Optional sbatch file whose parsed contents override ``slurm_args``.
+    """
+
+    def __init__(
+        self,
+        fn: Callable,
+        items: Iterable,
+        fn_args: dict | None = None,
+        *,
+        executor: str = "slurm",
+        output_dirpath: str | Path | None = None,
+        slurm_args: dict | None = None,
+        sbatch_filepath: str | Path | None = None,
+    ) -> None:
+        if executor not in EXECUTORS:
+            raise ValueError(f"executor must be one of {EXECUTORS}, got {executor!r}")
+        self.fn = fn
+        self.fn_args = dict(fn_args or {})
+        self.executor = executor
+        self.output_dirpath = output_dirpath
+        self.slurm_args = dict(slurm_args or {})
+        self.sbatch_filepath = sbatch_filepath
+        # Per-job positional args: unpack tuples, wrap scalars.
+        self.job_args = [item if isinstance(item, tuple) else (item,) for item in items]
+
+    def _execute_sequential(self, labels: list | None = None) -> list:
+        """Run every job in-process, serially, fail-fast.
+
+        The first job that raises propagates immediately, so a wrapping CLI (or a
+        Nextflow worker invoking ``--executor sequential``) exits non-zero with a
+        real traceback instead of swallowing the error.
+        """
+        results = []
+        for i, args in enumerate(self.job_args):
+            label = labels[i] if labels and i < len(labels) else i
+            click.echo(f"[{i + 1}/{len(self.job_args)}] running job ({label})")
+            results.append(self.fn(*args, **self.fn_args))
+        return results
+
+    def execute(
+        self,
+        *,
+        finalize: str = "monitor",
+        monitor_paths: list | None = None,
+    ) -> list | SlurmExecutor:
+        """
+        Run all jobs on the configured backend.
+
+        In CI (``CI=true``) there is no SLURM and subprocesses are flaky, so any
+        submitit backend is transparently downgraded to ``"sequential"`` -- mirroring
+        the old ``get_submitit_cluster`` "debug" behavior, but without submitit's
+        lazy-execution indirection.
+
+        Parameters
+        ----------
+        finalize : {"monitor", "wait", "none"}, optional
+            How to finalize submitit backends: ``"monitor"`` for live progress,
+            ``"wait"`` to block silently, ``"none"`` to submit and return. Ignored
+            for ``"sequential"`` (which always runs to completion in-process).
+            Default ``"monitor"``.
+        monitor_paths : list, optional
+            Per-job labels: progress labels for ``monitor_jobs`` (submitit) or for
+            the sequential progress lines. Typically the input position dirpaths.
+
+        Returns
+        -------
+        list | SlurmExecutor
+            For ``"sequential"``, the list of per-job return values. For submitit
+            backends, the :class:`SlurmExecutor` (with ``.jobs`` populated).
+        """
+        if finalize not in ("monitor", "wait", "none"):
+            raise ValueError(
+                f"finalize must be 'monitor', 'wait', or 'none', got {finalize!r}"
+            )
+
+        executor = self.executor
+        # No SLURM in CI, and local subprocesses are flaky there: run in-process.
+        if executor != "sequential" and os.environ.get("CI") == "true":
+            click.echo(f"CI detected: running '{executor}' jobs sequentially in-process.")
+            executor = "sequential"
+
+        if executor == "sequential":
+            if self.slurm_args:
+                click.echo(
+                    f"executor='sequential': ignoring SLURM parameters {sorted(self.slurm_args)}."
+                )
+            return self._execute_sequential(labels=monitor_paths)
+
+        # submitit backends: "local" (this machine) or "slurm" (cluster).
+        slurm_executor = SlurmExecutor(
+            self.output_dirpath,
+            self.slurm_args,
+            cluster=executor,
+            sbatch_filepath=self.sbatch_filepath,
+        )
+        slurm_executor.submit_batch(self.fn, [(args, self.fn_args) for args in self.job_args])
+
+        if finalize == "monitor":
+            if monitor_paths is not None:
+                slurm_executor.monitor(monitor_paths)
+            else:
+                slurm_executor.wait()
+        elif finalize == "wait":
+            slurm_executor.wait()
+        # "none": submit and return without blocking.
+        return slurm_executor

--- a/biahub/cli/parsing.py
+++ b/biahub/cli/parsing.py
@@ -275,6 +275,24 @@ def monitor() -> Callable:
     return decorator
 
 
+def executor() -> Callable:
+    def decorator(f: Callable) -> Callable:
+        return click.option(
+            "--executor",
+            type=click.Choice(["sequential", "local", "slurm"], case_sensitive=False),
+            default="slurm",
+            show_default=True,
+            help=(
+                "Execution backend: 'sequential' runs jobs in-process one at a time "
+                "(no SLURM; for debugging or single-position workers), 'local' runs "
+                "parallel subprocesses on this machine, 'slurm' submits to a SLURM "
+                "cluster."
+            ),
+        )(f)
+
+    return decorator
+
+
 def num_processes() -> Callable:
     def decorator(f: Callable) -> Callable:
         return click.option(

--- a/biahub/cli/slurm.py
+++ b/biahub/cli/slurm.py
@@ -1,6 +1,19 @@
+from collections.abc import Callable, Iterable
+from pathlib import Path
+
+import click
 import submitit
 
 from tqdm import tqdm
+
+from biahub.cli.monitor import monitor_jobs
+from biahub.cli.parsing import sbatch_to_submitit
+from biahub.cli.utils import get_submitit_cluster
+
+# A single unit of work: positional args (tuple) and keyword args (dict) for the
+# submitted callable. ``submit_jobs``/``SlurmExecutor.submit_batch`` iterate over
+# a list of these and call ``func(*args, **kwargs)`` once per entry.
+JobArgs = tuple[tuple, dict]
 
 
 def wait_for_jobs_to_finish(jobs: list[submitit.Job]) -> None:
@@ -23,3 +36,192 @@ def wait_for_jobs_to_finish(jobs: list[submitit.Job]) -> None:
             pass  # as_completed polls every 10 seconds by default, so we don't need to do anything here
         except Exception as e:
             print(f"Job {job.job_id} failed with exception: {e}")
+
+
+class SlurmExecutor:
+    """
+    Submit batches of SLURM jobs via a shared ``submitit.AutoExecutor`` wrapper.
+
+    Captures the job-submission boilerplate shared by every biahub CLI: cluster
+    selection, parameter setup, optional ``sbatch`` overrides, batched submission
+    inside a clean environment, job-id logging, and monitoring.
+
+    The generic :meth:`submit_batch` (``func`` + a list of ``(args, kwargs)``) is the
+    core abstraction and serves every shape of work: one-job-per-position image
+    processing (deskew, register, ...) *and* estimator fan-outs over an arbitrary
+    index such as timepoints (``estimate_registration``'s ``estimate_tczyx``).
+
+    For a single batch + finalize in one call, use the :func:`submit_jobs` wrapper.
+    Modules with multiple batches (e.g. ``register``, ``stabilize``) or dependency
+    chains (e.g. ``virtual_stain``) call :meth:`submit_batch` more than once and
+    finalize with :meth:`monitor` (live progress, image modules) or :meth:`wait`
+    (block silently, estimators).
+
+    Parameters
+    ----------
+    slurm_out_path : Union[str, Path]
+        Directory where submitit writes its logs and the job-id file.
+    slurm_args : dict
+        Parameters passed to ``executor.update_parameters`` (e.g. ``slurm_job_name``,
+        ``slurm_cpus_per_task``, ``slurm_mem_per_cpu``, ``slurm_partition``).
+    local : bool, optional
+        Run locally instead of submitting to SLURM. Used to resolve ``cluster`` when
+        ``cluster`` is not given. Default False.
+    cluster : str, optional
+        A pre-resolved submitit cluster backend (e.g. ``"slurm"``/``"local"``). If
+        given it takes precedence over ``local``; estimators that already called
+        ``get_submitit_cluster`` upstream pass it through here.
+    sbatch_filepath : Union[str, Path], optional
+        Optional sbatch file whose parsed contents override ``slurm_args``.
+    """
+
+    def __init__(
+        self,
+        slurm_out_path: str | Path,
+        slurm_args: dict,
+        *,
+        local: bool = False,
+        cluster: str | None = None,
+        sbatch_filepath: str | Path | None = None,
+    ) -> None:
+        self.slurm_out_path = Path(slurm_out_path)
+
+        # Override defaults if an sbatch file is provided. Copy so we don't mutate
+        # the caller's dict.
+        slurm_args = dict(slurm_args)
+        if sbatch_filepath:
+            slurm_args.update(sbatch_to_submitit(sbatch_filepath))
+        self.slurm_args = slurm_args
+
+        # Accept a pre-resolved cluster (estimators pass one in) or derive it from
+        # the ``local`` flag (image-processing modules).
+        if cluster is None:
+            cluster = get_submitit_cluster(local)
+        self._executor = submitit.AutoExecutor(folder=self.slurm_out_path, cluster=cluster)
+        self._executor.update_parameters(**slurm_args)
+
+        # Accumulates jobs across all submit_batch calls so the log file and
+        # monitor reflect every job this executor submitted.
+        self.jobs: list[submitit.Job] = []
+
+    def submit_batch(self, func: Callable, job_args: Iterable[JobArgs]) -> list[submitit.Job]:
+        """
+        Submit one batch of jobs, all calling ``func`` with per-job args.
+
+        Parameters
+        ----------
+        func : Callable
+            The callable to submit (e.g. ``process_single_position``). The same
+            callable is used for every job in the batch.
+        job_args : Iterable[JobArgs]
+            One ``(args, kwargs)`` tuple per job; each job runs
+            ``func(*args, **kwargs)``.
+
+        Returns
+        -------
+        list[submitit.Job]
+            The jobs submitted in this batch (also appended to ``self.jobs``).
+        """
+        job_args = list(job_args)
+        click.echo(f"Submitting {len(job_args)} jobs: {self.slurm_args}")
+
+        batch_jobs = []
+        with submitit.helpers.clean_env(), self._executor.batch():
+            for args, kwargs in job_args:
+                batch_jobs.append(self._executor.submit(func, *args, **kwargs))
+
+        self.jobs.extend(batch_jobs)
+        self._write_job_ids()
+        return batch_jobs
+
+    def _write_job_ids(self) -> None:
+        """Write all submitted job IDs to ``submitit_jobs_ids.log``."""
+        self.slurm_out_path.mkdir(parents=True, exist_ok=True)
+        log_path = self.slurm_out_path / "submitit_jobs_ids.log"
+        with log_path.open("w") as log_file:
+            log_file.write("\n".join(job.job_id for job in self.jobs))
+
+    def monitor(self, position_dirpaths: list | None = None) -> None:
+        """Monitor all jobs submitted by this executor with live progress."""
+        monitor_jobs(self.jobs, position_dirpaths or [])
+
+    def wait(self) -> None:
+        """Block until all submitted jobs finish, without live monitoring."""
+        wait_for_jobs_to_finish(self.jobs)
+
+
+def submit_jobs(
+    func: Callable,
+    job_args: Iterable[JobArgs],
+    *,
+    slurm_out_path: str | Path,
+    slurm_args: dict,
+    finalize: str = "monitor",
+    monitor_paths: list | None = None,
+    local: bool = False,
+    cluster: str | None = None,
+    sbatch_filepath: str | Path | None = None,
+) -> SlurmExecutor:
+    """
+    Submit one batch of SLURM jobs and finalize, in a single call.
+
+    Function-agnostic convenience wrapper around :class:`SlurmExecutor`: it sets up
+    the executor, submits ``func`` once per ``(args, kwargs)`` entry in ``job_args``,
+    and finalizes. ``func`` and the fan-out axis are entirely up to the caller — the
+    same call serves one-job-per-FOV image processing
+    (``submit_jobs(process_single_position, [...])``) and per-timepoint estimators
+    (``submit_jobs(estimate_tzyx, [...], finalize="wait")``) alike.
+
+    Modules that submit multiple batches (e.g. ``register``, ``stabilize``) or
+    dependency chains (e.g. ``virtual_stain``) should use :class:`SlurmExecutor`
+    directly, calling :meth:`SlurmExecutor.submit_batch` more than once.
+
+    Parameters
+    ----------
+    func : Callable
+        The callable to submit for every job. The same callable is used for the
+        whole batch; per-job variation lives in ``job_args``.
+    job_args : Iterable[JobArgs]
+        One ``(args, kwargs)`` tuple per job; each job runs ``func(*args, **kwargs)``.
+        Build this however the work fans out — over FOV, timepoints, channels, etc.
+    slurm_out_path : Union[str, Path]
+        Directory for submitit logs and the job-id file.
+    slurm_args : dict
+        Parameters for ``executor.update_parameters``.
+    finalize : {"monitor", "wait", "none"}, optional
+        How to finalize after submission: ``"monitor"`` for live progress (image
+        modules), ``"wait"`` to block silently until done (estimators), or
+        ``"none"`` to return immediately. Default ``"monitor"``.
+    monitor_paths : list, optional
+        Paths passed to ``monitor_jobs`` for progress labels when
+        ``finalize="monitor"`` (typically the input position dirpaths).
+    local : bool, optional
+        Run locally instead of submitting to SLURM. Default False.
+    cluster : str, optional
+        Pre-resolved submitit cluster backend; takes precedence over ``local``.
+    sbatch_filepath : Union[str, Path], optional
+        Optional sbatch file whose parsed contents override ``slurm_args``.
+
+    Returns
+    -------
+    SlurmExecutor
+        The executor used, with ``.jobs`` populated, so callers can inspect or
+        further wait on the submitted jobs.
+    """
+    if finalize not in ("monitor", "wait", "none"):
+        raise ValueError(f"finalize must be 'monitor', 'wait', or 'none', got {finalize!r}")
+
+    executor = SlurmExecutor(
+        slurm_out_path,
+        slurm_args,
+        local=local,
+        cluster=cluster,
+        sbatch_filepath=sbatch_filepath,
+    )
+    executor.submit_batch(func, job_args)
+
+    if finalize == "monitor":
+        executor.monitor(monitor_paths)
+    elif finalize == "wait":
+        executor.wait()
+    return executor

--- a/biahub/cli/slurm.py
+++ b/biahub/cli/slurm.py
@@ -8,12 +8,52 @@ from tqdm import tqdm
 
 from biahub.cli.monitor import monitor_jobs
 from biahub.cli.parsing import sbatch_to_submitit
-from biahub.cli.utils import get_submitit_cluster
+from biahub.cli.utils import estimate_resources, get_submitit_cluster
 
 # A single unit of work: positional args (tuple) and keyword args (dict) for the
-# submitted callable. ``submit_jobs``/``SlurmExecutor.submit_batch`` iterate over
-# a list of these and call ``func(*args, **kwargs)`` once per entry.
+# queued callable. ``JobRunner``/``SlurmExecutor.submit_batch`` iterate over a list
+# of these and call ``func(*args, **kwargs)`` once per entry.
 JobArgs = tuple[tuple, dict]
+
+
+def resolve_slurm_args(
+    slurm_args: dict,
+    shape: tuple[int, ...],
+    *,
+    ram_multiplier: float = 1.0,
+    max_num_cpus: int = 64,
+) -> dict:
+    """
+    Return a copy of ``slurm_args`` with cpus/mem sized to the data volume.
+
+    Every image-processing CLI shares this pattern: a static base of SLURM params
+    (job name, partition, time, array parallelism, ...) plus two fields that should
+    scale with the data -- ``slurm_cpus_per_task`` and ``slurm_mem_per_cpu``. This
+    estimates those two from ``shape`` and overrides them, leaving the rest of the
+    base untouched (so extra keys like ``slurm_use_srun`` survive).
+
+    Use the returned ``slurm_args["slurm_cpus_per_task"]`` as the kernel's
+    ``num_workers`` to keep a single source of truth for the CPU count.
+
+    Parameters
+    ----------
+    slurm_args : dict
+        Base SLURM parameters. Comes from ``settings.slurm_settings.model_dump()`` or
+        a literal dict. Not mutated.
+    shape : tuple[int, ...]
+        Data shape passed to :func:`estimate_resources` (typically ``(T, C, Z, Y, X)``).
+    ram_multiplier : float, optional
+        Per-CLI memory scaling for ``estimate_resources``. Default 1.0.
+    max_num_cpus : int, optional
+        Per-CLI cap for ``estimate_resources``. Default 64.
+    """
+    num_cpus, gb_ram = estimate_resources(
+        shape=shape, ram_multiplier=ram_multiplier, max_num_cpus=max_num_cpus
+    )
+    resolved = dict(slurm_args)
+    resolved["slurm_cpus_per_task"] = num_cpus
+    resolved["slurm_mem_per_cpu"] = f"{gb_ram}G"
+    return resolved
 
 
 def wait_for_jobs_to_finish(jobs: list[submitit.Job]) -> None:
@@ -51,16 +91,18 @@ class SlurmExecutor:
     processing (deskew, register, ...) *and* estimator fan-outs over an arbitrary
     index such as timepoints (``estimate_registration``'s ``estimate_tczyx``).
 
-    For a single batch + finalize in one call, use the :func:`submit_jobs` wrapper.
-    Modules with multiple batches (e.g. ``register``, ``stabilize``) or dependency
-    chains (e.g. ``virtual_stain``) call :meth:`submit_batch` more than once and
+    Most callers should use :class:`JobRunner` (backend selection plus a single
+    ``add``/``execute`` flow). Modules with multiple batches (e.g. ``register``,
+    ``stabilize``) or dependency chains (e.g. ``virtual_stain``) construct a
+    ``SlurmExecutor`` directly, call :meth:`submit_batch` more than once, and
     finalize with :meth:`monitor` (live progress, image modules) or :meth:`wait`
     (block silently, estimators).
 
     Parameters
     ----------
-    slurm_out_path : Union[str, Path]
-        Directory where submitit writes its logs and the job-id file.
+    output_dirpath : Union[str, Path]
+        The run's output store. submitit logs and the job-id file are written to a
+        ``slurm_output`` directory beside it (``output_dirpath.parent / "slurm_output"``).
     slurm_args : dict
         Parameters passed to ``executor.update_parameters`` (e.g. ``slurm_job_name``,
         ``slurm_cpus_per_task``, ``slurm_mem_per_cpu``, ``slurm_partition``).
@@ -77,14 +119,15 @@ class SlurmExecutor:
 
     def __init__(
         self,
-        slurm_out_path: str | Path,
+        output_dirpath: str | Path,
         slurm_args: dict,
         *,
         local: bool = False,
         cluster: str | None = None,
         sbatch_filepath: str | Path | None = None,
     ) -> None:
-        self.slurm_out_path = Path(slurm_out_path)
+        # SLURM logs + job-id file live in a `slurm_output` dir beside the output store.
+        self.slurm_out_path = Path(output_dirpath).parent / "slurm_output"
 
         # Override defaults if an sbatch file is provided. Copy so we don't mutate
         # the caller's dict.
@@ -148,80 +191,3 @@ class SlurmExecutor:
     def wait(self) -> None:
         """Block until all submitted jobs finish, without live monitoring."""
         wait_for_jobs_to_finish(self.jobs)
-
-
-def submit_jobs(
-    func: Callable,
-    job_args: Iterable[JobArgs],
-    *,
-    slurm_out_path: str | Path,
-    slurm_args: dict,
-    finalize: str = "monitor",
-    monitor_paths: list | None = None,
-    local: bool = False,
-    cluster: str | None = None,
-    sbatch_filepath: str | Path | None = None,
-) -> SlurmExecutor:
-    """
-    Submit one batch of SLURM jobs and finalize, in a single call.
-
-    Function-agnostic convenience wrapper around :class:`SlurmExecutor`: it sets up
-    the executor, submits ``func`` once per ``(args, kwargs)`` entry in ``job_args``,
-    and finalizes. ``func`` and the fan-out axis are entirely up to the caller — the
-    same call serves one-job-per-FOV image processing
-    (``submit_jobs(process_single_position, [...])``) and per-timepoint estimators
-    (``submit_jobs(estimate_tzyx, [...], finalize="wait")``) alike.
-
-    Modules that submit multiple batches (e.g. ``register``, ``stabilize``) or
-    dependency chains (e.g. ``virtual_stain``) should use :class:`SlurmExecutor`
-    directly, calling :meth:`SlurmExecutor.submit_batch` more than once.
-
-    Parameters
-    ----------
-    func : Callable
-        The callable to submit for every job. The same callable is used for the
-        whole batch; per-job variation lives in ``job_args``.
-    job_args : Iterable[JobArgs]
-        One ``(args, kwargs)`` tuple per job; each job runs ``func(*args, **kwargs)``.
-        Build this however the work fans out — over FOV, timepoints, channels, etc.
-    slurm_out_path : Union[str, Path]
-        Directory for submitit logs and the job-id file.
-    slurm_args : dict
-        Parameters for ``executor.update_parameters``.
-    finalize : {"monitor", "wait", "none"}, optional
-        How to finalize after submission: ``"monitor"`` for live progress (image
-        modules), ``"wait"`` to block silently until done (estimators), or
-        ``"none"`` to return immediately. Default ``"monitor"``.
-    monitor_paths : list, optional
-        Paths passed to ``monitor_jobs`` for progress labels when
-        ``finalize="monitor"`` (typically the input position dirpaths).
-    local : bool, optional
-        Run locally instead of submitting to SLURM. Default False.
-    cluster : str, optional
-        Pre-resolved submitit cluster backend; takes precedence over ``local``.
-    sbatch_filepath : Union[str, Path], optional
-        Optional sbatch file whose parsed contents override ``slurm_args``.
-
-    Returns
-    -------
-    SlurmExecutor
-        The executor used, with ``.jobs`` populated, so callers can inspect or
-        further wait on the submitted jobs.
-    """
-    if finalize not in ("monitor", "wait", "none"):
-        raise ValueError(f"finalize must be 'monitor', 'wait', or 'none', got {finalize!r}")
-
-    executor = SlurmExecutor(
-        slurm_out_path,
-        slurm_args,
-        local=local,
-        cluster=cluster,
-        sbatch_filepath=sbatch_filepath,
-    )
-    executor.submit_batch(func, job_args)
-
-    if finalize == "monitor":
-        executor.monitor(monitor_paths)
-    elif finalize == "wait":
-        executor.wait()
-    return executor

--- a/biahub/deskew.py
+++ b/biahub/deskew.py
@@ -1,3 +1,4 @@
+from functools import partial
 from pathlib import Path
 from typing import Literal
 
@@ -12,17 +13,17 @@ from monai.transforms.spatial.array import Affine
 from scipy.ndimage import binary_dilation
 
 from biahub.cli import utils
+from biahub.cli.job_runner import JobRunner
 from biahub.cli.parsing import (
     config_filepath,
+    executor,
     input_position_dirpaths,
-    local,
     monitor,
     output_dirpath,
     sbatch_filepath,
 )
-from biahub.cli.slurm import submit_jobs
+from biahub.cli.slurm import resolve_slurm_args
 from biahub.cli.utils import (
-    estimate_resources,
     resolve_ome_zarr_version,
     yaml_to_model,
 )
@@ -567,12 +568,77 @@ def _czyx_fast_deskew_data(data, device="cuda", num_splits=1, **kwargs):
     return fast_deskew_zyx(tensor, **kwargs).cpu().numpy()[None]
 
 
+def _init_output_plate(
+    input_position_dirpaths: list[Path],
+    output_dirpath: Path,
+    settings: DeskewSettings,
+) -> tuple[int, int, int, int, int]:
+    """Create the empty deskewed output plate mirroring the input.
+
+    Infers the dataset shape and channels from the first input position, computes
+    the deskewed output shape/voxel size, and creates the output store. Returns the
+    input ``(T, C, Z, Y, X)`` shape so the caller can size SLURM resources.
+    """
+    with open_ome_zarr(str(input_position_dirpaths[0]), mode="r") as input_dataset:
+        channel_names = input_dataset.channel_names
+        T, C, Z, Y, X = input_dataset.data.shape
+
+    params = settings.deskew_params
+    deskewed_shape, voxel_size = get_deskewed_data_shape(
+        (Z, Y, X),
+        params.ls_angle_deg,
+        params.px_to_scan_ratio,
+        params.keep_overhang,
+        params.average_n_slices,
+        settings.pixel_size_um,
+    )
+
+    create_empty_plate(
+        store_path=output_dirpath,
+        position_keys=[Path(p).parts[-3:] for p in input_position_dirpaths],
+        channel_names=channel_names,
+        shape=(T, C) + deskewed_shape,
+        scale=(1, 1) + voxel_size,
+        version=resolve_ome_zarr_version(
+            input_position_dirpaths[0], settings.output_ome_zarr_version
+        ),
+    )
+    return (T, C, Z, Y, X)
+
+
+def _resolve_settings(
+    settings: DeskewSettings, input_shape: tuple[int, int, int, int, int]
+) -> tuple[dict, dict]:
+    """Resolve concrete SLURM params and per-position fn kwargs from the settings.
+
+    The config's ``slurm_settings`` provides the base SLURM params; resolve_slurm_args
+    sizes cpus/mem to the data. The resulting ``slurm_cpus_per_task`` doubles as the
+    kernel's ``num_workers``, keeping one source of truth. Returns ``(slurm_args,
+    fn_args)``.
+    """
+    slurm_args = resolve_slurm_args(
+        settings.slurm_settings.model_dump(),
+        input_shape,
+        ram_multiplier=32,
+        max_num_cpus=8,
+    )
+
+    fn_args = {
+        # process_single_position's own orchestration args
+        "num_workers": slurm_args["slurm_cpus_per_task"],
+        "extra_metadata": {"deskew": settings.model_dump()},
+        # the deskew kernel params it forwards (settings.deskew_params *is* the signature)
+        **settings.deskew_params.model_dump(),
+    }
+    return slurm_args, fn_args
+
+
 def deskew(
     input_position_dirpaths: list[str],
     config_filepath: Path,
     output_dirpath: str,
     sbatch_filepath: str = None,
-    local: bool = False,
+    executor: str = "slurm",
     monitor: bool = True,
 ):
     """
@@ -588,8 +654,9 @@ def deskew(
         Path to the output directory
     sbatch_filepath : str, optional
         Path to the SLURM batch file
-    local : bool, optional
-        Whether to run locally or submit to SLURM
+    executor : {"sequential", "local", "slurm"}, optional
+        Execution backend: in-process, parallel subprocesses on this machine, or a
+        SLURM cluster. Default "slurm".
     monitor : bool, optional
         Whether to monitor the jobs
 
@@ -597,87 +664,29 @@ def deskew(
     -------
     None
     """
-    # Convert string paths to Path objects
     output_dirpath = Path(output_dirpath)
-
-    slurm_out_path = output_dirpath.parent / "slurm_output"
 
     # Handle single position or wildcard filepath
     output_position_paths = utils.get_output_paths(input_position_dirpaths, output_dirpath)
 
-    # Get the deskewing parameters
-    # Load the first position to infer dataset information
-    with open_ome_zarr(str(input_position_dirpaths[0]), mode="r") as input_dataset:
-        channel_names = input_dataset.channel_names
-        T, C, Z, Y, X = input_dataset.data.shape
-
     settings = yaml_to_model(config_filepath, DeskewSettings)
-    deskewed_shape, voxel_size = get_deskewed_data_shape(
-        (Z, Y, X),
-        settings.ls_angle_deg,
-        settings.px_to_scan_ratio,
-        settings.keep_overhang,
-        settings.average_n_slices,
-        settings.pixel_size_um,
-    )
+    input_shape = _init_output_plate(input_position_dirpaths, output_dirpath, settings)
+    slurm_args, fn_args = _resolve_settings(settings, input_shape)
 
-    # Create a zarr store output to mirror the input
-    create_empty_plate(
-        store_path=output_dirpath,
-        position_keys=[p.parts[-3:] for p in input_position_dirpaths],
-        channel_names=channel_names,
-        shape=(T, C) + deskewed_shape,
-        scale=(1, 1) + voxel_size,
-        version=resolve_ome_zarr_version(
-            input_position_dirpaths[0], settings.output_ome_zarr_version
-        ),
-    )
-
-    deskew_args = {
-        "ls_angle_deg": settings.ls_angle_deg,
-        "px_to_scan_ratio": settings.px_to_scan_ratio,
-        "keep_overhang": settings.keep_overhang,
-        "average_n_slices": settings.average_n_slices,
-        "overhang_fill": settings.overhang_fill,
-        "device": settings.device,
-        "extra_metadata": {"deskew": settings.model_dump()},
-    }
-
-    # Estimate resources
-    num_cpus, gb_ram = estimate_resources(
-        shape=(T, C, Z, Y, X), ram_multiplier=32, max_num_cpus=8
-    )
-
-    # Prepare SLURM arguments
-    slurm_args = {
-        "slurm_job_name": "deskew",
-        "slurm_mem_per_cpu": f"{gb_ram}G",
-        "slurm_cpus_per_task": num_cpus,
-        "slurm_array_parallelism": 100,  # process up to 100 positions at a time
-        "slurm_time": 60,
-        "slurm_partition": "preempted",
-    }
-
-    # Fan out one job per position (FOV) and submit/monitor via the shared helper
-    job_args = [
-        (
-            (_czyx_fast_deskew_data, input_position_path, output_position_path),
-            {"num_workers": slurm_args["slurm_cpus_per_task"], **deskew_args},
-        )
-        for input_position_path, output_position_path in zip(
-            input_position_dirpaths, output_position_paths, strict=True
-        )
-    ]
-
-    submit_jobs(
-        process_single_position,
-        job_args,
-        slurm_out_path=slurm_out_path,
+    # Bind the deskew kernel into iohub's per-position processor; only the input/output
+    # paths vary across jobs.
+    fn = partial(process_single_position, _czyx_fast_deskew_data)
+    JobRunner(
+        fn,
+        zip(input_position_dirpaths, output_position_paths, strict=True),
+        fn_args,
+        executor=executor,
+        output_dirpath=output_dirpath,
         slurm_args=slurm_args,
+        sbatch_filepath=sbatch_filepath,
+    ).execute(
         finalize="monitor" if monitor else "none",
         monitor_paths=input_position_dirpaths,
-        local=local,
-        sbatch_filepath=sbatch_filepath,
     )
 
 
@@ -686,29 +695,32 @@ def deskew(
 @config_filepath()
 @output_dirpath()
 @sbatch_filepath()
-@local()
+@executor()
 @monitor()
 def deskew_cli(
     input_position_dirpaths: list[str],
     config_filepath: Path,
     output_dirpath: str,
     sbatch_filepath: str = None,
-    local: bool = False,
+    executor: str = "slurm",
     monitor: bool = True,
 ):
-    """Deskew a single position across T and C axes using a configuration file, generated by estimate_deskew.py.
+    r"""Deskew a single position across T and C axes using a configuration file, generated by estimate_deskew.py.
 
-    >>> biahub deskew \
-        -i ./input.zarr/*/*/* \
-        -c ./deskew_params.yml \
-        -o ./output.zarr
+    \b
+    Fan out positions across a SLURM cluster:
+    >>> biahub deskew -i ./input.zarr/*/*/* -c ./deskew_params.yml -o ./output.zarr
+
+    \b
+    Run a single position in-process (e.g. debugging or a per-position worker):
+    >>> biahub deskew --executor sequential -i ./input.zarr/A/1/0 -c ./deskew_params.yml -o ./output.zarr
     """
     deskew(
         input_position_dirpaths=input_position_dirpaths,
         config_filepath=config_filepath,
         output_dirpath=output_dirpath,
         sbatch_filepath=sbatch_filepath,
-        local=local,
+        executor=executor,
         monitor=monitor,
     )
 

--- a/biahub/deskew.py
+++ b/biahub/deskew.py
@@ -3,7 +3,6 @@ from typing import Literal
 
 import click
 import numpy as np
-import submitit
 import torch
 import torch.nn.functional as F  # noqa: N812
 
@@ -13,7 +12,6 @@ from monai.transforms.spatial.array import Affine
 from scipy.ndimage import binary_dilation
 
 from biahub.cli import utils
-from biahub.cli.monitor import monitor_jobs
 from biahub.cli.parsing import (
     config_filepath,
     input_position_dirpaths,
@@ -21,11 +19,10 @@ from biahub.cli.parsing import (
     monitor,
     output_dirpath,
     sbatch_filepath,
-    sbatch_to_submitit,
 )
+from biahub.cli.slurm import submit_jobs
 from biahub.cli.utils import (
     estimate_resources,
-    get_submitit_cluster,
     resolve_ome_zarr_version,
     yaml_to_model,
 )
@@ -661,45 +658,27 @@ def deskew(
         "slurm_partition": "preempted",
     }
 
-    # Override defaults if sbatch_filepath is provided
-    if sbatch_filepath:
-        slurm_args.update(sbatch_to_submitit(sbatch_filepath))
-
-    # Run locally or submit to SLURM
-    cluster = get_submitit_cluster(local)
-
-    # Prepare and submit jobs
-    click.echo(f"Preparing jobs: {slurm_args}")
-    executor = submitit.AutoExecutor(folder=slurm_out_path, cluster=cluster)
-    executor.update_parameters(**slurm_args)
-
-    click.echo("Submitting SLURM jobs...")
-
-    jobs = []
-    with submitit.helpers.clean_env(), executor.batch():
+    # Fan out one job per position (FOV) and submit/monitor via the shared helper
+    job_args = [
+        (
+            (_czyx_fast_deskew_data, input_position_path, output_position_path),
+            {"num_workers": slurm_args["slurm_cpus_per_task"], **deskew_args},
+        )
         for input_position_path, output_position_path in zip(
             input_position_dirpaths, output_position_paths, strict=True
-        ):
-            jobs.append(
-                executor.submit(
-                    process_single_position,
-                    _czyx_fast_deskew_data,
-                    input_position_path,
-                    output_position_path,
-                    num_workers=slurm_args["slurm_cpus_per_task"],
-                    **deskew_args,
-                )
-            )
+        )
+    ]
 
-    job_ids = [job.job_id for job in jobs]  # Access job IDs after batch submission
-
-    slurm_out_path.mkdir(exist_ok=True)
-    log_path = Path(slurm_out_path / "submitit_jobs_ids.log")
-    with log_path.open("w") as log_file:
-        log_file.write("\n".join(job_ids))
-
-    if monitor:
-        monitor_jobs(jobs, input_position_dirpaths)
+    submit_jobs(
+        process_single_position,
+        job_args,
+        slurm_out_path=slurm_out_path,
+        slurm_args=slurm_args,
+        finalize="monitor" if monitor else "none",
+        monitor_paths=input_position_dirpaths,
+        local=local,
+        sbatch_filepath=sbatch_filepath,
+    )
 
 
 @click.command("deskew")

--- a/biahub/estimate_deskew.py
+++ b/biahub/estimate_deskew.py
@@ -1,5 +1,3 @@
-from dataclasses import asdict
-
 import click
 import napari
 import numpy as np
@@ -8,7 +6,7 @@ import yaml
 from iohub.ngff import open_ome_zarr
 
 from biahub.cli.parsing import input_position_dirpaths, output_filepath
-from biahub.settings import DeskewSettings
+from biahub.settings import DeskewParams, DeskewSettings
 
 
 @click.command("estimate-deskew")
@@ -71,15 +69,17 @@ def estimate_deskew_cli(input_position_dirpaths, output_filepath):
     # Create validated object
     settings = DeskewSettings(
         pixel_size_um=pixel_size_um,
-        ls_angle_deg=theta_deg,
-        px_to_scan_ratio=px_to_scan_ratio,
         scan_step_um=scan_step_um,
+        deskew_params=DeskewParams(
+            ls_angle_deg=theta_deg,
+            px_to_scan_ratio=px_to_scan_ratio,
+        ),
     )
 
     # Write result
     print(f"Writing deskewing parameters to {output_filepath}")
     with open(output_filepath, "w") as f:
-        yaml.dump(asdict(settings), f)
+        yaml.dump(settings.model_dump(), f)
 
 
 if __name__ == "__main__":

--- a/biahub/registration/beads.py
+++ b/biahub/registration/beads.py
@@ -40,10 +40,10 @@ from scipy.spatial import cKDTree
 from skimage.transform import AffineTransform, EuclideanTransform, SimilarityTransform
 
 from biahub.characterize_psf import detect_peaks
-from biahub.cli.slurm import submit_jobs
+from biahub.cli.job_runner import JobRunner
+from biahub.cli.slurm import resolve_slurm_args
 from biahub.cli.utils import (
     _check_nan_n_zeros,
-    estimate_resources,
 )
 from biahub.core.graph_matching import Graph, GraphMatcher
 from biahub.core.transform import Transform
@@ -502,50 +502,43 @@ def estimate_independently(
         "stabilization": align moving channel to itself over time.
     """
     T, Z, Y, X = mov_tzyx.shape
-    num_cpus, gb_ram_per_cpu = estimate_resources(
-        shape=(T, 2, Z, Y, X), ram_multiplier=5, max_num_cpus=16
+
+    # Static SLURM params; resolve_slurm_args sizes cpus/mem to the data.
+    slurm_args = resolve_slurm_args(
+        {
+            "slurm_job_name": "estimate_registration",
+            "slurm_array_parallelism": 100,
+            "slurm_time": 30,
+            "slurm_partition": "preempted",
+            "slurm_use_srun": False,
+        },
+        (T, 2, Z, Y, X),
+        ram_multiplier=5,
+        max_num_cpus=16,
     )
 
-    # Prepare SLURM arguments
-    slurm_args = {
-        "slurm_job_name": "estimate_registration",
-        "slurm_mem_per_cpu": f"{gb_ram_per_cpu}G",
-        "slurm_cpus_per_task": num_cpus,
-        "slurm_array_parallelism": 100,
-        "slurm_time": 30,
-        "slurm_partition": "preempted",
-        "slurm_use_srun": False,
-    }
+    # Map the legacy submitit cluster selector onto the JobRunner backend:
+    # "debug" -> in-process, falsy -> local, otherwise pass through.
+    backend = {"debug": "sequential"}.get(cluster, cluster) or "local"
 
-    slurm_out_path = output_folder_path.parent / "slurm_output"
-
-    # Fan out one job per timepoint (T) and block until all finish
-    job_args = [
-        (
-            (),
-            {
-                "t_idx": t,
-                "mov_tzyx": mov_tzyx,
-                "ref_tzyx": ref_tzyx,
-                "beads_match_settings": beads_match_settings,
-                "affine_transform_settings": affine_transform_settings,
-                "verbose": verbose,
-                "output_folder_path": output_folder_path,
-                "mode": mode,
-            },
-        )
-        for t in range(T)
-    ]
-
-    submit_jobs(
+    # Fan out one job per timepoint (T); only t_idx varies, the rest is constant.
+    JobRunner(
         estimate_tzyx,
-        job_args,
-        slurm_out_path=slurm_out_path,
+        range(T),
+        {
+            "mov_tzyx": mov_tzyx,
+            "ref_tzyx": ref_tzyx,
+            "beads_match_settings": beads_match_settings,
+            "affine_transform_settings": affine_transform_settings,
+            "verbose": verbose,
+            "output_folder_path": output_folder_path,
+            "mode": mode,
+        },
+        executor=backend,
+        output_dirpath=output_folder_path,
         slurm_args=slurm_args,
-        finalize="wait",
-        cluster=cluster,
         sbatch_filepath=sbatch_filepath,
-    )
+    ).execute(finalize="wait")
 
 
 def peaks_from_beads(

--- a/biahub/registration/beads.py
+++ b/biahub/registration/beads.py
@@ -25,7 +25,6 @@ Key conventions
 - Transforms map from moving space to reference space (forward direction).
 """
 
-from datetime import datetime
 from itertools import product
 from pathlib import Path
 from typing import Literal
@@ -34,7 +33,6 @@ import ants
 import click
 import dask.array as da
 import numpy as np
-import submitit
 
 from iohub import open_ome_zarr
 from numpy.typing import ArrayLike
@@ -42,10 +40,7 @@ from scipy.spatial import cKDTree
 from skimage.transform import AffineTransform, EuclideanTransform, SimilarityTransform
 
 from biahub.characterize_psf import detect_peaks
-from biahub.cli.parsing import (
-    sbatch_to_submitit,
-)
-from biahub.cli.slurm import wait_for_jobs_to_finish
+from biahub.cli.slurm import submit_jobs
 from biahub.cli.utils import (
     _check_nan_n_zeros,
     estimate_resources,
@@ -522,42 +517,35 @@ def estimate_independently(
         "slurm_use_srun": False,
     }
 
-    if sbatch_filepath:
-        slurm_args.update(sbatch_to_submitit(sbatch_filepath))
-
     slurm_out_path = output_folder_path.parent / "slurm_output"
-    slurm_out_path.mkdir(exist_ok=True)
 
-    # Submitit executor
-    executor = submitit.AutoExecutor(folder=slurm_out_path, cluster=cluster)
-    executor.update_parameters(**slurm_args)
-    click.echo(f"Submitting SLURM focus estimation jobs with resources: {slurm_args}")
+    # Fan out one job per timepoint (T) and block until all finish
+    job_args = [
+        (
+            (),
+            {
+                "t_idx": t,
+                "mov_tzyx": mov_tzyx,
+                "ref_tzyx": ref_tzyx,
+                "beads_match_settings": beads_match_settings,
+                "affine_transform_settings": affine_transform_settings,
+                "verbose": verbose,
+                "output_folder_path": output_folder_path,
+                "mode": mode,
+            },
+        )
+        for t in range(T)
+    ]
 
-    # Submit jobs
-    jobs = []
-    with submitit.helpers.clean_env(), executor.batch():
-        for t in range(T):
-            job = executor.submit(
-                estimate_tzyx,
-                t_idx=t,
-                mov_tzyx=mov_tzyx,
-                ref_tzyx=ref_tzyx,
-                beads_match_settings=beads_match_settings,
-                affine_transform_settings=affine_transform_settings,
-                verbose=verbose,
-                output_folder_path=output_folder_path,
-                mode=mode,
-            )
-            jobs.append(job)
-
-    # Save job IDs
-    timestamp = datetime.now().strftime("%Y%m%d-%H%M%S")
-    log_path = slurm_out_path / f"job_ids_{timestamp}.log"
-    with open(log_path, "w") as log_file:
-        for job in jobs:
-            log_file.write(f"{job.job_id}\n")
-
-    wait_for_jobs_to_finish(jobs)
+    submit_jobs(
+        estimate_tzyx,
+        job_args,
+        slurm_out_path=slurm_out_path,
+        slurm_args=slurm_args,
+        finalize="wait",
+        cluster=cluster,
+        sbatch_filepath=sbatch_filepath,
+    )
 
 
 def peaks_from_beads(

--- a/biahub/settings.py
+++ b/biahub/settings.py
@@ -23,6 +23,15 @@ class MyBaseModel(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
 
+class SlurmSettings(MyBaseModel):
+    slurm_job_name: str
+    slurm_mem_per_cpu: str
+    slurm_cpus_per_task: int
+    slurm_array_parallelism: int
+    slurm_time: int
+    slurm_partition: str
+
+
 class DetectPeaksSettings(MyBaseModel):
     threshold_abs: float = 110
     nms_distance: int = 16
@@ -295,17 +304,22 @@ class ProcessingSettings(MyBaseModel):
     rot90: int | None = 0
 
 
-class DeskewSettings(MyBaseModel):
-    pixel_size_um: PositiveFloat
+class DeskewParams(MyBaseModel):
+    """Deskew kernel parameters, matching the ``fast_deskew_zyx`` call signature.
+
+    These fields are splatted directly into the per-position kernel call
+    (``model_dump()`` -> ``func(**kwargs)``), so the model *is* the signature: no
+    hand-maintained mapping between settings and kernel args to drift out of sync.
+    ``px_to_scan_ratio`` may be left unset and derived by :class:`DeskewSettings`
+    from ``pixel_size_um`` / ``scan_step_um``.
+    """
+
     ls_angle_deg: PositiveFloat
     px_to_scan_ratio: PositiveFloat | None = None
-    scan_step_um: PositiveFloat | None = None
     keep_overhang: bool = False
     overhang_fill: Literal["mean"] | float = 0
     average_n_slices: PositiveInt = 3
     device: str = "cpu"
-    # When None, preserve the OME-Zarr version of the input store.
-    output_ome_zarr_version: Literal["0.4", "0.5"] | None = None
 
     @field_validator("ls_angle_deg")
     @classmethod
@@ -319,18 +333,43 @@ class DeskewSettings(MyBaseModel):
     def px_to_scan_ratio_check(cls, v):
         if v is not None:
             return round(float(v), 3)
+        return v
 
-    def __init__(self, **data):
-        if data.get("px_to_scan_ratio") is None:
-            if data.get("scan_step_um") is not None:
-                data["px_to_scan_ratio"] = round(
-                    data["pixel_size_um"] / data["scan_step_um"], 3
-                )
+
+class DeskewSettings(MyBaseModel):
+    pixel_size_um: PositiveFloat
+    scan_step_um: PositiveFloat | None = None
+    deskew_params: DeskewParams
+    # When None, preserve the OME-Zarr version of the input store.
+    output_ome_zarr_version: Literal["0.4", "0.5"] | None = None
+    slurm_settings: SlurmSettings = SlurmSettings(
+        slurm_job_name="deskew",
+        slurm_mem_per_cpu="32G",
+        slurm_cpus_per_task=8,
+        slurm_array_parallelism=100,
+        slurm_time=120,
+        slurm_partition="preempted",
+    )
+
+    @model_validator(mode="before")
+    @classmethod
+    def _derive_px_to_scan_ratio(cls, data):
+        # Fill deskew_params.px_to_scan_ratio from pixel_size_um / scan_step_um when
+        # it is not given directly, so callers can specify either.
+        if not isinstance(data, dict):
+            return data
+        params = data.get("deskew_params")
+        if isinstance(params, dict) and params.get("px_to_scan_ratio") is None:
+            pixel_size_um = data.get("pixel_size_um")
+            scan_step_um = data.get("scan_step_um")
+            if pixel_size_um is not None and scan_step_um is not None:
+                params["px_to_scan_ratio"] = round(pixel_size_um / scan_step_um, 3)
             else:
                 raise ValueError(
-                    "If px_to_scan_ratio is not provided, both pixel_size_um and scan_step_um must be provided"
+                    "If deskew_params.px_to_scan_ratio is not provided, both "
+                    "pixel_size_um and scan_step_um must be provided"
                 )
-        super().__init__(**data)
+        return data
 
 
 class RegistrationSettings(MyBaseModel):

--- a/biahub/stabilize.py
+++ b/biahub/stabilize.py
@@ -21,9 +21,9 @@ from biahub.cli.parsing import (
     sbatch_filepath,
     sbatch_to_submitit,
 )
+from biahub.cli.slurm import resolve_slurm_args
 from biahub.cli.utils import (
     copy_n_paste_czyx,
-    estimate_resources,
     get_submitit_cluster,
     resolve_ome_zarr_version,
     yaml_to_model,
@@ -241,22 +241,19 @@ def stabilize(
 
     copy_n_paste_kwargs = {"czyx_slicing_params": ([Z_slice, Y_slice, X_slice])}
 
-    # Estimate resources
-
-    num_cpus, gb_ram_per_cpu = estimate_resources(
-        shape=[T, C, Z, Y, X], ram_multiplier=16, max_num_cpus=16
+    # Prepare SLURM arguments; resolve_slurm_args sizes cpus/mem to the data.
+    slurm_args = resolve_slurm_args(
+        {
+            "slurm_job_name": "stabilize",
+            "slurm_array_parallelism": 100,  # process up to 100 positions at a time
+            "slurm_time": 20,
+            "slurm_partition": "preempted",
+            "slurm_use_srun": False,
+        },
+        (T, C, Z, Y, X),
+        ram_multiplier=16,
+        max_num_cpus=16,
     )
-
-    # Prepare SLURM arguments
-    slurm_args = {
-        "slurm_job_name": "stabilize",
-        "slurm_mem_per_cpu": f"{gb_ram_per_cpu}G",
-        "slurm_cpus_per_task": num_cpus,
-        "slurm_array_parallelism": 100,  # process up to 100 positions at a time
-        "slurm_time": 20,
-        "slurm_partition": "preempted",
-        "slurm_use_srun": False,
-    }
 
     # Override defaults if sbatch_filepath is provided
     if sbatch_filepath:

--- a/settings/example_deskew_settings.yml
+++ b/settings/example_deskew_settings.yml
@@ -1,7 +1,8 @@
 pixel_size_um: 0.116
-ls_angle_deg: 36.17  # can be calibrated using estimate_deskew.py
-px_to_scan_ratio: 0.371  # Optional, can be calibrated using estimate_deskew.py
-scan_step_um: 0.313  # Optional, corresponds to 10 mV
-keep_overhang: true  # Optional, if true deskewed array will have the shape of a tilted parallelepiped
-average_n_slices: 3  # Axial averaging applied after deskewing
-overhang_fill: mean # Optional, if true zero-padded overhang regions will be filled with the mean of the valid signal
+scan_step_um: 0.313  # Optional, corresponds to 10 mV; used to derive px_to_scan_ratio
+deskew_params:
+  ls_angle_deg: 36.17  # can be calibrated using estimate_deskew.py
+  px_to_scan_ratio: 0.371  # Optional, derived from pixel_size_um / scan_step_um if unset
+  keep_overhang: true  # Optional, if true deskewed array will have the shape of a tilted parallelepiped
+  average_n_slices: 3  # Axial averaging applied after deskewing
+  overhang_fill: mean  # Optional, value used to fill zero-padded overhang regions

--- a/tests/test_cli/test_deskew_cli.py
+++ b/tests/test_cli/test_deskew_cli.py
@@ -77,14 +77,41 @@ def test_deskew_cli(tmp_path, example_plate, example_deskew_settings, sbatch_fil
             str(config_path),
             "-o",
             str(output_path),
-            "--local",
+            "--executor",
+            "local",
             "--sbatch-filepath",
             sbatch_file,
         ],
     )
 
+    assert output_path.exists(), result.output
+    assert result.exit_code == 0, result.output
+
+
+def test_deskew_cli_sequential(tmp_path, example_plate, example_deskew_settings):
+    plate_path, _ = example_plate
+    config_path, _ = example_deskew_settings
+    output_path = tmp_path / "output.zarr"
+
+    # The "sequential" backend runs in-process with no SLURM/submitit.
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        [
+            "deskew",
+            "-i",
+            str(plate_path) + "/A/1/0",
+            "-c",
+            str(config_path),
+            "-o",
+            str(output_path),
+            "--executor",
+            "sequential",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
     assert output_path.exists()
-    assert result.exit_code == 0
 
 
 def test_deskew_overhang_only_dataset_error():

--- a/tests/test_example_settings.py
+++ b/tests/test_example_settings.py
@@ -89,20 +89,29 @@ def test_deskew_settings():
     # Test extra parameter
     with pytest.raises(ValidationError):
         DeskewSettings(
-            pixel_size_um=0.116, ls_angle_deg=36, scan_step_um=0.313, typo_param="test"
+            pixel_size_um=0.116,
+            scan_step_um=0.313,
+            deskew_params={"ls_angle_deg": 36},
+            typo_param="test",
         )
 
     # Test negative value
     with pytest.raises(ValidationError):
-        DeskewSettings(pixel_size_um=-3, ls_angle_deg=36, scan_step_um=0.313)
+        DeskewSettings(
+            pixel_size_um=-3, scan_step_um=0.313, deskew_params={"ls_angle_deg": 36}
+        )
 
     # Test light sheet angle range
     with pytest.raises(ValueError):
-        DeskewSettings(pixel_size_um=0.116, ls_angle_deg=90, scan_step_um=0.313)
+        DeskewSettings(
+            pixel_size_um=0.116, scan_step_um=0.313, deskew_params={"ls_angle_deg": 90}
+        )
 
     # Test px_to_scan_ratio logic
     with pytest.raises(ValueError):
-        DeskewSettings(pixel_size_um=0.116, ls_angle_deg=36, scan_step_um=None)
+        DeskewSettings(
+            pixel_size_um=0.116, scan_step_um=None, deskew_params={"ls_angle_deg": 36}
+        )
 
 
 def test_register_settings():


### PR DESCRIPTION
## Summary

Introduces a single, backend-agnostic way to run a function across a batch of jobs, and removes the per-CLI submitit/SLURM boilerplate that had started to drift between modules. Migrates `deskew`, `beads`, and `stabilize` onto it as the first consumers.

This is an alternative take on the executor direction explored in #252: rather than threading a `--cluster {slurm,local,debug}` flag through each CLI's hand-rolled submitit block, it factors the submission into one reusable abstraction so every CLI shares the same code path.

## What's here

### `JobRunner(fn, items, fn_args)` — `biahub/cli/job_runner.py`
A job is `fn(*item, **fn_args)`. `fn` and `fn_args` are constant across the batch; `items` is the fan-out axis (a tuple is unpacked, a scalar is one positional arg). Bind constant leading positionals with `functools.partial`. Backends:

- **`sequential`** — in-process, serial, fail-fast. No SLURM, no submitit. For debugging and orchestrators that already own the fan-out (e.g. a Nextflow worker on one position).
- **`local`** — parallel subprocesses via submitit.
- **`slurm`** — parallel cluster jobs via submitit.

The kernel and its call signature are **identical** across all backends — only the wrapping differs — so the "two parallel implementations drift apart" bug (which #252 also caught in the deskew kernel) becomes structurally impossible. In CI, submitit backends transparently downgrade to `sequential`.

### `resolve_slurm_args(...)` — `biahub/cli/slurm.py`
`slurm.py` is slimmed to the submitit engine (`SlurmExecutor`, which now derives its log dir from `output_dirpath`). `resolve_slurm_args(base, shape, *, ram_multiplier, max_num_cpus)` sizes `slurm_cpus_per_task`/`slurm_mem_per_cpu` to the data over a base dict — the pattern repeated in ~15 CLIs. It takes a plain dict (not a `SlurmSettings`), so it works whether the base comes from a settings model or a literal, and preserves extra keys like `slurm_use_srun`.

### Nested `DeskewParams` — `biahub/settings.py`
`DeskewSettings` now nests a `DeskewParams` sub-model that matches the `fast_deskew_zyx` kernel signature exactly, so `deskew_params.model_dump()` splats straight into the kernel call (no hand-maintained settings→kernel mapping). Top level keeps `pixel_size_um`/`scan_step_um`, `slurm_settings`, and the output version; `px_to_scan_ratio` derivation moves to a `model_validator`.

> ⚠️ **Breaking config change:** existing deskew YAMLs must move the kernel fields under `deskew_params:` (see `settings/example_deskew_settings.yml`).

### CLI surface
`biahub deskew` replaces `--local` with `--executor {sequential,local,slurm}`.

## Migrated CLIs
- **deskew** — nested config → `_init_output_plate` → `_resolve_settings`/`resolve_slurm_args` → `JobRunner`.
- **beads** — per-timepoint estimation through `JobRunner`; SLURM args via `resolve_slurm_args`.
- **stabilize** — SLURM args via `resolve_slurm_args`.

The remaining `estimate_resources`+slurm-dict CLIs (deconvolve, concatenate, flat-field, process_data, track, pyramid, …) can adopt `resolve_slurm_args` the same way in follow-ups. `segment.py` is the one exception — it post-processes the cpu count, so it needs more than a drop-in.

## Test plan
- [x] `ruff check` + `ruff format` clean across all touched files.
- [x] `pytest tests/test_cli/test_deskew_cli.py` (incl. new `--executor sequential` case), `test_example_settings.py`, `test_cli/test_register_cli.py`, `test_cli/test_stabilization_cli.py` — all pass.
- [ ] End-to-end run on real data (`sequential` single position + `slurm` fan-out) — in progress.

## Commits
1. `refactor(slurm)` — JobRunner + resolve_slurm_args + `--executor`
2. `refactor(settings)` — nest DeskewParams
3. `refactor` — migrate deskew, beads, stabilize