### PR TITLE
Route mantis-v2 CPU work to the preempted SLURM partition

### DIFF
--- a/nextflow/modules/common.nf
+++ b/nextflow/modules/common.nf
@@ -34,6 +34,23 @@ def slurm_logs(step_name) {
     return "--output=${dir}/%x_%j.err --error=${dir}/%x_%j.out"
 }
 
+// clusterOptions for the bulk CPU work on the preemptible `preempted` partition
+// (see the slurm profile in nextflow.config). Composes the log routing from
+// slurm_logs() with `--requeue`.
+//
+// `--requeue` is REQUIRED here, not optional: Nextflow's SLURM executor injects
+// `#SBATCH --no-requeue` into every batch script (it wants to own retries), so a
+// job is submitted with Requeue=0 and would be CANCELLED — not requeued — on
+// preemption, despite the cluster default JobRequeue=1. clusterOptions is
+// emitted as the last `#SBATCH` line, so this `--requeue` comes after Nextflow's
+// `--no-requeue` and wins (SLURM honours the last of conflicting directives),
+// flipping the job to Requeue=1. SLURM then requeues and reruns a preempted job
+// itself, so preemption is transparent to Nextflow and never fails the pipeline.
+// Ignored by the local executor, so it's a no-op under `-profile local`.
+def preemptible_logs(step_name) {
+    return "--requeue " + slurm_logs(step_name)
+}
+
 def biahub_cmd() {
     return params.biahub_project ?
         "uv run --project ${params.biahub_project} biahub" : "biahub"

--- a/nextflow/modules/common.nf
+++ b/nextflow/modules/common.nf
@@ -34,23 +34,6 @@ def slurm_logs(step_name) {
     return "--output=${dir}/%x_%j.err --error=${dir}/%x_%j.out"
 }
 
-// clusterOptions for the bulk CPU work on the preemptible `preempted` partition
-// (see the slurm profile in nextflow.config). Composes the log routing from
-// slurm_logs() with `--requeue`.
-//
-// `--requeue` is REQUIRED here, not optional: Nextflow's SLURM executor injects
-// `#SBATCH --no-requeue` into every batch script (it wants to own retries), so a
-// job is submitted with Requeue=0 and would be CANCELLED — not requeued — on
-// preemption, despite the cluster default JobRequeue=1. clusterOptions is
-// emitted as the last `#SBATCH` line, so this `--requeue` comes after Nextflow's
-// `--no-requeue` and wins (SLURM honours the last of conflicting directives),
-// flipping the job to Requeue=1. SLURM then requeues and reruns a preempted job
-// itself, so preemption is transparent to Nextflow and never fails the pipeline.
-// Ignored by the local executor, so it's a no-op under `-profile local`.
-def preemptible_logs(step_name) {
-    return "--requeue " + slurm_logs(step_name)
-}
-
 def biahub_cmd() {
     return params.biahub_project ?
         "uv run --project ${params.biahub_project} biahub" : "biahub"

--- a/nextflow/modules/deskew.nf
+++ b/nextflow/modules/deskew.nf
@@ -43,7 +43,6 @@ process run_deskew {
     tag "${position}"
     label 'cpu'
     clusterOptions { slurm_logs('deskew') }
-    maxForks 30
     cpus { meta.cpus }
     memory { "${meta.mem_gb} GB" }
     time { "${meta.time_minutes * task.attempt} min" }

--- a/nextflow/modules/deskew.nf
+++ b/nextflow/modules/deskew.nf
@@ -14,7 +14,7 @@
 // Nextflow task.  See also:
 // examples/submitit_debug_nextflow/2026-05-27-submitit-debug-nextflow-concerns.md
 
-include { parse_resources; biahub_cmd; preemptible_logs; slurm_log_dir } from './common'
+include { parse_resources; biahub_cmd; slurm_logs; slurm_log_dir } from './common'
 
 
 process init_deskew {
@@ -42,7 +42,7 @@ process init_deskew {
 process run_deskew {
     tag "${position}"
     label 'cpu'
-    clusterOptions { preemptible_logs('deskew') }
+    clusterOptions { slurm_logs('deskew') }
     cpus { meta.cpus }
     memory { "${meta.mem_gb} GB" }
     time { "${meta.time_minutes * task.attempt} min" }

--- a/nextflow/modules/deskew.nf
+++ b/nextflow/modules/deskew.nf
@@ -14,7 +14,7 @@
 // Nextflow task.  See also:
 // examples/submitit_debug_nextflow/2026-05-27-submitit-debug-nextflow-concerns.md
 
-include { parse_resources; biahub_cmd; slurm_logs; slurm_log_dir } from './common'
+include { parse_resources; biahub_cmd; preemptible_logs; slurm_log_dir } from './common'
 
 
 process init_deskew {
@@ -42,7 +42,7 @@ process init_deskew {
 process run_deskew {
     tag "${position}"
     label 'cpu'
-    clusterOptions { slurm_logs('deskew') }
+    clusterOptions { preemptible_logs('deskew') }
     cpus { meta.cpus }
     memory { "${meta.mem_gb} GB" }
     time { "${meta.time_minutes * task.attempt} min" }

--- a/nextflow/modules/deskew.nf
+++ b/nextflow/modules/deskew.nf
@@ -46,9 +46,6 @@ process run_deskew {
     cpus { meta.cpus }
     memory { "${meta.mem_gb} GB" }
     time { "${meta.time_minutes * task.attempt} min" }
-    maxRetries 1
-    errorStrategy 'retry'
-
 
     input:
     tuple val(position), val(meta)

--- a/nextflow/modules/flat_field.nf
+++ b/nextflow/modules/flat_field.nf
@@ -13,7 +13,7 @@
 // the Nextflow task.  See also:
 // examples/submitit_debug_nextflow/2026-05-27-submitit-debug-nextflow-concerns.md
 
-include { parse_resources; biahub_cmd; slurm_logs; slurm_log_dir } from './common'
+include { parse_resources; biahub_cmd; preemptible_logs; slurm_log_dir } from './common'
 
 
 process init_flat_field {
@@ -41,7 +41,7 @@ process init_flat_field {
 process run_flat_field {
     tag "${position}"
     label 'cpu'
-    clusterOptions { slurm_logs('flat_field') }
+    clusterOptions { preemptible_logs('flat_field') }
     cpus { meta.cpus }
     memory { "${meta.mem_gb} GB" }
     time { "${meta.time_minutes * task.attempt} min" }

--- a/nextflow/modules/flat_field.nf
+++ b/nextflow/modules/flat_field.nf
@@ -13,7 +13,7 @@
 // the Nextflow task.  See also:
 // examples/submitit_debug_nextflow/2026-05-27-submitit-debug-nextflow-concerns.md
 
-include { parse_resources; biahub_cmd; preemptible_logs; slurm_log_dir } from './common'
+include { parse_resources; biahub_cmd; slurm_logs; slurm_log_dir } from './common'
 
 
 process init_flat_field {
@@ -41,7 +41,7 @@ process init_flat_field {
 process run_flat_field {
     tag "${position}"
     label 'cpu'
-    clusterOptions { preemptible_logs('flat_field') }
+    clusterOptions { slurm_logs('flat_field') }
     cpus { meta.cpus }
     memory { "${meta.mem_gb} GB" }
     time { "${meta.time_minutes * task.attempt} min" }

--- a/nextflow/modules/flat_field.nf
+++ b/nextflow/modules/flat_field.nf
@@ -45,8 +45,6 @@ process run_flat_field {
     cpus { meta.cpus }
     memory { "${meta.mem_gb} GB" }
     time { "${meta.time_minutes * task.attempt} min" }
-    maxRetries 1
-    errorStrategy 'retry'
 
     input:
     tuple val(position), val(meta)

--- a/nextflow/modules/flat_field.nf
+++ b/nextflow/modules/flat_field.nf
@@ -42,7 +42,6 @@ process run_flat_field {
     tag "${position}"
     label 'cpu'
     clusterOptions { slurm_logs('flat_field') }
-    maxForks 30
     cpus { meta.cpus }
     memory { "${meta.mem_gb} GB" }
     time { "${meta.time_minutes * task.attempt} min" }

--- a/nextflow/modules/reconstruct.nf
+++ b/nextflow/modules/reconstruct.nf
@@ -92,8 +92,6 @@ process run_apply_inv_tf {
     cpus { meta.cpus }
     memory { "${meta.mem_gb} GB" }
     time { "${meta.time_minutes * task.attempt} min" }
-    maxRetries 1
-    errorStrategy 'retry'
 
     input:
     tuple val(position), val(meta)

--- a/nextflow/modules/reconstruct.nf
+++ b/nextflow/modules/reconstruct.nf
@@ -20,7 +20,7 @@
 // resource scheduling, so the CLI must NOT submit its own SLURM jobs.
 // See: examples/submitit_debug_nextflow/2026-05-27-submitit-debug-nextflow-concerns.md
 
-include { parse_resources; biahub_cmd; slurm_logs; slurm_log_dir } from './common'
+include { parse_resources; biahub_cmd; preemptible_logs; slurm_log_dir } from './common'
 
 
 process init_apply_inv_tf {
@@ -47,7 +47,7 @@ process init_apply_inv_tf {
 
 process compute_transfer_function {
     label 'cpu'
-    clusterOptions { slurm_logs('reconstruct') }
+    clusterOptions { preemptible_logs('reconstruct') }
     // Hardcoded resources for the one-shot transfer-function computation.
     //
     // waveorder upsamples the volume to Nyquist internally before building the
@@ -88,7 +88,7 @@ process compute_transfer_function {
 process run_apply_inv_tf {
     tag "${position}"
     label 'cpu'
-    clusterOptions { slurm_logs('reconstruct') }
+    clusterOptions { preemptible_logs('reconstruct') }
     cpus { meta.cpus }
     memory { "${meta.mem_gb} GB" }
     time { "${meta.time_minutes * task.attempt} min" }

--- a/nextflow/modules/reconstruct.nf
+++ b/nextflow/modules/reconstruct.nf
@@ -20,7 +20,7 @@
 // resource scheduling, so the CLI must NOT submit its own SLURM jobs.
 // See: examples/submitit_debug_nextflow/2026-05-27-submitit-debug-nextflow-concerns.md
 
-include { parse_resources; biahub_cmd; preemptible_logs; slurm_log_dir } from './common'
+include { parse_resources; biahub_cmd; slurm_logs; slurm_log_dir } from './common'
 
 
 process init_apply_inv_tf {
@@ -47,7 +47,7 @@ process init_apply_inv_tf {
 
 process compute_transfer_function {
     label 'cpu'
-    clusterOptions { preemptible_logs('reconstruct') }
+    clusterOptions { slurm_logs('reconstruct') }
     // Hardcoded resources for the one-shot transfer-function computation.
     //
     // waveorder upsamples the volume to Nyquist internally before building the
@@ -88,7 +88,7 @@ process compute_transfer_function {
 process run_apply_inv_tf {
     tag "${position}"
     label 'cpu'
-    clusterOptions { preemptible_logs('reconstruct') }
+    clusterOptions { slurm_logs('reconstruct') }
     cpus { meta.cpus }
     memory { "${meta.mem_gb} GB" }
     time { "${meta.time_minutes * task.attempt} min" }

--- a/nextflow/modules/reconstruct.nf
+++ b/nextflow/modules/reconstruct.nf
@@ -89,7 +89,6 @@ process run_apply_inv_tf {
     tag "${position}"
     label 'cpu'
     clusterOptions { slurm_logs('reconstruct') }
-    maxForks 30
     cpus { meta.cpus }
     memory { "${meta.mem_gb} GB" }
     time { "${meta.time_minutes * task.attempt} min" }

--- a/nextflow/modules/virtual_stain.nf
+++ b/nextflow/modules/virtual_stain.nf
@@ -106,7 +106,6 @@ process run_virtual_stain {
     tag "${position}"
     label 'gpu'
     clusterOptions { "--gres=gpu:1 " + slurm_logs('virtual_stain') }
-    maxForks 30
     cpus { meta.cpus }
     memory { "${meta.mem_gb} GB" }
     time { "${meta.time_minutes * task.attempt} min" }

--- a/nextflow/modules/virtual_stain.nf
+++ b/nextflow/modules/virtual_stain.nf
@@ -29,7 +29,7 @@
 // extra (cytoland → viscy-utils provides the `viscy` console script), so the
 // tasks here run in that extra's environment rather than the plain biahub env.
 
-include { parse_resources; preemptible_logs; slurm_logs; slurm_log_dir } from './common'
+include { parse_resources; slurm_logs; slurm_log_dir } from './common'
 
 // Command prefix for tools that require biahub's `stain` extra. Both
 // `biahub virtual-stain` (it imports cytoland) and `viscy preprocess` need it.
@@ -65,7 +65,7 @@ process init_virtual_stain {
 
 process run_virtual_stain_preprocess {
     label 'cpu'
-    clusterOptions { preemptible_logs('virtual_stain') }
+    clusterOptions { slurm_logs('virtual_stain') }
     cpus 16
     memory { "${64 * task.attempt} GB" }
     time '1h'

--- a/nextflow/modules/virtual_stain.nf
+++ b/nextflow/modules/virtual_stain.nf
@@ -69,8 +69,6 @@ process run_virtual_stain_preprocess {
     cpus 16
     memory { "${64 * task.attempt} GB" }
     time '1h'
-    maxRetries 1
-    errorStrategy 'retry'
 
     input:
     val input_zarr
@@ -109,8 +107,6 @@ process run_virtual_stain {
     cpus { meta.cpus }
     memory { "${meta.mem_gb} GB" }
     time { "${meta.time_minutes * task.attempt} min" }
-    maxRetries 1
-    errorStrategy 'retry'
 
     input:
     tuple val(position), val(meta)

--- a/nextflow/modules/virtual_stain.nf
+++ b/nextflow/modules/virtual_stain.nf
@@ -29,7 +29,7 @@
 // extra (cytoland → viscy-utils provides the `viscy` console script), so the
 // tasks here run in that extra's environment rather than the plain biahub env.
 
-include { parse_resources; slurm_logs; slurm_log_dir } from './common'
+include { parse_resources; preemptible_logs; slurm_logs; slurm_log_dir } from './common'
 
 // Command prefix for tools that require biahub's `stain` extra. Both
 // `biahub virtual-stain` (it imports cytoland) and `viscy preprocess` need it.
@@ -65,7 +65,7 @@ process init_virtual_stain {
 
 process run_virtual_stain_preprocess {
     label 'cpu'
-    clusterOptions { slurm_logs('virtual_stain') }
+    clusterOptions { preemptible_logs('virtual_stain') }
     cpus 16
     memory { "${64 * task.attempt} GB" }
     time '1h'

--- a/nextflow/nextflow.config
+++ b/nextflow/nextflow.config
@@ -31,15 +31,18 @@ process {
     // it with its own `maxForks` directive; single-shot steps ignore it.
     maxForks = 30
 
-    // Default error handling: retry a failed task once. The per-position fan-out
-    // steps scale time (and virtual-stain preprocess scales memory) by
-    // task.attempt, so the retry gets more headroom for transient timeout/OOM
-    // failures. This is also the backstop for the rare case a preempted-partition
-    // job surfaces as a failure instead of being requeued by SLURM. Applies to
-    // every process (init and compute-tf included, whose outputs are idempotent);
-    // a process may override with its own directive.
+    // Default error handling: retry a failed task. This is how preemption is
+    // absorbed — a job on the `preempted` partition that SLURM reclaims is
+    // cancelled (Nextflow submits every job with `#SBATCH --no-requeue`, so SLURM
+    // cannot requeue it), Nextflow's executor sees the non-zero exit, and this
+    // errorStrategy resubmits it as a fresh, tracked task. maxRetries is set
+    // generously because a single position may be preempted several times before
+    // it completes; each attempt also scales time (and virtual-stain preprocess
+    // scales memory) by task.attempt, giving transient timeout/OOM failures more
+    // headroom. Applies to every process (init and compute-tf included, whose
+    // outputs are idempotent); a process may override with its own directive.
     errorStrategy = 'retry'
-    maxRetries = 1
+    maxRetries = 5
 
     withLabel: 'cpu_local' {
         cpus   = 1
@@ -75,18 +78,17 @@ profiles {
     //   cpu_local -> local executor (lightweight init / list-positions steps
     //                stay on the head node; only the memory ceiling differs).
     //   cpu       -> `preempted` partition. This is the bulk per-position work
-    //                plus the one-shot compute-tf / preprocess steps. The
-    //                partition's PreemptMode=REQUEUE requeues a preempted job,
-    //                BUT only if the job is requeue-eligible — and Nextflow
-    //                injects `#SBATCH --no-requeue` into every batch script, so
-    //                each cpu process must re-enable it via `--requeue` in its
-    //                clusterOptions (modules/common.nf::preemptible_logs). SLURM
-    //                then requeues and reruns the job itself, so preemption is
-    //                handled by the scheduler and never fails the pipeline. The
-    //                global `errorStrategy 'retry'` is the backstop for genuine
-    //                (non-preemption) failures.
+    //                plus the one-shot compute-tf / preprocess steps. When SLURM
+    //                reclaims one of these jobs it is CANCELLED (Nextflow submits
+    //                every job with `#SBATCH --no-requeue`, so SLURM cannot
+    //                requeue it), Nextflow's executor sees the failure, and the
+    //                global `errorStrategy 'retry'` (maxRetries above) resubmits
+    //                it as a fresh, tracked task. Do NOT add SLURM `--requeue`
+    //                here: Nextflow does not follow a requeued job, so it reads
+    //                the killed run's exit code as a failure AND SLURM reruns the
+    //                original — a double execution racing on the same output.
     //   gpu       -> `gpu` partition (high PriorityTier, effectively not
-    //                preempted), for virtual-stain prediction; no --requeue.
+    //                preempted), for virtual-stain prediction.
     slurm {
         executor {
             name = 'slurm'

--- a/nextflow/nextflow.config
+++ b/nextflow/nextflow.config
@@ -75,16 +75,18 @@ profiles {
     //   cpu_local -> local executor (lightweight init / list-positions steps
     //                stay on the head node; only the memory ceiling differs).
     //   cpu       -> `preempted` partition. This is the bulk per-position work
-    //                plus the one-shot compute-tf / preprocess steps. Jobs here
-    //                may be reclaimed at any time; the partition's
-    //                PreemptMode=REQUEUE plus the cluster default JobRequeue=1
-    //                mean SLURM requeues and reruns a preempted job itself, so
-    //                preemption is handled by the scheduler and never fails the
-    //                pipeline (no per-job --requeue needed). `errorStrategy
-    //                'retry'` in each process remains the backstop for genuine
-    //                failures.
-    //   gpu       -> `gpu` partition (non-preemptible), for virtual-stain
-    //                prediction.
+    //                plus the one-shot compute-tf / preprocess steps. The
+    //                partition's PreemptMode=REQUEUE requeues a preempted job,
+    //                BUT only if the job is requeue-eligible — and Nextflow
+    //                injects `#SBATCH --no-requeue` into every batch script, so
+    //                each cpu process must re-enable it via `--requeue` in its
+    //                clusterOptions (modules/common.nf::preemptible_logs). SLURM
+    //                then requeues and reruns the job itself, so preemption is
+    //                handled by the scheduler and never fails the pipeline. The
+    //                global `errorStrategy 'retry'` is the backstop for genuine
+    //                (non-preemption) failures.
+    //   gpu       -> `gpu` partition (high PriorityTier, effectively not
+    //                preempted), for virtual-stain prediction; no --requeue.
     slurm {
         executor {
             name = 'slurm'

--- a/nextflow/nextflow.config
+++ b/nextflow/nextflow.config
@@ -39,10 +39,34 @@ process {
     }
 }
 
+// Execution profiles select WHERE work runs. The actual per-position resource
+// requests are set in each process body (cpus/memory/time, often driven by the
+// init step's RESOURCES payload); the `withLabel` blocks above are the defaults
+// for local runs. A profile overrides the executor and, under SLURM, the
+// partition each label maps to. NOTE: a `withLabel` block inside a profile
+// REPLACES (does not deep-merge with) the same-named block in the base `process`
+// block, so each override below restates the directives it needs.
 profiles {
+    // Run everything on the local executor (the process-block default). Useful
+    // for single-node or debug runs.
     local {
         process.executor = 'local'
     }
+
+    // SLURM execution, with each label routed to a partition:
+    //   cpu_local -> local executor (lightweight init / list-positions steps
+    //                stay on the head node; only the memory ceiling differs).
+    //   cpu       -> `preempted` partition. This is the bulk per-position work
+    //                plus the one-shot compute-tf / preprocess steps. Jobs here
+    //                may be reclaimed at any time; the partition's
+    //                PreemptMode=REQUEUE plus the cluster default JobRequeue=1
+    //                mean SLURM requeues and reruns a preempted job itself, so
+    //                preemption is handled by the scheduler and never fails the
+    //                pipeline (no per-job --requeue needed). `errorStrategy
+    //                'retry'` in each process remains the backstop for genuine
+    //                failures.
+    //   gpu       -> `gpu` partition (non-preemptible), for virtual-stain
+    //                prediction.
     slurm {
         executor {
             name = 'slurm'
@@ -51,15 +75,14 @@ profiles {
         }
         process {
             executor = 'slurm'
-            queue = 'cpu'
 
             withLabel: 'cpu_local' {
                 executor = 'local'
-                cpus   = 1
-                memory = '12 GB'
+                cpus     = 1
+                memory   = '12 GB'
             }
             withLabel: 'cpu' {
-                queue = 'cpu'
+                queue = 'preempted'
             }
             withLabel: 'gpu' {
                 queue = 'gpu'

--- a/nextflow/nextflow.config
+++ b/nextflow/nextflow.config
@@ -23,6 +23,14 @@ process {
     // local and SLURM tasks; safe when the var is unset.
     beforeScript = 'unset LD_PRELOAD'
 
+    // Per-process concurrency cap for the per-position fan-out (run_deskew,
+    // run_flat_field, run_apply_inv_tf, run_virtual_stain). Steps run
+    // sequentially, so at most one fan-out is active at a time — this bounds it
+    // to 30 concurrent tasks, keeping SLURM submission and filesystem load in
+    // check while staying under the executor queueSize. A process can override
+    // it with its own `maxForks` directive; single-shot steps ignore it.
+    maxForks = 30
+
     withLabel: 'cpu_local' {
         cpus   = 1
         memory = '8 GB'

--- a/nextflow/nextflow.config
+++ b/nextflow/nextflow.config
@@ -31,6 +31,16 @@ process {
     // it with its own `maxForks` directive; single-shot steps ignore it.
     maxForks = 30
 
+    // Default error handling: retry a failed task once. The per-position fan-out
+    // steps scale time (and virtual-stain preprocess scales memory) by
+    // task.attempt, so the retry gets more headroom for transient timeout/OOM
+    // failures. This is also the backstop for the rare case a preempted-partition
+    // job surfaces as a failure instead of being requeued by SLURM. Applies to
+    // every process (init and compute-tf included, whose outputs are idempotent);
+    // a process may override with its own directive.
+    errorStrategy = 'retry'
+    maxRetries = 1
+
     withLabel: 'cpu_local' {
         cpus   = 1
         memory = '8 GB'

--- a/nextflow/nextflow.config
+++ b/nextflow/nextflow.config
@@ -31,17 +31,25 @@ process {
     // it with its own `maxForks` directive; single-shot steps ignore it.
     maxForks = 30
 
-    // Default error handling: retry a failed task. This is how preemption is
-    // absorbed — a job on the `preempted` partition that SLURM reclaims is
-    // cancelled (Nextflow submits every job with `#SBATCH --no-requeue`, so SLURM
-    // cannot requeue it), Nextflow's executor sees the non-zero exit, and this
-    // errorStrategy resubmits it as a fresh, tracked task. maxRetries is set
-    // generously because a single position may be preempted several times before
-    // it completes; each attempt also scales time (and virtual-stain preprocess
-    // scales memory) by task.attempt, giving transient timeout/OOM failures more
-    // headroom. Applies to every process (init and compute-tf included, whose
-    // outputs are idempotent); a process may override with its own directive.
-    errorStrategy = 'retry'
+    // Error handling: retry only infrastructure/resource terminations, and fail
+    // fast on genuine errors. This is how preemption is absorbed — a job on the
+    // `preempted` partition that SLURM reclaims is cancelled (Nextflow submits
+    // every job with `#SBATCH --no-requeue`, so SLURM cannot requeue it), the
+    // executor sees the non-zero exit, and this strategy resubmits it as a fresh,
+    // tracked task. Preemption, time-limit, and OOM kills all surface as
+    // "128 + signal" exits — SIGTERM 143 (preempt/timeout), SIGKILL 137 (OOM /
+    // hard kill), Nextflow's near-limit SIGUSR2 140, etc. — i.e. the 130..145
+    // range. A non-signal exit (bad config, code bug: exit 1/2/...) terminates
+    // instead of burning all retries on every position. maxRetries is generous
+    // because one position may be preempted several times; each attempt also
+    // scales time (and virtual-stain preprocess scales memory) by task.attempt,
+    // giving genuine timeout/OOM kills more headroom on retry. Applies to every
+    // process (init and compute-tf included, whose outputs are idempotent); a
+    // process may override with its own directive.
+    // CAVEAT: a kill that records NO exit status (rare — node loss) won't match
+    // the range and will terminate; switch to a blanket 'retry' if preemption
+    // resilience must be absolute at the cost of retrying real bugs too.
+    errorStrategy = { task.exitStatus in (130..145) ? 'retry' : 'terminate' }
     maxRetries = 5
 
     withLabel: 'cpu_local' {


### PR DESCRIPTION
## Summary

Transitions the mantis-v2 pipeline's CPU work from the `cpu` partition to the preemptible `preempted` partition, so bulk reconstruction work runs on reclaimable nodes without breaking the workflow. GPU prediction stays on `gpu`; lightweight init/list steps stay on the local executor. Also consolidates duplicated process directives in `nextflow.config`.

### Partition routing (by process label)
- **`cpu_local`** → local executor: `init_*`, `list_positions` (run on the head node alongside the Nextflow driver).
- **`cpu`** → `preempted` partition: all the CPU workhorses — flat-field, deskew, reconstruct (`compute_transfer_function` + per-position `apply-inv-tf`), and virtual-stain `preprocess`.
- **`gpu`** → `gpu` partition: virtual-stain prediction.

### Config cleanup
- Consolidated the identical per-process `maxForks 30` and `errorStrategy`/`maxRetries` into the base `process` block (kept there, not in a `withLabel` selector, because a profile `withLabel` block *replaces* rather than deep-merges the base one).
- Removed redundant profile cruft (the process-level `queue = 'cpu'` default and the no-op `withLabel: 'cpu' { queue = 'cpu' }`).

## Key findings

**1. Nextflow forces `--no-requeue`, so SLURM-managed requeue is the wrong tool here.**
Nextflow's SLURM executor injects `#SBATCH --no-requeue` into every batch script (it wants to own retries). We initially tried to override that with `--requeue` in `clusterOptions` so SLURM would requeue preempted jobs itself. Live testing showed this backfires: Nextflow does **not** track a requeued job, so when SLURM preempts (SIGTERM → exit 143) Nextflow reads that as a task failure and resubmits a **new** job, while SLURM **also** reruns the original — a double execution racing on the same output. Observed: requeuing job `34745334` left it `PENDING` (SLURM rerun) while Nextflow re-submitted it as `34745351`.

**2. Correct approach: let Nextflow's executor absorb preemption via `errorStrategy`.**
Keep Nextflow's default `--no-requeue`. A preempted job is then *cancelled* by SLURM (the partition is `PreemptMode=REQUEUE`, but a non-requeue-eligible job is cancelled instead), Nextflow's executor sees the non-zero exit, and `errorStrategy` resubmits it as a single tracked task.

**3. Retry only signal-based terminations; fail fast on genuine errors.**
`errorStrategy = { task.exitStatus in (130..145) ? 'retry' : 'terminate' }` with `maxRetries = 5`. Preemption, time-limit, and OOM kills all surface as `128 + signal` exits (SIGTERM 143, SIGKILL 137, Nextflow near-limit SIGUSR2 140), so the `130..145` range covers them; a genuine non-signal error (bad config, code bug → exit 1/2) terminates instead of burning all retries on every position. *Caveat (documented inline):* a kill that records no exit status at all (rare node loss) won't match the range — switch to blanket `'retry'` if absolute preemption resilience is required.

### Relevant cluster facts (czbiohub cluster)
- `preempted` partition: `PriorityTier=1`, `PreemptMode=REQUEUE`, `GraceTime=30`. `cpu`/`gpu`: `PriorityTier=1000`.
- Cluster default `JobRequeue=1` — but irrelevant here because Nextflow forces `--no-requeue` per job.

## Verification (live)

Cancelled a running preempted-partition task (`scancel`, simulating preemption) and confirmed via `.nextflow.log` + `sacct`:
- Job `34745461` → single `CANCELLED`, `.batch` exit `15:0` (SIGTERM → 143); **no** SLURM requeue/rerun row.
- Nextflow: `terminated with an error exit status (143) -- Execution is retried (1)` → one `Re-submitted process` in a new workdir.
- The retry re-ran on `preempted` and the pipeline continued; sibling positions unaffected.

## Testing notes
- Because jobs are `--no-requeue`, `scontrol requeue` is (correctly) refused — use `scancel <jobid>` to simulate a preemption, or submit a higher-`PriorityTier` `cpu` job onto the same node to force real preemption.
- Validated config resolution and pipeline parsing with `nextflow config -profile slurm` and `nextflow run ... -profile slurm -preview`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)