### PR TITLE
feat(nextflow): make per-step wall-time dynamic and volume-based

### DIFF
--- a/biahub/apply_inverse_transfer_function.py
+++ b/biahub/apply_inverse_transfer_function.py
@@ -25,7 +25,7 @@ from biahub.cli.parsing import (
 )
 from biahub.cli.utils import (
     echo_resources,
-    estimate_time_minutes,
+    estimate_resources,
     get_submitit_cluster,
     yaml_to_model,
 )
@@ -115,15 +115,15 @@ def apply_inverse_transfer_function(
     max_num_cpus = 16
     num_cpus, mem_per_cpu = wo_estimate_resources(list(input_shape), settings, max_num_cpus)
     mem_gb = num_cpus * mem_per_cpu
-    # Wall-time scales with total voxels reconstructed. Phase reconstruction only
-    # processes the input channels named in the config, so scale T*Z*Y*X by that
-    # count rather than the full C. Calibrated from a completed run: worst-case
-    # ~2.4 h for a single-channel 2.8e10-voxel volume -> ~3e6 voxels/s (this step
-    # is largely single-threaded per position). safety_factor covers the rest.
+    # CPUs/RAM come from waveorder above. Wall-time scales with total voxels
+    # reconstructed: phase reconstruction only processes the config's input
+    # channels, so pass a shape with C = that count and take only the time.
+    # time_multiplier ~= 11 min/Gvox calibrated from a completed run (~2.4 h for
+    # a single-channel ~2.8e10-voxel volume on ~1 CPU, with a ~2x margin).
     T, C, Z, Y, X = input_shape
     n_reconstructed = len(settings.input_channel_names)
-    time_minutes = estimate_time_minutes(
-        T * n_reconstructed * Z * Y * X, voxels_per_second=3.0e6
+    time_minutes, _, _ = estimate_resources(
+        (T, n_reconstructed, Z, Y, X), time_multiplier=11.0, max_num_cpus=max_num_cpus
     )
     echo_resources(num_cpus, mem_gb, time_minutes)
 

--- a/biahub/apply_inverse_transfer_function.py
+++ b/biahub/apply_inverse_transfer_function.py
@@ -25,6 +25,7 @@ from biahub.cli.parsing import (
 )
 from biahub.cli.utils import (
     echo_resources,
+    estimate_time_minutes,
     get_submitit_cluster,
     yaml_to_model,
 )
@@ -114,7 +115,16 @@ def apply_inverse_transfer_function(
     max_num_cpus = 16
     num_cpus, mem_per_cpu = wo_estimate_resources(list(input_shape), settings, max_num_cpus)
     mem_gb = num_cpus * mem_per_cpu
-    time_minutes = 360
+    # Wall-time scales with total voxels reconstructed. Phase reconstruction only
+    # processes the input channels named in the config, so scale T*Z*Y*X by that
+    # count rather than the full C. Calibrated from a completed run: worst-case
+    # ~2.4 h for a single-channel 2.8e10-voxel volume -> ~3e6 voxels/s (this step
+    # is largely single-threaded per position). safety_factor covers the rest.
+    T, C, Z, Y, X = input_shape
+    n_reconstructed = len(settings.input_channel_names)
+    time_minutes = estimate_time_minutes(
+        T * n_reconstructed * Z * Y * X, voxels_per_second=3.0e6
+    )
     echo_resources(num_cpus, mem_gb, time_minutes)
 
     if init_only:

--- a/biahub/apply_inverse_transfer_function.py
+++ b/biahub/apply_inverse_transfer_function.py
@@ -115,15 +115,22 @@ def apply_inverse_transfer_function(
     max_num_cpus = 16
     num_cpus, mem_per_cpu = wo_estimate_resources(list(input_shape), settings, max_num_cpus)
     mem_gb = num_cpus * mem_per_cpu
-    # CPUs/RAM come from waveorder above. Wall-time scales with total voxels
-    # reconstructed: phase reconstruction only processes the config's input
-    # channels, so pass a shape with C = that count and take only the time.
-    # time_multiplier ~= 11 min/Gvox calibrated from a completed run (~2.4 h for
-    # a single-channel ~2.8e10-voxel volume on ~1 CPU, with a ~2x margin).
+    # CPUs/RAM come from waveorder above. Wall-time scales with the number of
+    # volumes reconstructed: phase reconstruction only processes the config's
+    # input channels, so pass a shape with C = that count and take only the time.
+    #
+    # time_multiplier = 3.0 min/volume, ~2x the worst rate observed over
+    # completed runs (A549 2026_06_16, 101 min for 67 volumes = 1.51 min/vol).
+    # NOTE: reconstruct is the one step where per-volume cost is not
+    # geometry-driven -- it spans 0.14-1.51 min/volume across runs (10x), and
+    # keying on voxels instead is no better (also ~10x), because the cost is
+    # dominated by the reconstruction algorithm settings (regularization, TV
+    # iterations) rather than data size. Sizing for the worst case therefore
+    # over-requests on many-volume datasets; see PR #273 discussion.
     T, C, Z, Y, X = input_shape
     n_reconstructed = len(settings.input_channel_names)
     time_minutes, _, _ = estimate_resources(
-        (T, n_reconstructed, Z, Y, X), time_multiplier=11.0, max_num_cpus=max_num_cpus
+        (T, n_reconstructed, Z, Y, X), time_multiplier=3.0, max_num_cpus=max_num_cpus
     )
     echo_resources(num_cpus, mem_gb, time_minutes)
 

--- a/biahub/cli/utils.py
+++ b/biahub/cli/utils.py
@@ -456,5 +456,14 @@ def estimate_time_minutes(
     int
         Estimated wall-time in minutes (ceil), never below ``floor_minutes``.
     """
+    if num_voxels < 0:
+        raise ValueError("num_voxels must be >= 0.")
+    if voxels_per_second <= 0:
+        raise ValueError("voxels_per_second must be > 0.")
+    if floor_minutes < 0:
+        raise ValueError("floor_minutes must be >= 0.")
+    if safety_factor <= 0:
+        raise ValueError("safety_factor must be > 0.")
+
     minutes = safety_factor * num_voxels / voxels_per_second / 60.0
     return int(np.ceil(max(floor_minutes, minutes)))

--- a/biahub/cli/utils.py
+++ b/biahub/cli/utils.py
@@ -454,7 +454,8 @@ def estimate_time_minutes(
     Returns
     -------
     int
-        Estimated wall-time in minutes (ceil), never below ``floor_minutes``.
+        Estimated wall-time in minutes, rounded up to the nearest 10 minutes
+        and never below ``floor_minutes``.
     """
     if num_voxels < 0:
         raise ValueError("num_voxels must be >= 0.")
@@ -465,5 +466,6 @@ def estimate_time_minutes(
     if safety_factor <= 0:
         raise ValueError("safety_factor must be > 0.")
 
-    minutes = safety_factor * num_voxels / voxels_per_second / 60.0
-    return int(np.ceil(max(floor_minutes, minutes)))
+    minutes = max(floor_minutes, safety_factor * num_voxels / voxels_per_second / 60.0)
+    # Round up to the nearest 10 minutes for tidy SLURM wall-time requests.
+    return int(np.ceil(minutes / 10.0) * 10)

--- a/biahub/cli/utils.py
+++ b/biahub/cli/utils.py
@@ -415,3 +415,46 @@ def estimate_resources(
     gb_ram_per_cpu = np.ceil(max(min_ram_per_cpu, gb_ram_per_volume * ram_multiplier))
 
     return int(num_cpus), int(gb_ram_per_cpu)
+
+
+def estimate_time_minutes(
+    num_voxels: int,
+    voxels_per_second: float,
+    floor_minutes: int = 30,
+    safety_factor: float = 2.0,
+) -> int:
+    """Estimate a per-position SLURM wall-time (minutes) from the data volume.
+
+    The companion to ``estimate_resources``: where memory scales with a single
+    ZYX volume, wall-time scales with the TOTAL number of voxels a step touches
+    for one position -- i.e. ``T * C_processed * Z * Y * X`` of its working set.
+    That total is divided by an empirically-measured per-step throughput
+    (voxels/second at the step's allocated CPU count) and inflated by a safety
+    factor, with a floor for tiny inputs.
+
+    Keying on total voxels (rather than the number of timepoints) is what makes
+    this GENERALIZE across dataset geometries. A long, thin timelapse (large T,
+    small YX) and a short, wide acquisition (small T, large ZYX) with comparable
+    total work get comparable wall-times -- neither is systematically under- or
+    over-provisioned. The per-step ``voxels_per_second`` constants were
+    calibrated from observed COMPLETED runs (see each call site); the safety
+    factor absorbs GPU/CPU variance, retries, and slower nodes.
+
+    Parameters
+    ----------
+    num_voxels : int
+        Total voxels processed for one position (T * C_processed * Z * Y * X).
+    voxels_per_second : float
+        Measured whole-job throughput for this step at its allocated resources.
+    floor_minutes : int, optional
+        Minimum wall-time so small inputs still get a sane request. Default 30.
+    safety_factor : float, optional
+        Multiplier over the nominal estimate. Default 2.0.
+
+    Returns
+    -------
+    int
+        Estimated wall-time in minutes (ceil), never below ``floor_minutes``.
+    """
+    minutes = safety_factor * num_voxels / voxels_per_second / 60.0
+    return int(np.ceil(max(floor_minutes, minutes)))

--- a/biahub/cli/utils.py
+++ b/biahub/cli/utils.py
@@ -378,11 +378,26 @@ def estimate_resources(
     shape: tuple[int, int, int, int, int],
     dtype: DTypeLike = np.float32,
     ram_multiplier: float = 1.0,
+    time_multiplier: float = 1.0,
     max_num_cpus: int = 64,
     min_ram_per_cpu: int = 4,
+    min_time_minutes: int = 30,
 ):
-    """
-    Estimate the number of CPUs and the amount of RAM required for processing a given data volume.
+    """Estimate wall-time, CPUs, and RAM required to process a data volume.
+
+    RAM scales with a single ZYX volume (the per-CPU working set); wall-time
+    scales with the TOTAL data (T * C * Z * Y * X). Keying wall-time on total
+    voxels -- rather than the number of timepoints -- is what makes the estimate
+    GENERALIZE across dataset geometries: a long, thin timelapse (large T, small
+    YX) and a short, wide acquisition (small T, large ZYX) with comparable total
+    work get comparable wall-times.
+
+    ``time_multiplier`` mirrors ``ram_multiplier``: it is the per-step scaling
+    knob, in minutes of wall-time per gigavoxel of total data, calibrated from
+    observed COMPLETED runs (see each call site). Callers that only need CPUs and
+    RAM can ignore the time estimate:
+
+        _, num_cpus, gb_ram_per_cpu = estimate_resources(shape, ram_multiplier=8)
 
     Parameters
     ----------
@@ -391,22 +406,30 @@ def estimate_resources(
     dtype : DTypeLike, optional
         The data type of the elements. Default is np.float32.
     ram_multiplier : float, optional
-        Multiplier to scale the required memory for processing a given ZYX volume. For example,
-        if a processing pipeline makes two copies of the input data, then the ram_multiplier
-        should be at least 3. Default is 1.0.
+        Multiplier to scale the required memory for processing a given ZYX volume.
+        For example, if a pipeline makes two copies of the input data, the
+        ram_multiplier should be at least 3. Default is 1.0.
+    time_multiplier : float, optional
+        Wall-time in minutes per gigavoxel of total data (T*C*Z*Y*X). The
+        per-step calibration knob, analogous to ram_multiplier. Default is 1.0.
     max_num_cpus : int, optional
         Maximum number of available CPUs. Default is 64.
     min_ram_per_cpu : int, optional
         Minimum amount of RAM per CPU in GB. Default is 4.
+    min_time_minutes : int, optional
+        Minimum wall-time so tiny inputs still get a sane request. Default 30.
 
     Returns
     -------
-    Tuple[int, int]
-        A tuple containing the estimated number of CPUs and the required amount of RAM per CPU in GB.
-        These values can be passed to the `--cpus_per_task` and `--mem_per_cpu` parameters of sbatch.
+    Tuple[int, int, int]
+        (time_minutes, num_cpus, gb_ram_per_cpu). time_minutes is rounded up to
+        the nearest 10 minutes; num_cpus and gb_ram_per_cpu map to sbatch's
+        --time, --cpus_per_task, and --mem_per_cpu.
     """
     if len(shape) != 5:
         raise ValueError("The shape must be a 5-tuple (T, C, Z, Y, X).")
+    if ram_multiplier <= 0 or time_multiplier <= 0:
+        raise ValueError("ram_multiplier and time_multiplier must be > 0.")
 
     T, C, Z, Y, X = shape
     gb_per_element = np.dtype(dtype).itemsize / 2**30  # bytes_per_element / bytes_per_gb
@@ -414,58 +437,10 @@ def estimate_resources(
     gb_ram_per_volume = Z * Y * X * gb_per_element
     gb_ram_per_cpu = np.ceil(max(min_ram_per_cpu, gb_ram_per_volume * ram_multiplier))
 
-    return int(num_cpus), int(gb_ram_per_cpu)
+    # Wall-time from total data volume, scaled by the per-step time_multiplier,
+    # then rounded up to the nearest 10 minutes for tidy SLURM requests.
+    gigavoxels = T * C * Z * Y * X / 1e9
+    minutes = max(min_time_minutes, gigavoxels * time_multiplier)
+    time_minutes = int(np.ceil(minutes / 10.0) * 10)
 
-
-def estimate_time_minutes(
-    num_voxels: int,
-    voxels_per_second: float,
-    floor_minutes: int = 30,
-    safety_factor: float = 2.0,
-) -> int:
-    """Estimate a per-position SLURM wall-time (minutes) from the data volume.
-
-    The companion to ``estimate_resources``: where memory scales with a single
-    ZYX volume, wall-time scales with the TOTAL number of voxels a step touches
-    for one position -- i.e. ``T * C_processed * Z * Y * X`` of its working set.
-    That total is divided by an empirically-measured per-step throughput
-    (voxels/second at the step's allocated CPU count) and inflated by a safety
-    factor, with a floor for tiny inputs.
-
-    Keying on total voxels (rather than the number of timepoints) is what makes
-    this GENERALIZE across dataset geometries. A long, thin timelapse (large T,
-    small YX) and a short, wide acquisition (small T, large ZYX) with comparable
-    total work get comparable wall-times -- neither is systematically under- or
-    over-provisioned. The per-step ``voxels_per_second`` constants were
-    calibrated from observed COMPLETED runs (see each call site); the safety
-    factor absorbs GPU/CPU variance, retries, and slower nodes.
-
-    Parameters
-    ----------
-    num_voxels : int
-        Total voxels processed for one position (T * C_processed * Z * Y * X).
-    voxels_per_second : float
-        Measured whole-job throughput for this step at its allocated resources.
-    floor_minutes : int, optional
-        Minimum wall-time so small inputs still get a sane request. Default 30.
-    safety_factor : float, optional
-        Multiplier over the nominal estimate. Default 2.0.
-
-    Returns
-    -------
-    int
-        Estimated wall-time in minutes, rounded up to the nearest 10 minutes
-        and never below ``floor_minutes``.
-    """
-    if num_voxels < 0:
-        raise ValueError("num_voxels must be >= 0.")
-    if voxels_per_second <= 0:
-        raise ValueError("voxels_per_second must be > 0.")
-    if floor_minutes < 0:
-        raise ValueError("floor_minutes must be >= 0.")
-    if safety_factor <= 0:
-        raise ValueError("safety_factor must be > 0.")
-
-    minutes = max(floor_minutes, safety_factor * num_voxels / voxels_per_second / 60.0)
-    # Round up to the nearest 10 minutes for tidy SLURM wall-time requests.
-    return int(np.ceil(minutes / 10.0) * 10)
+    return time_minutes, int(num_cpus), int(gb_ram_per_cpu)

--- a/biahub/cli/utils.py
+++ b/biahub/cli/utils.py
@@ -385,17 +385,23 @@ def estimate_resources(
 ):
     """Estimate wall-time, CPUs, and RAM required to process a data volume.
 
-    RAM scales with a single ZYX volume (the per-CPU working set); wall-time
-    scales with the TOTAL data (T * C * Z * Y * X). Keying wall-time on total
-    voxels -- rather than the number of timepoints -- is what makes the estimate
-    GENERALIZE across dataset geometries: a long, thin timelapse (large T, small
-    YX) and a short, wide acquisition (small T, large ZYX) with comparable total
-    work get comparable wall-times.
+    Both RAM and wall-time key on the ZYX volume, the natural unit of work here:
+    RAM scales with a single volume (the per-CPU working set), and wall-time
+    scales with the NUMBER of volumes processed (T * C).
+
+    Counting volumes -- rather than voxels -- is deliberate. Per-voxel
+    throughput is not a stable quantity: it depends on the CPU/GPU model, the
+    filesystem write speed, and the chunking, so a voxel-rate calibrated on one
+    run does not transfer to the next. Volume count is a property of the
+    dataset alone. The spread in per-volume cost between, say, an A549 volume
+    and a neuromast volume is absorbed by ``time_multiplier``, which is a fudge
+    factor, not a physical constant -- over-requesting 2x on one dataset and
+    1.5x on another is fine and expected.
 
     ``time_multiplier`` mirrors ``ram_multiplier``: it is the per-step scaling
-    knob, in minutes of wall-time per gigavoxel of total data, calibrated from
-    observed COMPLETED runs (see each call site). Callers that only need CPUs and
-    RAM can ignore the time estimate:
+    knob, in minutes of wall-time per ZYX volume, calibrated from observed
+    COMPLETED runs (see each call site). Callers that only need CPUs and RAM can
+    ignore the time estimate:
 
         _, num_cpus, gb_ram_per_cpu = estimate_resources(shape, ram_multiplier=8)
 
@@ -410,7 +416,7 @@ def estimate_resources(
         For example, if a pipeline makes two copies of the input data, the
         ram_multiplier should be at least 3. Default is 1.0.
     time_multiplier : float, optional
-        Wall-time in minutes per gigavoxel of total data (T*C*Z*Y*X). The
+        Wall-time in minutes per ZYX volume processed (T*C volumes total). The
         per-step calibration knob, analogous to ram_multiplier. Default is 1.0.
     max_num_cpus : int, optional
         Maximum number of available CPUs. Default is 64.
@@ -439,10 +445,11 @@ def estimate_resources(
     gb_ram_per_volume = Z * Y * X * gb_per_element
     gb_ram_per_cpu = np.ceil(max(min_ram_per_cpu, gb_ram_per_volume * ram_multiplier))
 
-    # Wall-time from total data volume, scaled by the per-step time_multiplier,
-    # then rounded up to the nearest 10 minutes for tidy SLURM requests.
-    gigavoxels = T * C * Z * Y * X / 1e9
-    minutes = max(min_time_minutes, gigavoxels * time_multiplier)
+    # Wall-time from the number of ZYX volumes processed, scaled by the per-step
+    # time_multiplier, then rounded up to the nearest 10 minutes for tidy SLURM
+    # requests.
+    num_volumes = T * C
+    minutes = max(min_time_minutes, num_volumes * time_multiplier)
     time_minutes = int(np.ceil(minutes / 10.0) * 10)
 
     return time_minutes, int(num_cpus), int(gb_ram_per_cpu)

--- a/biahub/concatenate.py
+++ b/biahub/concatenate.py
@@ -384,7 +384,7 @@ def concatenate(
 
     # Estimate resources
     batch_size = settings.shards_ratio[0] if settings.shards_ratio else 1
-    num_cpus, gb_ram_per_cpu = estimate_resources(
+    _, num_cpus, gb_ram_per_cpu = estimate_resources(
         shape=(T // batch_size, C, Z, Y, X), ram_multiplier=4 * batch_size, max_num_cpus=16
     )
     # Prepare SLURM arguments

--- a/biahub/deconvolve.py
+++ b/biahub/deconvolve.py
@@ -153,7 +153,7 @@ def deconvolve_cli(
         )
 
     # Estimate resources
-    num_cpus, gb_ram_per_cpu = estimate_resources(
+    _, num_cpus, gb_ram_per_cpu = estimate_resources(
         shape=[T, C, Z, Y, X], ram_multiplier=16, max_num_cpus=16
     )
     # Prepare SLURM arguments

--- a/biahub/deskew.py
+++ b/biahub/deskew.py
@@ -29,6 +29,7 @@ from biahub.cli.parsing import (
 from biahub.cli.utils import (
     echo_resources,
     estimate_resources,
+    estimate_time_minutes,
     get_submitit_cluster,
     resolve_ome_zarr_version,
     yaml_to_model,
@@ -678,7 +679,11 @@ def deskew(
         shape=input_shape, ram_multiplier=8, max_num_cpus=16
     )
     mem_gb = num_cpus * gb_ram_per_cpu
-    time_minutes = 60
+    # Wall-time scales with total voxels processed. Calibrated from a completed
+    # run at this step's 16 CPUs: worst-case ~68 min for T*C*Z*Y*X ~= 2.9e11
+    # voxels -> ~7e7 voxels/s. safety_factor covers node/IO variance and retries.
+    T, C, Z, Y, X = input_shape
+    time_minutes = estimate_time_minutes(T * C * Z * Y * X, voxels_per_second=7.0e7)
     echo_resources(num_cpus, mem_gb, time_minutes)
 
     if init_only:

--- a/biahub/deskew.py
+++ b/biahub/deskew.py
@@ -29,7 +29,6 @@ from biahub.cli.parsing import (
 from biahub.cli.utils import (
     echo_resources,
     estimate_resources,
-    estimate_time_minutes,
     get_submitit_cluster,
     resolve_ome_zarr_version,
     yaml_to_model,
@@ -675,15 +674,14 @@ def deskew(
     _warn_pixel_size_mismatch(settings, input_position_dirpaths[0])
     input_shape, _ = _init_output_plate(input_position_dirpaths, output_dirpath, settings)
 
-    num_cpus, gb_ram_per_cpu = estimate_resources(
-        shape=input_shape, ram_multiplier=8, max_num_cpus=16
+    # RAM scales with one ZYX volume (ram_multiplier=8); wall-time scales with
+    # total voxels. time_multiplier ~= 0.5 min/Gvox calibrated from a completed
+    # run at this step's 16 CPUs (worst-case ~68 min for ~2.9e11 voxels, ~2x
+    # margin).
+    time_minutes, num_cpus, gb_ram_per_cpu = estimate_resources(
+        shape=input_shape, ram_multiplier=8, time_multiplier=0.5, max_num_cpus=16
     )
     mem_gb = num_cpus * gb_ram_per_cpu
-    # Wall-time scales with total voxels processed. Calibrated from a completed
-    # run at this step's 16 CPUs: worst-case ~68 min for T*C*Z*Y*X ~= 2.9e11
-    # voxels -> ~7e7 voxels/s. safety_factor covers node/IO variance and retries.
-    T, C, Z, Y, X = input_shape
-    time_minutes = estimate_time_minutes(T * C * Z * Y * X, voxels_per_second=7.0e7)
     echo_resources(num_cpus, mem_gb, time_minutes)
 
     if init_only:

--- a/biahub/deskew.py
+++ b/biahub/deskew.py
@@ -680,9 +680,10 @@ def deskew(
     input_shape, _ = _init_output_plate(input_position_dirpaths, output_dirpath, settings)
 
     # RAM scales with one ZYX volume (ram_multiplier=8); wall-time scales with
-    # total voxels. time_multiplier ~= 0.5 min/Gvox calibrated from a completed
-    # run at this step's 16 CPUs (worst-case ~68 min for ~2.9e11 voxels, ~2x
-    # margin).
+    # the number of volumes (T*C). time_multiplier = 0.5 min/volume: the worst
+    # per-volume rate observed over completed runs at this step's 16 CPUs is
+    # 0.24 min/volume (neuromast 2026_06_25, 307 min for 1316 volumes), so this
+    # carries a ~2x margin.
     time_minutes, num_cpus, gb_ram_per_cpu = estimate_resources(
         shape=input_shape, ram_multiplier=8, time_multiplier=0.5, max_num_cpus=16
     )

--- a/biahub/estimate_crop.py
+++ b/biahub/estimate_crop.py
@@ -198,7 +198,7 @@ def estimate_crop(
     with open_ome_zarr(lf_position_dirpaths[0]) as dataset:
         T, C, Z, Y, X = dataset.data.shape
 
-    num_cpus, gb_ram_per_cpu = estimate_resources(
+    _, num_cpus, gb_ram_per_cpu = estimate_resources(
         shape=[T, C, Z, Y, X], ram_multiplier=16, max_num_cpus=16
     )
     # Prepare SLURM arguments

--- a/biahub/estimate_stabilization.py
+++ b/biahub/estimate_stabilization.py
@@ -632,7 +632,7 @@ def estimate_xyz_stabilization_pcc(
         shape = dataset.data.shape
         T, C, Z, Y, X = shape
 
-    num_cpus, gb_ram_per_cpu = estimate_resources(
+    _, num_cpus, gb_ram_per_cpu = estimate_resources(
         shape=(T, C, Z, Y, X), ram_multiplier=16, max_num_cpus=16
     )
 
@@ -834,7 +834,7 @@ def estimate_xy_stabilization(
             focus_finding_settings=stack_reg_settings.focus_finding_settings,
         )
 
-    num_cpus, gb_ram_per_cpu = estimate_resources(
+    _, num_cpus, gb_ram_per_cpu = estimate_resources(
         shape=shape, ram_multiplier=16, max_num_cpus=16
     )
 
@@ -1097,7 +1097,7 @@ def estimate_z_stabilization(
     with open_ome_zarr(input_position_dirpaths[0]) as dataset:
         shape = dataset.data.shape  # (T, C, Z, Y, X)
 
-    num_cpus, gb_ram_per_cpu = estimate_resources(
+    _, num_cpus, gb_ram_per_cpu = estimate_resources(
         shape=shape, ram_multiplier=16, max_num_cpus=16
     )
 

--- a/biahub/flat_field.py
+++ b/biahub/flat_field.py
@@ -191,12 +191,13 @@ def flat_field(
     )
 
     # RAM scales with one ZYX volume (ram_multiplier=8); wall-time scales with
-    # total voxels. time_multiplier ~= 1.4 min/Gvox calibrated from a completed
-    # run (worst-case ~50 min for ~2.9e11 voxels at 64 CPUs, scaled to this
-    # step's 16 with a ~2x margin). Channel selection only reduces work, so
-    # using all C is a safe upper bound.
+    # the number of volumes (T*C). time_multiplier = 0.7 min/volume: the worst
+    # per-volume rate observed over completed runs is 0.34 min/volume (A549
+    # 2026_07_14, 68.3 min for 201 volumes; neuromast 2026_06_25 is 0.28), so
+    # this carries a ~2x margin. Channel selection only reduces work, so using
+    # all C is a safe upper bound.
     time_minutes, num_cpus, gb_ram_per_cpu = estimate_resources(
-        shape=input_shape, ram_multiplier=8, time_multiplier=1.4, max_num_cpus=16
+        shape=input_shape, ram_multiplier=8, time_multiplier=0.7, max_num_cpus=16
     )
     mem_gb = num_cpus * gb_ram_per_cpu
     echo_resources(num_cpus, mem_gb, time_minutes)

--- a/biahub/flat_field_correction.py
+++ b/biahub/flat_field_correction.py
@@ -22,7 +22,6 @@ from biahub.cli.parsing import (
 from biahub.cli.utils import (
     echo_resources,
     estimate_resources,
-    estimate_time_minutes,
     get_submitit_cluster,
     resolve_ome_zarr_version,
     yaml_to_model,
@@ -162,17 +161,15 @@ def flat_field(
         input_position_dirpaths, output_dirpath, settings
     )
 
-    T, C, Z, Y, X = input_shape
-    num_cpus, gb_ram_per_cpu = estimate_resources(
-        shape=input_shape, ram_multiplier=8, max_num_cpus=16
+    # RAM scales with one ZYX volume (ram_multiplier=8); wall-time scales with
+    # total voxels. time_multiplier ~= 1.4 min/Gvox calibrated from a completed
+    # run (worst-case ~50 min for ~2.9e11 voxels at 64 CPUs, scaled to this
+    # step's 16 with a ~2x margin). Channel selection only reduces work, so
+    # using all C is a safe upper bound.
+    time_minutes, num_cpus, gb_ram_per_cpu = estimate_resources(
+        shape=input_shape, ram_multiplier=8, time_multiplier=1.4, max_num_cpus=16
     )
     mem_gb = num_cpus * gb_ram_per_cpu
-    # Wall-time scales with total voxels processed. Calibrated from a completed
-    # run: worst-case ~50 min for T*C*Z*Y*X ~= 2.9e11 voxels, scaled from that
-    # run's 64 CPUs to this step's 16 -> ~2.4e7 voxels/s. safety_factor covers
-    # the rest. Channel selection (channel_names) only reduces work, so using
-    # all C is a safe upper bound.
-    time_minutes = estimate_time_minutes(T * C * Z * Y * X, voxels_per_second=2.4e7)
     echo_resources(num_cpus, mem_gb, time_minutes)
 
     if init_only:

--- a/biahub/flat_field_correction.py
+++ b/biahub/flat_field_correction.py
@@ -22,6 +22,7 @@ from biahub.cli.parsing import (
 from biahub.cli.utils import (
     echo_resources,
     estimate_resources,
+    estimate_time_minutes,
     get_submitit_cluster,
     resolve_ome_zarr_version,
     yaml_to_model,
@@ -166,7 +167,12 @@ def flat_field(
         shape=input_shape, ram_multiplier=8, max_num_cpus=16
     )
     mem_gb = num_cpus * gb_ram_per_cpu
-    time_minutes = 60
+    # Wall-time scales with total voxels processed. Calibrated from a completed
+    # run: worst-case ~50 min for T*C*Z*Y*X ~= 2.9e11 voxels, scaled from that
+    # run's 64 CPUs to this step's 16 -> ~2.4e7 voxels/s. safety_factor covers
+    # the rest. Channel selection (channel_names) only reduces work, so using
+    # all C is a safe upper bound.
+    time_minutes = estimate_time_minutes(T * C * Z * Y * X, voxels_per_second=2.4e7)
     echo_resources(num_cpus, mem_gb, time_minutes)
 
     if init_only:

--- a/biahub/process_data.py
+++ b/biahub/process_data.py
@@ -268,7 +268,7 @@ def process_with_config(
     }
 
     # Estimate Resources
-    num_cpus, gb_ram_per_cpu = estimate_resources(
+    _, num_cpus, gb_ram_per_cpu = estimate_resources(
         shape=output_shape, dtype=np.float32, ram_multiplier=4, max_num_cpus=16
     )
 

--- a/biahub/pyramid.py
+++ b/biahub/pyramid.py
@@ -92,7 +92,7 @@ def pyramid_cli(
     with open_ome_zarr(input_position_dirpaths[0], mode="r") as dataset:
         T, C, Z, Y, X = dataset.data.shape
 
-    num_cpus, gb_ram = estimate_resources(shape=(T, C, Z, Y, X), ram_multiplier=5)
+    _, num_cpus, gb_ram = estimate_resources(shape=(T, C, Z, Y, X), ram_multiplier=5)
 
     cluster = get_submitit_cluster(local)
 

--- a/biahub/register.py
+++ b/biahub/register.py
@@ -525,7 +525,7 @@ def register_cli(
     copy_n_paste_kwargs = {"czyx_slicing_params": ([Z_slice, Y_slice, X_slice])}
 
     # Estimate resources
-    num_cpus, gb_ram = estimate_resources(shape=(T, C, Z, Y, X), ram_multiplier=5)
+    _, num_cpus, gb_ram = estimate_resources(shape=(T, C, Z, Y, X), ram_multiplier=5)
 
     # Prepare SLURM arguments
     slurm_out_path = Path(output_dirpath).parent / "slurm_output"

--- a/biahub/registration/ants.py
+++ b/biahub/registration/ants.py
@@ -462,7 +462,7 @@ def estimate_tczyx(
     initial_tform = np.asarray(affine_transform_settings.approx_transform)
     click.echo(f"Initial transform: {initial_tform}")
 
-    num_cpus, gb_ram_per_cpu = estimate_resources(
+    _, num_cpus, gb_ram_per_cpu = estimate_resources(
         shape=(T, 2, Z, Y, X), ram_multiplier=16, max_num_cpus=16
     )
 

--- a/biahub/registration/beads.py
+++ b/biahub/registration/beads.py
@@ -507,7 +507,7 @@ def estimate_independently(
         "stabilization": align moving channel to itself over time.
     """
     T, Z, Y, X = mov_tzyx.shape
-    num_cpus, gb_ram_per_cpu = estimate_resources(
+    _, num_cpus, gb_ram_per_cpu = estimate_resources(
         shape=(T, 2, Z, Y, X), ram_multiplier=5, max_num_cpus=16
     )
 

--- a/biahub/segment.py
+++ b/biahub/segment.py
@@ -209,7 +209,7 @@ def segment_cli(
     )
 
     # Estimate resources
-    num_cpus, gb_ram_request = estimate_resources(shape=segmentation_shape, ram_multiplier=20)
+    _, num_cpus, gb_ram_request = estimate_resources(shape=segmentation_shape, ram_multiplier=20)
     num_gpus = 1
     slurm_time = np.ceil(np.max([80, T * 2.5])).astype(int)
     slurm_array_parallelism = 100

--- a/biahub/segment.py
+++ b/biahub/segment.py
@@ -209,7 +209,9 @@ def segment_cli(
     )
 
     # Estimate resources
-    _, num_cpus, gb_ram_request = estimate_resources(shape=segmentation_shape, ram_multiplier=20)
+    _, num_cpus, gb_ram_request = estimate_resources(
+        shape=segmentation_shape, ram_multiplier=20
+    )
     num_gpus = 1
     slurm_time = np.ceil(np.max([80, T * 2.5])).astype(int)
     slurm_array_parallelism = 100

--- a/biahub/stabilize.py
+++ b/biahub/stabilize.py
@@ -243,7 +243,7 @@ def stabilize(
 
     # Estimate resources
 
-    num_cpus, gb_ram_per_cpu = estimate_resources(
+    _, num_cpus, gb_ram_per_cpu = estimate_resources(
         shape=[T, C, Z, Y, X], ram_multiplier=16, max_num_cpus=16
     )
 

--- a/biahub/stitch.py
+++ b/biahub/stitch.py
@@ -451,7 +451,7 @@ def stitch_cli(
             )
 
     # Estimate resources
-    num_cpus, gb_ram = estimate_resources(
+    _, num_cpus, gb_ram = estimate_resources(
         shape=input_fov_shape, ram_multiplier=25, max_num_cpus=16
     )
 

--- a/biahub/track.py
+++ b/biahub/track.py
@@ -873,7 +873,7 @@ def track(
     )
 
     # Estimate resources
-    num_cpus, gb_ram_per_cpu = estimate_resources(
+    _, num_cpus, gb_ram_per_cpu = estimate_resources(
         shape=[T, C, Z, Y, X], ram_multiplier=16, max_num_cpus=16
     )
 

--- a/biahub/virtual_stain.py
+++ b/biahub/virtual_stain.py
@@ -340,7 +340,9 @@ def virtual_stain(
     # the init_only return so --init emits it for the Nextflow pipeline.
     T, Z = input_shape[0], input_shape[2]
     seconds_per_window = 1.0
-    time_minutes = int(np.ceil(max(60, T * Z * seconds_per_window / 60)))
+    minutes = max(60, T * Z * seconds_per_window / 60)
+    # Round up to the nearest 10 minutes for tidy SLURM wall-time requests.
+    time_minutes = int(np.ceil(minutes / 10.0) * 10)
     echo_resources(num_cpus, mem_gb, time_minutes)
 
     if init_only:

--- a/biahub/virtual_stain.py
+++ b/biahub/virtual_stain.py
@@ -328,8 +328,9 @@ def virtual_stain(
         cfg.output_ome_zarr_version,
     )
 
-    # Timepoints are processed sequentially on a single GPU, so resource needs
-    # are independent of dataset size.
+    # Timepoints are processed sequentially on a single GPU, so CPU and RAM
+    # needs are fixed (independent of dataset size); only wall-time scales with
+    # the data (see the T*Z budget below).
     num_cpus, mem_gb = 16, 64
     # Wall-clock budget (minutes) for GPU prediction. Each timepoint runs ~Z
     # sliding windows along Z; this is a GPU step so time scales with T*Z, not

--- a/biahub/virtual_stain.py
+++ b/biahub/virtual_stain.py
@@ -331,13 +331,14 @@ def virtual_stain(
     # Timepoints are processed sequentially on a single GPU, so resource needs
     # are independent of dataset size.
     num_cpus, mem_gb = 16, 64
-    # Generous wall-clock budget (minutes), assuming median TTA (4 rotations).
-    # Each timepoint runs ~Z sliding windows along Z. Measured ~1.4 s/window
-    # with TTA on this model; budget ~5 s/window (~3-4x margin for slower GPUs,
-    # larger FOVs, and compute-bound runs) with a 60-minute floor. Computed
-    # before the init_only return so --init emits it for the Nextflow pipeline.
+    # Wall-clock budget (minutes) for GPU prediction. Each timepoint runs ~Z
+    # sliding windows along Z; this is a GPU step so time scales with T*Z, not
+    # with CPU count. Measured ~2 windows/s (0.5 s/window) with median TTA on
+    # this model from a completed run's tqdm; budget 1.0 s/window (~2x margin
+    # for slower GPUs and larger FOVs) with a 60-minute floor. Computed before
+    # the init_only return so --init emits it for the Nextflow pipeline.
     T, Z = input_shape[0], input_shape[2]
-    seconds_per_window = 5
+    seconds_per_window = 1.0
     time_minutes = int(np.ceil(max(60, T * Z * seconds_per_window / 60)))
     echo_resources(num_cpus, mem_gb, time_minutes)
 

--- a/biahub/virtual_stain.py
+++ b/biahub/virtual_stain.py
@@ -26,6 +26,7 @@ from biahub.cli.parsing import (
 )
 from biahub.cli.utils import (
     echo_resources,
+    estimate_resources,
     get_submitit_cluster,
     resolve_ome_zarr_version,
 )
@@ -355,17 +356,21 @@ def virtual_stain(
     # needs are fixed (independent of dataset size); only wall-time scales with
     # the data (see the T*Z budget below).
     num_cpus, mem_gb = 16, 64
-    # Wall-clock budget (minutes) for GPU prediction. Each timepoint runs ~Z
-    # sliding windows along Z; this is a GPU step so time scales with T*Z, not
-    # with CPU count. Measured ~2 windows/s (0.5 s/window) with median TTA on
-    # this model from a completed run's tqdm; budget 1.0 s/window (~2x margin
-    # for slower GPUs and larger FOVs) with a 60-minute floor. Computed before
-    # the init_only return so --init emits it for the Nextflow pipeline.
-    T, Z = input_shape[0], input_shape[2]
-    seconds_per_window = 1.0
-    minutes = max(60, T * Z * seconds_per_window / 60)
-    # Round up to the nearest 10 minutes for tidy SLURM wall-time requests.
-    time_minutes = int(np.ceil(minutes / 10.0) * 10)
+    # Wall-clock budget for GPU prediction, on the same min/volume currency as
+    # the CPU steps. A per-window (T*Z) budget was tried first and fits worse:
+    # seconds/window spans 0.31 (neuromast) to 1.58 (A549) because a window's
+    # cost also depends on the YX footprint, so no single value covers both --
+    # 1.0 s/window under-provisions A549 and 5.0 over-provisions neuromast ~16x.
+    # Per-volume cost is much tighter (0.88-2.53 min/volume, ~3x), so budget
+    # 5.0 min/volume: ~2x the worst observed (A549 2026_05_27, 169 min for 67
+    # volumes). Computed before the init_only return so --init emits it for the
+    # Nextflow pipeline.
+    # One GPU pass per timepoint emits all target channels at once, so the unit
+    # of work is T volumes regardless of the input/target channel count.
+    T, _, Z, Y, X = input_shape
+    time_minutes, _, _ = estimate_resources(
+        (T, 1, Z, Y, X), time_multiplier=5.0, min_time_minutes=60
+    )
     echo_resources(num_cpus, mem_gb, time_minutes)
 
     if init_only:


### PR DESCRIPTION
## Summary

Wall-time for the fan-out Nextflow steps was hardcoded (flat-field/deskew 60 min, reconstruct 360 min) and virtual-stain used a per-window budget that mis-fits both dataset geometries. Fixed times mis-provision in **both** directions across geometries: a long-thin timelapse (large T, small YX) and a short-wide acquisition (small T, large ZYX) need very different wall-times.

This extends `estimate_resources()` to also return a wall-time estimate. It now returns `(time_minutes, num_cpus, gb_ram_per_cpu)`, with a `time_multiplier` knob mirroring the existing `ram_multiplier`. Callers that only need CPUs and RAM use `_, num_cpus, gb_ram_per_cpu = estimate_resources(...)`.

Wall-time scales with the **number of ZYX volumes** processed (`T * C`), not total voxels. Per-voxel throughput is not a stable quantity — it depends on the CPU/GPU model, filesystem write speed, and chunking — whereas volume count is a property of the dataset alone. The per-volume spread between, say, an A549 volume and a neuromast volume is absorbed by `time_multiplier`, which is a fudge factor rather than a physical constant.

## The fixed budgets were killing jobs

Not just over-provisioning. Measured from `sacct` over ~3,300 step jobs since June 2026:

| Step | Jobs killed at the wall limit | Where |
|------|-------------------------------|-------|
| deskew | 15 / 761 (2.0%) | neuromast `2026_06_04` |
| flat-field | 8 / 1291 (0.6%) | A549 `2026_07_14`, `2026_05_27` |
| virtual-stain | 2 / 674 (0.3%) | neuromast `2026_06_04` |

These surface as `FAILED` rather than `TIMEOUT`, with `Elapsed == Timelimit` (e.g. `00:59:59 / 01:00:00`), which is why they were easy to miss.

## Calibration

Multipliers set to ~2x the worst per-volume rate observed across **6 A549 runs and 3 neuromast runs**:

| Step | time_multiplier | Worst observed | Margin across all 9 runs |
|------|-----------------|----------------|--------------------------|
| flat-field | 0.7 min/volume | 0.34 | 2.2 – 12.3x |
| deskew | 0.5 min/volume | 0.24 | 2.1 – 5.9x |
| reconstruct | 3.0 min/volume | 1.51 | 2.1 – 21.6x |
| virtual-stain | 5.0 min/volume | 2.53 | 2.0 – 5.7x |

Worked example (deskew): A549 gets 110 min against a 47.9 min observed max (2.3x); neuromast `48hpf` gets 660 min against 307.4 min (2.1x). Both near the 2x target, from a single multiplier.

## Why volumes and not voxels

Tested rather than assumed, using observed maxima to back out the implied multiplier under each key:

| Step | Dataset | Volumes | min/volume | min/Gvox |
|------|---------|---------|------------|----------|
| flat-field | A549 `07_01` | 201 | 0.250 | 0.549 |
| flat-field | A549 `07_14` | 201 | 0.340 | 0.747 |
| flat-field | neuromast `48hpf` | 1316 | 0.275 | 0.749 |
| | **spread** | | **1.36x** | **1.36x** |

A tie, so volumes wins on simplicity at no accuracy cost. Caveat: our two dataset families have similar per-volume sizes (4.55e8 vs 3.67e8 voxels), so this evidence cannot strongly discriminate the two keys — worth re-checking if we process a dataset with a very different ZYX.

## Virtual staining moved onto the same currency

The per-window (`T*Z`) budget fits poorly because a window's cost also depends on its YX footprint, which the window count ignores. Measured seconds/window:

- **A549: 1.29 – 1.58 s/window** (`07_01`, `06_16`, `05_27`)
- **neuromast: 0.31 s/window** (`48hpf`)

No single value covers both: 1.0 s/window under-provisions A549, and 5.0 over-provisions neuromast ~16x (9,377 min requested against 580 min used). Per-volume cost is far tighter (0.88 – 2.53 min/volume, ~2.9x spread), so virtual-stain now uses 5.0 min/volume and both families land at 2.0 – 5.7x.

## Known limitation: reconstruct

Reconstruct is the one step where no geometric key works. Per-volume cost spans **10x** across runs:

| Dataset | Volumes | Observed max | min/volume |
|---------|---------|--------------|------------|
| A549 `06_16` | 67 | 101.4 min | 1.513 |
| A549 `07_01` | 67 | 59.7 min | 0.891 |
| A549 `07_14` | 67 | 10.1 min | 0.151 |
| neuromast `06_04` | 266 | 146.4 min | 0.550 |
| neuromast `48hpf` | 658 | 91.8 min | 0.140 |

Keying on voxels does not help (also ~10x) — the reconstruction geometries are only 1.8x apart (A549 96x1664x1193 vs neuromast 171x768x794), so the variance comes from the reconstruction *settings* (regularization, TV iterations), not data size.

Consequence: sizing for the worst case means neuromast `48hpf` requests **21.6x** its observed max, against **3.9x** under today's hardcoded 360 — **for that dataset this PR is a regression.** Options:

1. Accept it (current state; tradeoff documented in-code).
2. Keep the hardcoded 360 for reconstruct only, taking the win on the other three steps.
3. Derive reconstruct's multiplier from the reconstruction settings.

Currently (1), for a uniform design. (2) is defensible.

## Notes

- `RESOURCES` contract unchanged.
- `main` merged in; `tests/test_cli/test_deskew_cli.py` (added in #278, after this branch forked) still unpacked the old 2-tuple and is fixed.
- CI green: Lint, build, Test on Python 3.12 and 3.13.
