### PR TITLE
feat(visualize): grid-per-well and grid-movies MP4 tiling CLIs

### DIFF
--- a/biahub/cli/main.py
+++ b/biahub/cli/main.py
@@ -174,6 +174,16 @@ COMMANDS = [
         "import_path": "biahub.track.track_cli",
         "help": "Track objects in 2D/3D time-lapse microscopy",
     },
+    {
+        "name": "grid-per-well",
+        "import_path": "biahub.visualize.grid_per_well.grid_per_well_cli",
+        "help": "Tile per-FOV MP4s into per-well grid movies",
+    },
+    {
+        "name": "grid-movies",
+        "import_path": "biahub.visualize.grid_movies.grid_movies_cli",
+        "help": "Tile a set of movies (channels) into a grid, optionally one per FOV",
+    },
 ]
 
 

--- a/biahub/settings.py
+++ b/biahub/settings.py
@@ -23,6 +23,72 @@ class MyBaseModel(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
 
+class MovieTileSettings(MyBaseModel):
+    """One source movie placed in a `grid-movies` grid."""
+
+    mov_path: str
+    legend: str | None = None
+    crop_box: list[int] | None = None  # (y0, y1, x0, x1); None => auto non-black
+    rotation: float = 0
+    frame_step: int = 1  # keep every Nth source frame
+    frame_time_sampling_min: float | None = None  # minutes between source frames
+    legend_font_size: int = 20
+    timestamp_font_size: int = 16
+
+    @field_validator("crop_box")
+    @classmethod
+    def _check_crop_box(cls, v):
+        if v is not None and len(v) != 4:
+            raise ValueError("crop_box must be [y0, y1, x0, x1]")
+        return v
+
+
+class GridMoviesSettings(MyBaseModel):
+    """Tile a fixed set of movies (e.g. channels) into one grid movie."""
+
+    movs: list[MovieTileSettings]
+    output_dir: str
+    output_filename: str
+    grid: list[int] = [2, 2]
+    max_frames: int | None = None
+    fps: float | None = None
+    quality: int = 8
+    # Batch one grid per FOV by substituting `fov_placeholder` in paths/legends.
+    fov_list: list[str] | None = None
+    fov_placeholder: str = "{fov}"
+
+    @field_validator("grid")
+    @classmethod
+    def _check_grid(cls, v):
+        if len(v) != 2:
+            raise ValueError("grid must be [rows, cols]")
+        return v
+
+
+class GridPerWellSettings(MyBaseModel):
+    """Group per-FOV movies by well and tile each well onto a grid."""
+
+    mov_path: str
+    output_path: str
+    grid: list[int] = [2, 2]
+    time_sampling_min: float | None = None
+    rotation: float = 0
+    max_frames: int | None = None
+    frame_step: int = 1
+    legend_font_size: int = 20
+    timestamp_font_size: int = 24
+    add_legend: bool = True
+    fps: float | None = None
+    quality: int = 8
+
+    @field_validator("grid")
+    @classmethod
+    def _check_grid(cls, v):
+        if len(v) != 2:
+            raise ValueError("grid must be [rows, cols]")
+        return v
+
+
 class DetectPeaksSettings(MyBaseModel):
     threshold_abs: float = 110
     nms_distance: int = 16

--- a/biahub/visualize/grid_movies.py
+++ b/biahub/visualize/grid_movies.py
@@ -1,0 +1,107 @@
+"""Tile a fixed set of movies (e.g. channels) into one grid movie.
+
+Each entry in ``movs`` becomes one tile, with its own crop box, rotation, frame
+step, legend and timestamp. Optionally batch-render one grid per FOV by listing
+``fov_list`` and embedding ``fov_placeholder`` (default ``{fov}``) in the movie
+paths, legends and output filename.
+"""
+
+from copy import deepcopy
+from pathlib import Path
+
+import click
+
+from biahub.cli.parsing import config_filepath
+from biahub.cli.utils import yaml_to_model
+from biahub.settings import GridMoviesSettings
+from biahub.visualize.video_utils import TileSpec, tile_videos
+
+
+def get_unique_output_path(base_path: Path) -> Path:
+    """Append ``_2``, ``_3``, ... to avoid overwriting an existing file."""
+    if not base_path.exists():
+        return base_path
+    suffix = 2
+    while True:
+        candidate = base_path.with_name(f"{base_path.stem}_{suffix}{base_path.suffix}")
+        if not candidate.exists():
+            return candidate
+        suffix += 1
+
+
+def _tiles_from_settings(settings: GridMoviesSettings) -> list[TileSpec]:
+    """Build TileSpecs from the ``movs`` list, skipping missing files."""
+    tiles = []
+    for mov in settings.movs:
+        path = Path(mov.mov_path)
+        if not path.exists():
+            print(f"  !! Skipping missing video: {path}")
+            continue
+        tiles.append(
+            TileSpec(
+                path=path,
+                legend=mov.legend,
+                crop_box=tuple(mov.crop_box) if mov.crop_box else None,
+                rotation=mov.rotation,
+                frame_step=mov.frame_step,
+                time_sampling_min=mov.frame_time_sampling_min,
+                legend_font_size=mov.legend_font_size,
+                timestamp_font_size=mov.timestamp_font_size,
+            )
+        )
+    return tiles
+
+
+def _substitute_fov(settings: GridMoviesSettings, fov: str) -> GridMoviesSettings:
+    """Return a copy of ``settings`` with ``fov_placeholder`` filled in for one FOV.
+
+    Paths and the output filename use the ``a_b_c`` form of the FOV id; legends
+    keep the human-readable ``a/b/c`` form.
+    """
+    token = settings.fov_placeholder
+    fov_path = fov.replace("/", "_")
+    out = deepcopy(settings)
+    out.output_filename = out.output_filename.replace(token, fov_path)
+    for mov in out.movs:
+        mov.mov_path = mov.mov_path.replace(token, fov_path)
+        if mov.legend:
+            mov.legend = mov.legend.replace(token, fov)
+    return out
+
+
+def grid_movies(settings: GridMoviesSettings) -> None:
+    """Tile the configured movies into a single grid movie."""
+    output_dir = Path(settings.output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    tiles = _tiles_from_settings(settings)
+    if not tiles:
+        raise RuntimeError("No videos could be opened successfully.")
+
+    out_file = get_unique_output_path(output_dir / settings.output_filename)
+    tile_videos(
+        tiles,
+        grid=tuple(settings.grid),
+        out_file=out_file,
+        fps=settings.fps,
+        max_frames=settings.max_frames,
+        quality=settings.quality,
+    )
+
+
+@click.command("grid-movies")
+@config_filepath()
+def grid_movies_cli(config_filepath: Path):
+    """Tile a set of movies (channels) into a grid, optionally one per FOV."""
+    settings = yaml_to_model(config_filepath, GridMoviesSettings)
+
+    if settings.fov_list:
+        for fov in settings.fov_list:
+            print(f"\n=== FOV {fov} ===")
+            grid_movies(_substitute_fov(settings, fov))
+    else:
+        grid_movies(settings)
+
+
+if __name__ == "__main__":
+    grid_movies_cli()

--- a/biahub/visualize/grid_per_well.py
+++ b/biahub/visualize/grid_per_well.py
@@ -1,0 +1,83 @@
+"""Tile per-FOV MP4s into per-well grid movies.
+
+Given a directory of ``<prefix>_<well>_...mp4`` files, group them by well id and
+lay each well's FOVs out on a grid, producing one (or more) movies per well.
+All tiles in a run share the same rotation, frame step and timestamp sampling;
+each tile is labelled with its source file stem.
+"""
+
+from math import ceil
+from pathlib import Path
+
+import click
+
+from biahub.cli.parsing import config_filepath
+from biahub.cli.utils import yaml_to_model
+from biahub.settings import GridPerWellSettings
+from biahub.visualize.video_utils import TileSpec, tile_videos
+
+
+def get_well_id(stem: str) -> str:
+    """Parse the well id from a ``prefix_well_...`` filename stem."""
+    parts = stem.split("_")
+    if len(parts) < 2:
+        raise ValueError(f"Cannot parse well id from filename: {stem}")
+    return parts[1]
+
+
+def grid_per_well(settings: GridPerWellSettings) -> None:
+    """Tile per-FOV movies into per-well grids."""
+    mov_path = Path(settings.mov_path)
+    output_path = Path(settings.output_path)
+    grid = tuple(settings.grid)
+    output_path.mkdir(parents=True, exist_ok=True)
+
+    files = sorted(mov_path.glob("*.mp4"))
+    if not files:
+        raise FileNotFoundError(f"No .mp4 files found in {mov_path}")
+
+    by_well: dict = {}
+    for f in files:
+        by_well.setdefault(get_well_id(f.stem), []).append(f)
+    print(f"Found wells: {sorted(by_well.keys())}")
+
+    grid_size = grid[0] * grid[1]
+    for well_id, well_files in sorted(by_well.items()):
+        well_files = sorted(well_files)
+        num_groups = ceil(len(well_files) / grid_size)
+        print(f"\n[Well {well_id}] {len(well_files)} file(s) -> {num_groups} video(s)")
+
+        for group_idx in range(num_groups):
+            group = well_files[group_idx * grid_size : (group_idx + 1) * grid_size]
+            tiles = [
+                TileSpec(
+                    path=f,
+                    legend=f.stem if settings.add_legend else None,
+                    rotation=settings.rotation,
+                    frame_step=settings.frame_step,
+                    time_sampling_min=settings.time_sampling_min,
+                    legend_font_size=settings.legend_font_size,
+                    timestamp_font_size=settings.timestamp_font_size,
+                )
+                for f in group
+            ]
+            tile_videos(
+                tiles,
+                grid=grid,
+                out_file=output_path / f"{well_id}_{group_idx}.mp4",
+                fps=settings.fps,
+                max_frames=settings.max_frames,
+                quality=settings.quality,
+            )
+
+
+@click.command("grid-per-well")
+@config_filepath()
+def grid_per_well_cli(config_filepath: Path):
+    """Tile per-FOV MP4s into per-well grid movies."""
+    settings = yaml_to_model(config_filepath, GridPerWellSettings)
+    grid_per_well(settings)
+
+
+if __name__ == "__main__":
+    grid_per_well_cli()

--- a/biahub/visualize/video_utils.py
+++ b/biahub/visualize/video_utils.py
@@ -1,0 +1,351 @@
+"""Shared utilities for assembling and annotating MP4 movies.
+
+These helpers back the video-tiling tools (``grid_per_well`` and
+``grid_movies``). They are deliberately free of any napari/OME-Zarr dependency
+so they can be imported in headless jobs.
+"""
+
+from dataclasses import dataclass
+from functools import lru_cache
+from pathlib import Path
+from typing import List, Optional, Tuple
+
+import imageio
+import numpy as np
+from PIL import Image, ImageDraw, ImageFont
+
+Box = Tuple[int, int, int, int]  # (y0, y1, x0, x1)
+
+# Default font shipped with matplotlib/Pillow; falls back to the bitmap font.
+_DEFAULT_FONT = "DejaVuSans.ttf"
+
+
+# -----------------------------------------------------------------------------
+# Frame geometry helpers
+# -----------------------------------------------------------------------------
+def ensure_rgb(frame: np.ndarray) -> np.ndarray:
+    """Return an ``(H, W, 3)`` array regardless of input layout."""
+    if frame.ndim == 2:
+        return np.repeat(frame[..., None], 3, axis=2)
+    if frame.ndim == 3 and frame.shape[2] == 1:
+        return np.repeat(frame, 3, axis=2)
+    if frame.ndim == 3 and frame.shape[2] >= 3:
+        return frame[..., :3]
+    return frame
+
+
+def get_crop_box_nonblack(img: np.ndarray) -> Optional[Box]:
+    """Tight bounding box (y0, y1, x0, x1) around the non-black pixels.
+
+    Returns ``None`` if the image is entirely black.
+    """
+    rgb = img[..., :3]
+    rows = np.where(np.any(rgb != 0, axis=(1, 2)))[0]
+    cols = np.where(np.any(rgb != 0, axis=(0, 2)))[0]
+    if rows.size == 0 or cols.size == 0:
+        return None
+    return int(rows.min()), int(rows.max()) + 1, int(cols.min()), int(cols.max()) + 1
+
+
+def apply_box(img: np.ndarray, box: Box) -> np.ndarray:
+    """Crop ``img`` to the given (y0, y1, x0, x1) box."""
+    y0, y1, x0, x1 = box
+    return img[y0:y1, x0:x1]
+
+
+def center_crop_to(img: np.ndarray, target_hw: Tuple[int, int]) -> np.ndarray:
+    """Center-crop ``img`` to ``(target_h, target_w)``."""
+    th, tw = target_hw
+    h, w = img.shape[:2]
+    y0 = max(0, (h - th) // 2)
+    x0 = max(0, (w - tw) // 2)
+    return img[y0 : y0 + th, x0 : x0 + tw]
+
+
+def fit_to(img: np.ndarray, target_hw: Tuple[int, int]) -> np.ndarray:
+    """Center-crop, then resize as a fallback, so the result is exactly target."""
+    th, tw = target_hw
+    out = center_crop_to(img, target_hw)
+    if out.shape[:2] != (th, tw):
+        out = np.array(Image.fromarray(out).resize((tw, th)))
+    return out
+
+
+def rotate(img: np.ndarray, degrees: float) -> np.ndarray:
+    """Rotate an image by ``degrees`` (no-op when 0), expanding the canvas."""
+    if not degrees:
+        return img
+    return np.array(Image.fromarray(img).rotate(degrees, expand=True))
+
+
+# -----------------------------------------------------------------------------
+# Text annotation helpers
+# -----------------------------------------------------------------------------
+@lru_cache(maxsize=32)
+def get_font(size: int) -> ImageFont.FreeTypeFont:
+    """Load (and cache) a TrueType font, falling back to Pillow's default.
+
+    Cached because constructing a font is relatively expensive and we draw
+    text on every tile of every frame.
+    """
+    try:
+        return ImageFont.truetype(_DEFAULT_FONT, size)
+    except IOError:
+        return ImageFont.load_default()
+
+
+def format_hhmm(elapsed_min: float) -> str:
+    """Format an elapsed time in minutes as ``HH:MM (hh:mm)``."""
+    total = int(round(elapsed_min))
+    h, m = divmod(total, 60)
+    return f"{h:02d}:{m:02d} (hh:mm)"
+
+
+def draw_label(img: Image.Image, text: str, font_size: int, margin: int = 10) -> None:
+    """Draw a boxed label in the top-left corner (in place)."""
+    draw = ImageDraw.Draw(img)
+    font = get_font(font_size)
+    bbox = draw.textbbox((0, 0), text, font=font)
+    draw.rectangle(
+        [margin - 4, margin - 4, margin + bbox[2] + 4, margin + bbox[3] + 4],
+        fill=(0, 0, 0),
+    )
+    draw.text((margin, margin), text, font=font, fill=(255, 255, 255))
+
+
+def draw_timestamp(
+    img: Image.Image, text: str, font_size: int, margin: int = 10
+) -> None:
+    """Draw a boxed timestamp in the bottom-right corner (in place)."""
+    draw = ImageDraw.Draw(img)
+    font = get_font(font_size)
+    w, h = img.size
+    bbox = draw.textbbox((0, 0), text, font=font)
+    tw, th = bbox[2] - bbox[0], bbox[3] - bbox[1]
+    tx = w - tw - margin
+    ty = h - th - margin
+    draw.rectangle([tx - 5, ty - 5, tx + tw + 5, ty + th + 5], fill=(0, 0, 0))
+    draw.text((tx, ty), text, font=font, fill=(255, 255, 255))
+
+
+def open_writer(out_file, fps: float, quality: int = 8):
+    """Open an H.264 MP4 writer with web-friendly (yuv420p) output.
+
+    ``macro_block_size=1`` disables imageio's silent resize-to-multiple-of-16;
+    callers are responsible for passing even frame dimensions (required by
+    yuv420p).
+    """
+    return imageio.get_writer(
+        out_file,
+        fps=fps,
+        codec="libx264",
+        quality=quality,
+        macro_block_size=1,
+        pixelformat="yuv420p",
+    )
+
+
+# -----------------------------------------------------------------------------
+# Tiling engine
+# -----------------------------------------------------------------------------
+@dataclass
+class TileSpec:
+    """One tile in the output grid.
+
+    A ``path`` of ``None`` produces a perpetual black tile (used to pad a grid
+    that has fewer videos than cells); blank tiles never end the movie.
+    """
+
+    path: Optional[Path] = None
+    legend: Optional[str] = None
+    crop_box: Optional[Box] = None  # None => auto-detect non-black box
+    rotation: float = 0
+    frame_step: int = 1  # keep every Nth source frame
+    time_sampling_min: Optional[float] = None  # minutes between source frames
+    legend_font_size: int = 20
+    timestamp_font_size: int = 16
+
+
+@dataclass
+class _OpenTile:
+    spec: TileSpec
+    reader: Optional[object] = None
+    crop_box: Optional[Box] = None
+    first: Optional[np.ndarray] = None
+    kept: int = 0  # number of frames kept (post frame_step) so far
+    iterator: Optional[object] = None
+
+
+def _iter_step(reader, step: int):
+    """Yield every ``step``-th frame from ``reader``."""
+    for i, frame in enumerate(reader):
+        if i % step == 0:
+            yield frame
+
+
+def _prepare_first_frame(tile: _OpenTile) -> np.ndarray:
+    """Read, crop and rotate the first frame; record the crop box."""
+    f0 = next(iter(tile.reader), None)
+    if f0 is None:
+        raise ValueError(f"Empty video: {tile.spec.path}")
+    f0 = ensure_rgb(f0)
+    box = (
+        tile.spec.crop_box
+        or get_crop_box_nonblack(f0)
+        or (0, f0.shape[0], 0, f0.shape[1])
+    )
+    tile.crop_box = tuple(box)
+    f0 = apply_box(f0, tile.crop_box)
+    f0 = rotate(f0, tile.spec.rotation)
+    return f0
+
+
+def tile_videos(
+    tiles: List[TileSpec],
+    grid: Tuple[int, int],
+    out_file,
+    fps: Optional[float] = None,
+    max_frames: Optional[int] = None,
+    quality: int = 8,
+) -> int:
+    """Tile several videos into a single grid movie with optional annotations.
+
+    Parameters
+    ----------
+    tiles : list of TileSpec
+        Tile specs in row-major order. Must fit within ``grid``.
+    grid : (rows, cols)
+        Grid layout. ``rows * cols`` must be >= ``len(tiles)``.
+    out_file : path-like
+        Destination ``.mp4``.
+    fps : float, optional
+        Output frame rate. Defaults to the fps of the first readable source.
+    max_frames : int, optional
+        Stop after writing this many frames.
+    quality : int, default 8
+        imageio/ffmpeg quality (0-10).
+
+    Returns
+    -------
+    int
+        Number of frames written.
+    """
+    rows, cols = grid
+    grid_size = rows * cols
+    if len(tiles) > grid_size:
+        raise ValueError(
+            f"Grid {grid} has {grid_size} cells but got {len(tiles)} tiles"
+        )
+
+    # Pad with blank tiles so the grid is always full.
+    tiles = list(tiles) + [TileSpec() for _ in range(grid_size - len(tiles))]
+
+    # --- open readers and read first frames -----------------------------------
+    open_tiles: List[_OpenTile] = []
+    src_fps = None
+    for spec in tiles:
+        ot = _OpenTile(spec=spec)
+        if spec.path is not None:
+            try:
+                ot.reader = imageio.get_reader(spec.path)
+                if src_fps is None:
+                    src_fps = ot.reader.get_meta_data().get("fps", None)
+                ot.first = _prepare_first_frame(ot)
+            except Exception as e:  # noqa: BLE001 - report and degrade to blank
+                print(
+                    f"  !! Failed to open {getattr(spec.path, 'name', spec.path)} -> {e}"
+                )
+                if ot.reader is not None:
+                    ot.reader.close()
+                ot.reader = None
+                ot.first = None
+        open_tiles.append(ot)
+
+    real_firsts = [ot.first for ot in open_tiles if ot.first is not None]
+    if not real_firsts:
+        raise RuntimeError("No videos could be opened successfully.")
+
+    # Target tile size = smallest common size, rounded down to even dims so the
+    # assembled canvas is yuv420p-compatible.
+    tile_h = min(f.shape[0] for f in real_firsts)
+    tile_w = min(f.shape[1] for f in real_firsts)
+    tile_h -= tile_h % 2
+    tile_w -= tile_w % 2
+    target_hw = (tile_h, tile_w)
+    out_h, out_w = rows * tile_h, cols * tile_w
+
+    fps = fps or src_fps or 30
+
+    # Build per-tile frame iterators.
+    for ot in open_tiles:
+        if ot.reader is not None:
+            ot.iterator = _iter_step(ot.reader, max(1, ot.spec.frame_step))
+
+    out_file = Path(out_file)
+    writer = open_writer(out_file, fps=fps, quality=quality)
+    print(
+        f"  >> Writing {out_file.name} | grid={rows}x{cols} | "
+        f"size={out_w}x{out_h} | fps={fps}"
+    )
+
+    frames_written = 0
+    try:
+        while True:
+            if max_frames is not None and frames_written >= max_frames:
+                break
+
+            frames = []
+            exhausted = False
+            for ot in open_tiles:
+                if ot.iterator is None:  # blank/failed tile
+                    frames.append(np.zeros((tile_h, tile_w, 3), dtype=np.uint8))
+                    continue
+
+                frame = next(ot.iterator, None)
+                if frame is None:
+                    exhausted = True
+                    break
+
+                frame = ensure_rgb(frame)
+                frame = apply_box(frame, ot.crop_box)
+                frame = rotate(frame, ot.spec.rotation)
+                frame = fit_to(frame, target_hw)
+
+                pil_tile = Image.fromarray(frame)
+                if ot.spec.legend:
+                    draw_label(pil_tile, ot.spec.legend, ot.spec.legend_font_size)
+                if ot.spec.time_sampling_min is not None:
+                    elapsed = ot.kept * ot.spec.frame_step * ot.spec.time_sampling_min
+                    draw_timestamp(
+                        pil_tile, format_hhmm(elapsed), ot.spec.timestamp_font_size
+                    )
+
+                ot.kept += 1
+                frames.append(np.array(pil_tile))
+
+            if exhausted:
+                break
+
+            canvas = np.zeros((out_h, out_w, 3), dtype=np.uint8)
+            for idx, frame in enumerate(frames):
+                r, c = divmod(idx, cols)
+                y0, x0 = r * tile_h, c * tile_w
+                canvas[y0 : y0 + tile_h, x0 : x0 + tile_w] = frame
+
+            writer.append_data(canvas)
+            frames_written += 1
+
+        print(f"  << Done {out_file.name}: {frames_written} frames written")
+    finally:
+        for ot in open_tiles:
+            if ot.reader is not None:
+                try:
+                    ot.reader.close()
+                except Exception:
+                    pass
+        try:
+            writer.close()
+        except Exception:
+            pass
+
+    return frames_written

--- a/settings/example_grid_movies_settings.yml
+++ b/settings/example_grid_movies_settings.yml
@@ -1,0 +1,42 @@
+# Tile a fixed set of movies (e.g. channels) into one grid movie.
+# Optionally batch one grid per FOV: list fov_list and embed `{fov}` in paths,
+# legends and output_filename. `{fov}` becomes `a_b_c` in paths/filenames and
+# `a/b/c` in legends.
+output_dir: /path/to/output/all_channels
+output_filename: BF_nuc_mem_{fov}.mp4
+grid: [1, 3]
+max_frames: null
+fps: null                 # null => inherit from the first source movie
+quality: 8
+fov_placeholder: "{fov}"
+fov_list:
+  - 0/1/000000
+  - 0/2/002000
+
+movs:
+  - mov_path: /path/to/BF/fov/{fov}.mp4
+    crop_box: [176, 1072, 970, 2166]   # [y0, y1, x0, x1]; null => auto non-black
+    legend: "BF - {fov}"
+    legend_font_size: 20
+    timestamp_font_size: 20
+    rotation: 0
+    frame_step: 12
+    frame_time_sampling_min: 5
+
+  - mov_path: /path/to/nuclei_projection/fov/{fov}.mp4
+    crop_box: [0, 784, 240, 881]
+    legend: "Nuclei max projection - {fov}"
+    legend_font_size: 20
+    timestamp_font_size: 20
+    rotation: -90
+    frame_step: 12
+    frame_time_sampling_min: 5
+
+  - mov_path: /path/to/membrane_projection/fov/{fov}.mp4
+    crop_box: [0, 1248, 976, 2168]
+    legend: "Membrane max projection - {fov}"
+    legend_font_size: 20
+    timestamp_font_size: 20
+    rotation: -90
+    frame_step: 12
+    frame_time_sampling_min: 5

--- a/settings/example_grid_per_well_settings.yml
+++ b/settings/example_grid_per_well_settings.yml
@@ -1,0 +1,14 @@
+# Tile per-FOV MP4s into per-well grids (one or more videos per well).
+# Files are grouped by well id parsed from the filename: <prefix>_<well>_...mp4
+mov_path: /path/to/per_fov_mp4s
+output_path: /path/to/output/per_well
+grid: [2, 2]
+time_sampling_min: 5      # minutes between source frames (null disables timestamp)
+rotation: 90              # degrees, applied to every tile
+max_frames: null          # or an int to cap output length
+frame_step: 5             # keep every 5th source frame
+legend_font_size: 20
+timestamp_font_size: 24
+add_legend: true          # label each tile with its source file stem
+fps: null                 # null => inherit from the first source movie
+quality: 8                # ffmpeg quality, 0-10

--- a/tests/test_example_settings.py
+++ b/tests/test_example_settings.py
@@ -13,6 +13,8 @@ from biahub.settings import (
     EstimateRegistrationSettings,
     EstimateStabilizationSettings,
     FlatFieldCorrectionSettings,
+    GridMoviesSettings,
+    GridPerWellSettings,
     ProcessingImportFuncSettings,
     RegistrationSettings,
     SegmentationSettings,
@@ -53,6 +55,8 @@ example_settings_params = [
     ("example_stitch_settings.yml", StitchSettings),
     ("example_track_settings.yml", TrackingSettings),
     ("example_flat_field_settings.yml", FlatFieldCorrectionSettings),
+    ("example_grid_per_well_settings.yml", GridPerWellSettings),
+    ("example_grid_movies_settings.yml", GridMoviesSettings),
 ]
 
 try:


### PR DESCRIPTION
## Summary

Two config-driven CLIs for assembling **grid montages from already-rendered MP4s**, sharing a single tiling engine in `biahub/visualize/video_utils.py`:

- **`grid-per-well`** — group per-FOV movies by well id (parsed from the filename) and tile each well's FOVs onto a grid, producing one or more videos per well.
- **`grid-movies`** — tile a fixed set of movies (e.g. channels) into one grid, with per-tile crop box / rotation / frame step / legend / timestamp, and optional per-FOV batching via a `{fov}` placeholder.

These complement (and reuse the conventions of) the napari renderer in #180: this PR tiles MP4s that `napari-movie` produces. It does **not** touch `napari_movie.py`.

## What's in `video_utils.py`

`ensure_rgb`, non-black crop detection, center-crop/fit, **cached** font loading, boxed label/timestamp drawing, an even-dimension `yuv420p` H.264 writer, and the `TileSpec` / `tile_videos` engine that both CLIs call.

## Settings

Validated via pydantic models (`GridPerWellSettings`, `GridMoviesSettings`, `MovieTileSettings`). Example YAMLs added under `settings/` and covered by `tests/test_example_settings.py`.

## Origin

Refactored from standalone debug scripts (`grid_per_well.py`, `grid_mov.py`) that shared ~90% of their code. Fixes carried over from that consolidation:
- per-tile frame iteration (the old `zip(readers)` iterated over a 1-tuple instead of frames)
- per-tile legends (previously every tile showed the last file's label)
- cached fonts (previously reloaded per tile per frame)
- explicit codec/quality + even-dimension handling for the writer

## Testing

- `tests/test_example_settings.py`: 29 passed.
- Ran both CLIs end-to-end on real per-FOV MP4s; outputs decode correctly (e.g. 1×3 grid → 1872×624 @ 10 fps).

## Related

Builds on the visualization conventions introduced in #180 (`napari-movie`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)