### PR TITLE
CLI consistency skill

### DIFF
--- a/.claude/skills/biahub-cli-consistency/SKILL.md
+++ b/.claude/skills/biahub-cli-consistency/SKILL.md
@@ -1,0 +1,178 @@
+---
+name: biahub-cli-consistency
+description: >-
+  Audit a biahub CLI module (biahub/*.py) for style and structural consistency
+  against the canonical command template, and emit a structured findings report
+  that a separate fixer agent can apply. Use when adding a new `biahub <command>`,
+  reviewing a CLI PR, or when asked to check that CLIs "follow the same
+  structure/style". Reviews and reports only — it does NOT edit files.
+---
+
+# biahub CLI consistency review
+
+biahub commands are single-file modules under `biahub/` that expose a `@click.command`
+and are registered in `biahub/cli/main.py`. The processing commands share a strict
+template — see `flat_field_correction.py`, `deskew.py`, `virtual_stain.py`, and
+`apply_inverse_transfer_function.py`. This skill finds where a module drifts from that
+template and reports it for a fixer agent.
+
+## The layered-function rule (most important)
+
+Every CLI module is layered. When reviewing, first classify each function into a layer,
+then check the layer's rule:
+
+1. **Array-in / array-out compute functions** — pure `(array, params) -> array`, no I/O.
+   e.g. `deskew_zyx`, `fast_deskew_zyx`, `flat_field_correction`. **Required only for
+   reconstruction/compute methods internal to biahub.** A CLI whose heavy lifting comes
+   from an external library is *exempt* — do NOT invent one. Exempt examples:
+   `apply_inverse_transfer_function` (delegates to `waveorder`'s
+   `apply_inverse_transfer_function_single_position`) and `virtual_stain`
+   (delegates to cytoland's `AugmentedPredictionVSUNet`).
+2. **API function** — `<verb>(paths_to_data, config, ...) -> None`, operating on zarr
+   stores given paths + config. **Required for every CLI.** This is the orchestrator:
+   `deskew`, `flat_field`, `virtual_stain`, `apply_inverse_transfer_function`. It must be
+   a real function separate from the `_cli`, importable and callable programmatically.
+3. **CLI function** — `<verb>_cli`, the thin `@click.command` wrapper that only parses
+   options and delegates to the API function by keyword.
+
+The pairing is the contract: `deskew_cli`↔`deskew`,
+`apply_inverse_transfer_function_cli`↔`apply_inverse_transfer_function`. A `_cli` that
+inlines its logic instead of delegating to an API function is a defect (see
+`reconstruct.py`).
+
+The two layers must also share one stem (the **name triad** below). `flat_field` breaks
+this — its module/`_cli` are `flat_field_correction`/`flat_field_correction_cli` while the
+API function/command are `flat_field`/`flat-field`. **Flag this as a defect**; do not
+treat `flat_field_correction` as the canonical name. The whole module should converge on
+the single stem `flat_field` (file `flat_field.py`, functions `flat_field`/
+`flat_field_cli`, command `flat-field`).
+
+## Scope
+
+- **In scope now:** processing and composition commands (the four references + peers like
+  `register`, `stabilize`, `stitch`, `concatenate`, `segment`, `track`, `reconstruct`).
+- **Planned, not yet enforced:** `estimate-*` and utility commands. The layered-function
+  rule and the name triad already apply to them, but do not yet fail them against the full
+  processing template — note them as "future scope" if asked to review one.
+
+Ruff (`make lint`, config in `pyproject.toml`: rules `F,E,W,I,N,UP,B,D`, numpy
+docstring convention, isort `lines-between-types=1`) already enforces the *mechanical*
+layer — import order, formatting, docstring presence. **Do not re-report anything ruff
+catches.** This skill covers the *structural/semantic* layer ruff cannot see: module
+anatomy, the name triad, type hints that must match the option callbacks, orchestrator
+body ordering, the CLI docstring example block, provenance metadata, and registration.
+
+## What "consistent" means here
+
+Read these before reviewing — they are the source of truth:
+
+- `references/canonical-cli.md` — the annotated module template, orchestrator body
+  order, decorator stack, and docstring rules.
+- `references/known-inconsistencies.md` — real deviations that exist *among the four
+  reference commands today*. Use them to calibrate: the target module almost certainly
+  has issues from the same categories.
+
+The canonical processing CLIs (`flat_field`, `deskew`, `virtual_stain`,
+`apply_inverse_transfer_function`) are the gold standard. `reconstruct.py` is a thinner
+"composition" command (it chains `compute-tf` + `apply-inv-tf`); judge composition
+commands against the "Composition CLI" section of the template — but note that even
+composition commands must expose an API function separate from the `_cli`
+(`reconstruct.py` currently does not, and that is a flagged defect, not an exemption).
+
+## Procedure
+
+1. **Load the canon.** Read both reference files. If reviewing something other than the
+   four examples, also skim one reference command (`deskew.py`) end-to-end so line-level
+   comparisons are grounded.
+2. **Identify the command category** of each target module: *processing* (fans positions
+   out to submitit), *composition* (chains other CLIs), or *estimate/utility* (planned
+   scope — see "Scope" above). Only processing commands are held to the full template;
+   the layered-function rule and name triad apply to all categories.
+3. **Cross-check type hints against `biahub/cli/parsing.py`.** Every `_cli` parameter
+   annotation must equal the runtime type the corresponding option decorator produces.
+   Use the authoritative *Option → runtime type* table in `references/canonical-cli.md`
+   (grounded in the callbacks/types in `parsing.py`); re-derive from `parsing.py` if an
+   option isn't in the table. Key traps: un-callbacked `click.Path` yields **`str`** (no
+   `path_type` is set anywhere), so `sbatch_filepath` is `str | None`, not `Path | None`;
+   callbacked path options yield `Path`/`list[Path]`. Apply the two-layer rule: the `_cli`
+   annotates the raw option type; the API function annotates the post-conversion type.
+   This is the single most common real defect.
+4. **Cross-check registration.** Confirm the command is in the `COMMANDS` list in
+   `biahub/cli/main.py` with a `name` (kebab-case), `import_path` ending in `<verb>_cli`,
+   and a `help` string.
+5. **Walk the checklist below** against each target module.
+6. **Emit the findings report** in the format below. Do not edit any files.
+
+## Checklist
+
+For each target module, check and record deviations in these categories:
+
+- **Name triad** — module filename stem, orchestrator function, and `<verb>_cli`
+  function should share one stem; the `@click.command("...")` string and `main.py` name
+  are that stem in kebab-case. (`flat_field_correction.py` breaks this.)
+- **Module anatomy / order** — pure compute fn(s) → `_czyx_*` picklable wrapper (if using
+  `process_single_position`) → `_init_output_plate` → other `_helpers` → orchestrator →
+  `<verb>_cli` → `if __name__ == "__main__":`.
+- **Signatures & type hints** — orchestrator and `_cli` share the standard signature
+  `(input_position_dirpaths, config_filepath, output_dirpath, sbatch_filepath=None,
+  cluster="slurm", monitor=..., init_only=False)`; **every annotation matches the
+  authoritative Option → runtime type table** (`references/canonical-cli.md`), applying
+  the two-layer rule (raw type in `_cli`, converted type in the API fn); prefer `X | None`
+  over a bare `= None`; `_cli` uses `monitor: bool = False`.
+- **Orchestrator body order** — matches the ordered steps in the template (Path coerce →
+  slurm_out_path → settings → init plate → resources+echo → `init_only` return →
+  output paths → args dict → slurm_args dict → sbatch override → executor → batched
+  submit → jobs-id log → debug foreground loop → monitor).
+- **Idioms / dedup** — `slurm_out_path.mkdir(exist_ok=True)` (no `parents=True`);
+  consistent `num_workers` handling (no `int(...)` cast — `num_cpus` is already `int`).
+  Wrapping an already-`Path` value in `Path(...)` is an accepted safety idiom, **not** a
+  finding.
+- **Provenance** — output metadata carries `extra_metadata={"biahub-<verb>":
+  settings.model_dump()}` (flag processing commands that omit it).
+- **CLI docstring** — one-line summary + `\b` block with the three canonical examples
+  (SLURM fan-out / `--init` / `--cluster debug`) + trailing `# noqa: D301`.
+- **Docstring accuracy** — numpydoc Parameters match the actual signature (no documented-
+  but-absent params, no undocumented params); this is drift ruff won't flag.
+- **SLURM args** — `slurm_args` dict has the standard keys; `slurm_partition` is
+  `"preempted"` (the preferred partition) — **flag any other value** (e.g. `"cpu"`,
+  `"gpu"`); parallelism value carries an explanatory comment.
+
+## Findings report format
+
+Emit one section per file. Each finding is a numbered entry:
+
+```
+### biahub/<module>.py  (category: processing)
+
+1. [signature] biahub/<module>.py:264 — severity: structural
+   Issue:   `input_position_dirpaths: list[str]` but the option callback
+            `_validate_and_process_paths` returns `list[Path]`.
+   Canon:   Type hints match the callback's runtime type (see deskew.py, reconstruct.py).
+   Fix:     Change annotation to `list[Path]` on both the orchestrator and `_cli`.
+   Auto-fix: safe.
+
+2. [idiom] biahub/<module>.py:388 — severity: cosmetic
+   Issue:   `log_path = Path(slurm_out_path / "...")` wraps an already-`Path` value.
+   Canon:   `log_path = slurm_out_path / "submitit_jobs_ids.log"` (flat_field_correction.py:220).
+   Fix:     Drop the redundant `Path(...)`.
+   Auto-fix: safe.
+```
+
+Rules for the report:
+
+- Anchor every finding to `file:line` and name the **category** and **severity**
+  (`structural` = shape/contract differs; `cosmetic` = idiom/wording).
+- State the **canonical rule** and cite the reference command that exemplifies it.
+- Give a **concrete fix**, and mark `Auto-fix: safe` (mechanical, no judgment) vs
+  `Auto-fix: needs review` (behavior or intent may change — e.g. adding `init_only` to a
+  command that never had it, or changing a `slurm_partition`).
+- End with a short **handoff line**: which findings a fixer agent can apply blind, and the
+  reminder to run `make format && make lint && make test` afterward.
+- If the module is fully consistent, say so explicitly and list what was checked.
+
+## Handoff to a fixer agent
+
+This skill only reports. To resolve findings, dispatch a separate agent (e.g. via the
+Agent tool) with the findings report as its task, instructing it to apply only the
+`Auto-fix: safe` items unless told otherwise, then run `make format && make lint && make
+test`. Keep the reviewer and the fixer separate so the audit stays auditable.

--- a/.claude/skills/biahub-cli-consistency/SKILL.md
+++ b/.claude/skills/biahub-cli-consistency/SKILL.md
@@ -12,7 +12,7 @@ description: >-
 
 biahub commands are single-file modules under `biahub/` that expose a `@click.command`
 and are registered in `biahub/cli/main.py`. The processing commands share a strict
-template — see `flat_field_correction.py`, `deskew.py`, `virtual_stain.py`, and
+template — see `flat_field.py`, `deskew.py`, `virtual_stain.py`, and
 `apply_inverse_transfer_function.py`. This skill finds where a module drifts from that
 template and reports it for a fixer agent.
 
@@ -22,12 +22,16 @@ Every CLI module is layered. When reviewing, first classify each function into a
 then check the layer's rule:
 
 1. **Array-in / array-out compute functions** — pure `(array, params) -> array`, no I/O.
-   e.g. `deskew_zyx`, `fast_deskew_zyx`, `flat_field_correction`. **Required only for
-   reconstruction/compute methods internal to biahub.** A CLI whose heavy lifting comes
-   from an external library is *exempt* — do NOT invent one. Exempt examples:
-   `apply_inverse_transfer_function` (delegates to `waveorder`'s
+   **Named `<verb>_zyx()`** (operating on a ZYX volume), e.g. `deskew_zyx()`,
+   `flat_field_zyx()`; a qualified variant keeps the suffix (`fast_deskew_zyx()`).
+   **Required only for reconstruction/compute methods internal to biahub.** A CLI whose
+   heavy lifting comes from an external library is *exempt* — do NOT invent one. Exempt
+   examples: `apply_inverse_transfer_function` (delegates to `waveorder`'s
    `apply_inverse_transfer_function_single_position`) and `virtual_stain`
    (delegates to cytoland's `AugmentedPredictionVSUNet`).
+   The CZYX multiprocessing wrapper around a `<verb>_zyx()` function (the picklable
+   callable passed to `process_single_position`) is **named `_<verb>_czyx()`**, e.g.
+   `_deskew_czyx()`, `_flat_field_czyx()`.
 2. **API function** — `<verb>(paths_to_data, config, ...) -> None`, operating on zarr
    stores given paths + config. **Required for every CLI.** This is the orchestrator:
    `deskew`, `flat_field`, `virtual_stain`, `apply_inverse_transfer_function`. It must be
@@ -40,12 +44,12 @@ The pairing is the contract: `deskew_cli`↔`deskew`,
 inlines its logic instead of delegating to an API function is a defect (see
 `reconstruct.py`).
 
-The two layers must also share one stem (the **name triad** below). `flat_field` breaks
-this — its module/`_cli` are `flat_field_correction`/`flat_field_correction_cli` while the
-API function/command are `flat_field`/`flat-field`. **Flag this as a defect**; do not
-treat `flat_field_correction` as the canonical name. The whole module should converge on
-the single stem `flat_field` (file `flat_field.py`, functions `flat_field`/
-`flat_field_cli`, command `flat-field`).
+The layers must also share one stem (the **name triad** below): file `flat_field.py`, API
+`flat_field`, CLI `flat_field_cli`, command `flat-field` — all one stem. The layer-1 array
+function and its CZYX wrapper follow the `<verb>_zyx()` / `_<verb>_czyx()` rule above; the
+`flat_field` module still has the array function named `flat_field_correction` (should be
+`flat_field_zyx`) and its wrapper `_czyx_flat_field` (should be `_flat_field_czyx`) — flag
+those.
 
 ## Scope
 
@@ -109,10 +113,11 @@ For each target module, check and record deviations in these categories:
 
 - **Name triad** — module filename stem, orchestrator function, and `<verb>_cli`
   function should share one stem; the `@click.command("...")` string and `main.py` name
-  are that stem in kebab-case. (`flat_field_correction.py` breaks this.)
-- **Module anatomy / order** — pure compute fn(s) → `_czyx_*` picklable wrapper (if using
-  `process_single_position`) → `_init_output_plate` → other `_helpers` → orchestrator →
-  `<verb>_cli` → `if __name__ == "__main__":`.
+  are that stem in kebab-case. Separately, the layer-1 array fn is `<verb>_zyx()` and its
+  CZYX wrapper `_<verb>_czyx()` (see the layered-function rule).
+- **Module anatomy / order** — pure compute fn(s) `<verb>_zyx()` → `_<verb>_czyx()`
+  picklable wrapper (if using `process_single_position`) → `_init_output_plate` → other
+  `_helpers` → orchestrator → `<verb>_cli` → `if __name__ == "__main__":`.
 - **Signatures & type hints** — orchestrator and `_cli` share the standard signature
   `(input_position_dirpaths, config_filepath, output_dirpath, sbatch_filepath=None,
   cluster="slurm", monitor=..., init_only=False)`; **every annotation matches the
@@ -157,9 +162,9 @@ Emit one section per file. Each finding is a numbered entry:
    Auto-fix: safe.
 
 2. [idiom] biahub/<module>.py:388 — severity: cosmetic
-   Issue:   `log_path = Path(slurm_out_path / "...")` wraps an already-`Path` value.
-   Canon:   `log_path = slurm_out_path / "submitit_jobs_ids.log"` (flat_field_correction.py:220).
-   Fix:     Drop the redundant `Path(...)`.
+   Issue:   `slurm_out_path.mkdir(parents=True, exist_ok=True)`.
+   Canon:   `slurm_out_path.mkdir(exist_ok=True)` — no `parents=True` (deskew.py, flat_field.py).
+   Fix:     Drop `parents=True`.
    Auto-fix: safe.
 ```
 

--- a/.claude/skills/biahub-cli-consistency/SKILL.md
+++ b/.claude/skills/biahub-cli-consistency/SKILL.md
@@ -127,8 +127,13 @@ For each target module, check and record deviations in these categories:
   consistent `num_workers` handling (no `int(...)` cast — `num_cpus` is already `int`).
   Wrapping an already-`Path` value in `Path(...)` is an accepted safety idiom, **not** a
   finding.
-- **Provenance** — output metadata carries `extra_metadata={"biahub-<verb>":
-  settings.model_dump()}` (flag processing commands that omit it).
+- **Provenance** — this metadata block is important: output metadata must carry
+  `extra_metadata={"biahub-<verb>": settings.model_dump()}`. **Flag it whenever it is
+  missing.** The *only* current exception is `apply_inverse_transfer_function`, because it
+  is known that `waveorder` writes the equivalent metadata for it. Do not generalize this:
+  using an external library is not itself an excuse — any other command that omits the
+  block (e.g. `virtual_stain`, which uses cytoland but does not write it) is still flagged
+  unless you have verified that command writes the equivalent provenance.
 - **CLI docstring** — one-line summary + `\b` block with the three canonical examples
   (SLURM fan-out / `--init` / `--cluster debug`) + trailing `# noqa: D301`.
 - **Docstring accuracy** — numpydoc Parameters match the actual signature (no documented-

--- a/.claude/skills/biahub-cli-consistency/references/canonical-cli.md
+++ b/.claude/skills/biahub-cli-consistency/references/canonical-cli.md
@@ -1,0 +1,271 @@
+# Canonical biahub CLI structure
+
+Derived from the reference commands: `biahub/deskew.py`, `biahub/flat_field_correction.py`,
+`biahub/virtual_stain.py`, `biahub/apply_inverse_transfer_function.py` (processing) and
+`biahub/reconstruct.py` (composition).
+
+## Function layers (applies to every command)
+
+Every module is layered; the pairing of layers is the core contract.
+
+| Layer | Signature | Required? | Examples |
+|---|---|---|---|
+| 1. Array compute | `(array, params) -> array`, pure, no I/O | **Only** for compute methods *internal to biahub* | `deskew_zyx`, `fast_deskew_zyx`, `flat_field_correction` |
+| 2. API function | `<verb>(paths, config, ...) -> None`, operates on zarr stores | **Every** command | `deskew`, `flat_field`, `virtual_stain`, `apply_inverse_transfer_function` |
+| 3. CLI function | `<verb>_cli`, thin `@click.command` wrapper, delegates to layer 2 | **Every** command | `deskew_cli`, `apply_inverse_transfer_function_cli` |
+
+Layer 1 is **exempt** when the numerical work lives in an external library — do not invent
+an array-in/array-out function in that case:
+
+- `apply_inverse_transfer_function` → `waveorder`'s
+  `apply_inverse_transfer_function_single_position`.
+- `virtual_stain` → cytoland's `AugmentedPredictionVSUNet.predict_sliding_windows`.
+
+Layer 2 is **never** exempt: a command that puts its logic directly in `<verb>_cli` (no
+separate API function) is a defect. `reconstruct.py` currently does this — flag it.
+
+## Command categories
+
+- **Processing** — reads a plate, creates an output plate, fans positions out to submitit
+  (one job per position). Held to the *full* template below. Examples: deskew, flat-field,
+  virtual-stain, apply-inv-tf.
+- **Composition** — chains other biahub/waveorder CLIs; no plate creation or submitit of
+  its own. Example: reconstruct. Held to the "Composition CLI" section, but still owes a
+  layer-2 API function separate from its `_cli`.
+- **Estimate / utility** — produces a config or a small artifact. Planned scope; layers +
+  name triad apply, full processing template does not yet.
+
+## Processing module anatomy (top to bottom)
+
+1. **Imports**, isort-grouped (stdlib / third-party / iohub / biahub), `lines-between-types = 1`.
+   Optional module-level setup (e.g. deskew's `torch.multiprocessing.set_start_method`).
+2. **Pure compute function(s)** — operate on `np.ndarray` / `torch.Tensor`, numpydoc
+   docstrings. e.g. `flat_field_correction`, `deskew_zyx`.
+3. **`_czyx_*` wrapper** — top-level (picklable) CZYX adapter passed to
+   `process_single_position`. Only when the command uses `process_single_position`.
+   (virtual-stain instead defines a bespoke `virtual_stain_position`, which is an
+   intentional exception because inference is GPU-bound and serial over time.)
+4. **`_init_output_plate(input_position_dirpaths, output_dirpath, settings) ->
+   (shape, channel_names)`** — creates the output plate via `create_empty_plate`
+   (idempotent), returns the input `(T, C, Z, Y, X)` and channel names.
+5. **Other private `_helpers`** as needed.
+6. **Orchestrator function `<verb>(...)`** — the SLURM fan-out logic (body order below).
+7. **`<verb>_cli`** — `@click.command` + decorator stack, delegates to the orchestrator.
+8. **`if __name__ == "__main__": <verb>_cli()`**
+
+## The name triad
+
+One stem flows through the whole module:
+
+| Artifact | Form | Example |
+|---|---|---|
+| module file | `<stem>.py` | `deskew.py` |
+| orchestrator fn | `<stem>` | `deskew` |
+| CLI fn | `<stem>_cli` | `deskew_cli` |
+| `@click.command("...")` | `<stem>` kebab | `"deskew"` |
+| `main.py` COMMANDS name | `<stem>` kebab | `"deskew"` |
+
+`flat_field_correction.py` **violates** this and must be flagged: file/`_cli` use
+`flat_field_correction` while the API function and command use `flat_field`/`flat-field`.
+The fix converges the whole module on one stem — `flat_field`:
+
+| Artifact | Currently | Should be |
+|---|---|---|
+| module file | `flat_field_correction.py` | `flat_field.py` |
+| API fn | `flat_field` | `flat_field` (already correct) |
+| CLI fn | `flat_field_correction_cli` | `flat_field_cli` |
+| command | `flat-field` | `flat-field` (already correct) |
+| `main.py` import_path | `biahub.flat_field_correction.flat_field_correction_cli` | `biahub.flat_field.flat_field_cli` |
+
+This is `Auto-fix: needs review` — it renames a module and its `_cli`, so it touches
+`main.py`, imports elsewhere, and the test file `tests/test_cli/test_flat_field_cli.py`.
+
+## Standard signature
+
+Both the orchestrator and `<verb>_cli` take:
+
+```python
+def <verb>(
+    input_position_dirpaths: list[Path],   # callback returns list[Path], NOT list[str]
+    config_filepath: Path,
+    output_dirpath: Path,                   # callback returns Path, NOT str
+    sbatch_filepath: Path | None = None,
+    cluster: str = "slurm",
+    monitor: bool = True,                   # orchestrator default True; _cli default False
+    init_only: bool = False,
+):
+```
+
+### Type hints must match `biahub/cli/parsing.py` (authoritative)
+
+Every option decorator in `parsing.py` produces a specific runtime type — via its
+`callback` or its `click.Path`/`click.Choice`/`is_flag`/`int` type. The `_cli` parameter
+annotation must be exactly that type. This is a hard rule, not a preference. There is no
+`path_type=` on any `click.Path`, so an un-callbacked `click.Path` yields a **`str`**, not
+a `Path`.
+
+| Option decorator | Mechanism | Runtime type → annotate as |
+|---|---|---|
+| `input_position_dirpaths` | `callback=_validate_and_process_paths` | `list[Path]` |
+| `source_position_dirpaths` | `callback=_validate_and_process_paths` | `list[Path]` |
+| `target_position_dirpaths` | `callback=_validate_and_process_paths` | `list[Path]` |
+| `config_filepaths` | `callback=_validate_and_process_config_paths` | `list[Path]` |
+| `config_filepath` | `callback=_str_to_path` | `Path` |
+| `output_dirpath` | `callback=_str_to_path` | `Path` |
+| `output_filepath` | `callback=_str_to_path` | `Path` |
+| `sbatch_filepath` (+ `_preprocess`/`_predict`) | `click.Path`, **no callback**, `default=None` | `str \| None` |
+| `cluster` | `click.Choice`, `default="slurm"` | `str` |
+| `init_only` | `is_flag`, dest `init_only` | `bool` |
+| `monitor` | `is_flag` | `bool` |
+| `local` | `is_flag` | `bool` |
+| `num_processes` | `type=int`, `default=1` | `int` |
+| ad-hoc `click.Path()` (e.g. apply-inv-tf's `--transfer-function-dirpath`) | `click.Path`, no callback | `str \| None` |
+
+**Two-layer typing rule.** The `_cli` (layer 3) annotates the *raw* type the option
+produces (above). If the `_cli` then converts a value before delegating (e.g.
+`Path(transfer_function_dirpath)`), the **API function** (layer 2) annotates the
+*converted* type. Where no conversion happens, both layers use the same type. So:
+
+- `sbatch_filepath` is never converted → **`str | None` in both layers.** Annotating it
+  `Path | None` (as `apply_inverse_transfer_function` does) is a mismatch — flag it.
+- `output_dirpath`/`config_filepath` arrive as `Path` from the callback → `Path` in both
+  layers (a defensive `output_dirpath = Path(output_dirpath)` inside the API fn is fine).
+- `--transfer-function-dirpath` arrives as `str | None`, is converted with `Path(...)` in
+  the `_cli`, and is `Path` in the API function — the correct pattern to mirror.
+
+Prefer `X | None` over a bare `= None` with a non-optional annotation.
+
+## Orchestrator body order
+
+```python
+output_dirpath = Path(output_dirpath)
+slurm_out_path = output_dirpath.parent / "slurm_output"
+
+settings = yaml_to_model(config_filepath, <Verb>Settings)
+input_shape, channel_names = _init_output_plate(input_position_dirpaths, output_dirpath, settings)
+
+num_cpus, gb_ram_per_cpu = estimate_resources(shape=input_shape, ram_multiplier=8, max_num_cpus=16)
+mem_gb = num_cpus * gb_ram_per_cpu
+time_minutes = 60
+echo_resources(num_cpus, mem_gb, time_minutes)
+
+if init_only:
+    click.echo(f"Initialized {output_dirpath} ({len(input_position_dirpaths)} positions)")
+    return
+
+output_position_paths = utils.get_output_paths(input_position_dirpaths, output_dirpath)
+
+<verb>_args = {
+    ...,
+    "extra_metadata": {"biahub-<verb>": settings.model_dump()},   # provenance
+}
+
+slurm_args = {
+    "slurm_job_name": "<verb>",
+    "slurm_mem": f"{mem_gb}G",
+    "slurm_cpus_per_task": num_cpus,
+    "slurm_array_parallelism": 100,   # process up to N positions at a time  <- keep the comment
+    "slurm_time": time_minutes,
+    "slurm_partition": "preempted",   # preferred; flag any other value
+}
+if sbatch_filepath:
+    slurm_args.update(sbatch_to_submitit(sbatch_filepath))
+
+resolved_cluster = get_submitit_cluster(cluster=cluster)
+click.echo(f"Preparing jobs on cluster='{resolved_cluster}': {slurm_args}")
+executor = submitit.AutoExecutor(folder=slurm_out_path, cluster=resolved_cluster)
+executor.update_parameters(**slurm_args)
+
+click.echo("Submitting jobs...")
+jobs = []
+with submitit.helpers.clean_env(), executor.batch():
+    for input_position_path, output_position_path in zip(
+        input_position_dirpaths, output_position_paths, strict=True
+    ):
+        jobs.append(executor.submit(process_single_position, _czyx_<verb>, ...))
+
+job_ids = [job.job_id for job in jobs]
+slurm_out_path.mkdir(exist_ok=True)                          # canonical form (no parents=True)
+log_path = slurm_out_path / "submitit_jobs_ids.log"          # wrapping in Path(...) is also fine
+with log_path.open("w") as log_file:
+    log_file.write("\n".join(job_ids))
+
+# submitit's DebugExecutor is lazy — run each in the foreground and stream progress.
+if resolved_cluster == "debug":
+    for job, path in zip(jobs, input_position_dirpaths, strict=True):
+        job.wait()
+        click.echo(f"<Verb> complete: {path}")
+    return
+
+if monitor:
+    monitor_jobs(jobs, input_position_dirpaths)
+```
+
+## CLI decorator stack
+
+```python
+@click.command("<verb>")
+@input_position_dirpaths()
+@config_filepath()
+@output_dirpath()
+@sbatch_filepath()
+@cluster()
+@monitor()
+@init_only()
+def <verb>_cli(...):
+    """One-line summary.
+
+    \b
+    SLURM fan-out of positions across a whole plate:
+    >>> biahub <verb> -i ./input.zarr/*/*/* -c ./<verb>_params.yml -o ./output.zarr
+
+    \b
+    Initialize the output plate only (e.g. before running per-position Nextflow workers):
+    >>> biahub <verb> --init -i ./input.zarr/*/*/* -c ./<verb>_params.yml -o ./output.zarr
+
+    \b
+    In-process run of a single position (e.g. from a Nextflow worker):
+    >>> biahub <verb> --cluster debug -i ./input.zarr/A/1/0 -c ./<verb>_params.yml -o ./output.zarr
+    """  # noqa: D301
+    <verb>(
+        input_position_dirpaths=input_position_dirpaths,
+        config_filepath=config_filepath,
+        output_dirpath=output_dirpath,
+        sbatch_filepath=sbatch_filepath,
+        cluster=cluster,
+        monitor=monitor,
+        init_only=init_only,
+    )
+```
+
+The `_cli` delegates with **keyword** arguments and does no logic of its own.
+
+## Registration (biahub/cli/main.py)
+
+Add an entry to `COMMANDS`:
+
+```python
+{"name": "<verb>", "import_path": "biahub.<module>.<verb>_cli", "help": "..."},
+```
+
+## Composition CLI (reconstruct)
+
+A composition command has no plate creation and no submitit batch of its own — it just
+chains sub-CLIs. It is still layered: it needs a **layer-2 API function** (`reconstruct`)
+that takes paths + config and calls the sub-steps, plus a thin `reconstruct_cli` that
+delegates to it. `reconstruct.py` currently inlines everything in `reconstruct_cli` with
+no API function — **flag this** (a caller cannot invoke `reconstruct` programmatically).
+
+Hold a composition command to:
+
+- the name triad and the layer-2/layer-3 split (API function + delegating `_cli`);
+- correct type hints matching the option callbacks;
+- the `@click.command` decorator stack it needs (may omit `init_only` if it delegates);
+- a docstring whose runnable example(s) use the same `\b` block + trailing `# noqa: D301`
+  formatting as the processing commands (the *examples* may differ — a composition command
+  need not show `--init`/`--cluster debug` — but the formatting must match).
+
+Do **not** demand a layer-1 array function, `_init_output_plate`, `estimate_resources`,
+the debug loop, or the three-example `\b` block from a composition command — but do flag
+misleading signatures (e.g. `monitor: bool = True` on a `_cli` when the `monitor()`
+option default is `False`).

--- a/.claude/skills/biahub-cli-consistency/references/canonical-cli.md
+++ b/.claude/skills/biahub-cli-consistency/references/canonical-cli.md
@@ -1,6 +1,6 @@
 # Canonical biahub CLI structure
 
-Derived from the reference commands: `biahub/deskew.py`, `biahub/flat_field_correction.py`,
+Derived from the reference commands: `biahub/deskew.py`, `biahub/flat_field.py`,
 `biahub/virtual_stain.py`, `biahub/apply_inverse_transfer_function.py` (processing) and
 `biahub/reconstruct.py` (composition).
 
@@ -8,11 +8,17 @@ Derived from the reference commands: `biahub/deskew.py`, `biahub/flat_field_corr
 
 Every module is layered; the pairing of layers is the core contract.
 
-| Layer | Signature | Required? | Examples |
-|---|---|---|---|
-| 1. Array compute | `(array, params) -> array`, pure, no I/O | **Only** for compute methods *internal to biahub* | `deskew_zyx`, `fast_deskew_zyx`, `flat_field_correction` |
-| 2. API function | `<verb>(paths, config, ...) -> None`, operates on zarr stores | **Every** command | `deskew`, `flat_field`, `virtual_stain`, `apply_inverse_transfer_function` |
-| 3. CLI function | `<verb>_cli`, thin `@click.command` wrapper, delegates to layer 2 | **Every** command | `deskew_cli`, `apply_inverse_transfer_function_cli` |
+| Layer | Name | Signature | Required? | Examples |
+|---|---|---|---|---|
+| 1. Array compute | `<verb>_zyx()` | `(zyx_array, params) -> array`, pure, no I/O | **Only** for compute methods *internal to biahub* | `deskew_zyx`, `fast_deskew_zyx`, `flat_field_zyx` |
+| 1b. CZYX wrapper | `_<verb>_czyx()` | picklable CZYX adapter passed to `process_single_position` | Only with layer 1 + `process_single_position` | `_deskew_czyx`, `_fast_deskew_czyx`, `_flat_field_czyx` |
+| 2. API function | `<verb>()` | `(paths, config, ...) -> None`, operates on zarr stores | **Every** command | `deskew`, `flat_field`, `virtual_stain`, `apply_inverse_transfer_function` |
+| 3. CLI function | `<verb>_cli()` | thin `@click.command` wrapper, delegates to layer 2 | **Every** command | `deskew_cli`, `apply_inverse_transfer_function_cli` |
+
+Naming: the array function is suffixed `_zyx` (the volume layout it takes); its CZYX
+multiprocessing wrapper is `_<verb>_czyx` (private, since it exists only for pickling). A
+qualified array variant keeps the suffix and its wrapper mirrors the qualifier —
+`fast_deskew_zyx` → `_fast_deskew_czyx`.
 
 Layer 1 is **exempt** when the numerical work lives in an external library — do not invent
 an array-in/array-out function in that case:
@@ -39,9 +45,9 @@ separate API function) is a defect. `reconstruct.py` currently does this — fla
 
 1. **Imports**, isort-grouped (stdlib / third-party / iohub / biahub), `lines-between-types = 1`.
    Optional module-level setup (e.g. deskew's `torch.multiprocessing.set_start_method`).
-2. **Pure compute function(s)** — operate on `np.ndarray` / `torch.Tensor`, numpydoc
-   docstrings. e.g. `flat_field_correction`, `deskew_zyx`.
-3. **`_czyx_*` wrapper** — top-level (picklable) CZYX adapter passed to
+2. **Pure compute function(s) `<verb>_zyx()`** — operate on a ZYX `np.ndarray` /
+   `torch.Tensor`, numpydoc docstrings. e.g. `deskew_zyx`, `flat_field_zyx`.
+3. **`_<verb>_czyx()` wrapper** — top-level (picklable) CZYX adapter passed to
    `process_single_position`. Only when the command uses `process_single_position`.
    (virtual-stain instead defines a bespoke `virtual_stain_position`, which is an
    intentional exception because inference is GPU-bound and serial over time.)
@@ -65,20 +71,16 @@ One stem flows through the whole module:
 | `@click.command("...")` | `<stem>` kebab | `"deskew"` |
 | `main.py` COMMANDS name | `<stem>` kebab | `"deskew"` |
 
-`flat_field_correction.py` **violates** this and must be flagged: file/`_cli` use
-`flat_field_correction` while the API function and command use `flat_field`/`flat-field`.
-The fix converges the whole module on one stem — `flat_field`:
+`flat_field.py` now satisfies the triad (file `flat_field.py`, API `flat_field`, CLI
+`flat_field_cli`, command `flat-field`, `main.py` import `biahub.flat_field.flat_field_cli`).
+If you find a module where the stem drifts across file/`_cli`/command, flag it and give a
+rename table like the one above; renames are `Auto-fix: needs review` because they touch
+`main.py`, imports elsewhere, and the command's test file.
 
-| Artifact | Currently | Should be |
-|---|---|---|
-| module file | `flat_field_correction.py` | `flat_field.py` |
-| API fn | `flat_field` | `flat_field` (already correct) |
-| CLI fn | `flat_field_correction_cli` | `flat_field_cli` |
-| command | `flat-field` | `flat-field` (already correct) |
-| `main.py` import_path | `biahub.flat_field_correction.flat_field_correction_cli` | `biahub.flat_field.flat_field_cli` |
-
-This is `Auto-fix: needs review` — it renames a module and its `_cli`, so it touches
-`main.py`, imports elsewhere, and the test file `tests/test_cli/test_flat_field_cli.py`.
+The array-layer names are a **separate** rule (see "Function layers"): `flat_field.py`
+still names its array function `flat_field_correction` (should be `flat_field_zyx`) and its
+wrapper `_czyx_flat_field` (should be `_flat_field_czyx`) — those remain open defects even
+though the triad is now clean.
 
 ## Standard signature
 

--- a/.claude/skills/biahub-cli-consistency/references/canonical-cli.md
+++ b/.claude/skills/biahub-cli-consistency/references/canonical-cli.md
@@ -157,7 +157,11 @@ output_position_paths = utils.get_output_paths(input_position_dirpaths, output_d
 
 <verb>_args = {
     ...,
-    "extra_metadata": {"biahub-<verb>": settings.model_dump()},   # provenance
+    # Provenance — important; required on every command. The ONLY known exception
+    # is apply-inv-tf, because waveorder writes the equivalent metadata for it.
+    # Using an external library is not itself an excuse (virtual_stain uses cytoland
+    # and still owes this block). Flag it whenever it is missing.
+    "extra_metadata": {"biahub-<verb>": settings.model_dump()},
 }
 
 slurm_args = {

--- a/.claude/skills/biahub-cli-consistency/references/known-inconsistencies.md
+++ b/.claude/skills/biahub-cli-consistency/references/known-inconsistencies.md
@@ -1,6 +1,6 @@
 # Known open defects in the reference commands
 
-These are real deviations present in `deskew.py`, `flat_field_correction.py`,
+These are real deviations present in `deskew.py`, `flat_field.py`,
 `virtual_stain.py`, `apply_inverse_transfer_function.py`, and `reconstruct.py` at the time
 this skill was written. **All of them should be fixed** — they are also the *calibration
 set*: a module under review very likely has issues from the same categories. Line numbers
@@ -20,22 +20,23 @@ path — is fine as a safety idiom and is **not** a finding.)
 | 1 | idiom | virtual_stain `slurm_out_path.mkdir(parents=True, exist_ok=True)` | Diverges from deskew/flat_field/apply-inv-tf | Use `slurm_out_path.mkdir(exist_ok=True)` (drop `parents=True`) — the canonical form. `Auto-fix: safe`. |
 | 2 | idiom | flat_field `num_workers=int(slurm_args["slurm_cpus_per_task"])` vs deskew no cast | Inconsistent `num_workers` coercion | `num_cpus` is already `int` from `estimate_resources`; drop the cast (deskew form) everywhere. `Auto-fix: safe`. |
 | 3 | comments | flat_field `slurm_array_parallelism: 100` has no comment; deskew/virtual_stain do | Missing the "process up to N positions at a time" comment | Add the explanatory inline comment on the parallelism value. `Auto-fix: safe`. |
-| 4 | provenance | virtual_stain writes no `extra_metadata` | Output plate lacks the `{"biahub-<verb>": ...}` provenance block the others record | Record a provenance block. virtual-stain uses a VisCy jsonargparse config, not a biahub `settings` model, so dump the equivalent config rather than skipping it. `Auto-fix: needs review`. |
-| 5 | name triad | `flat_field_correction.py` / `flat_field_correction_cli` vs API fn `flat_field` / command `flat-field` | Module + `_cli` stem disagree with the API-fn/command stem | Converge the whole module on `flat_field` (see canonical-cli.md → "The name triad" rename table). `Auto-fix: needs review` — renames module + `_cli`, touches main.py + test file. |
-| 6 | layered functions | `reconstruct.py` inlines all logic in `reconstruct_cli`; there is no `reconstruct` API function | Every command owes a layer-2 API function `(paths, config, ...)` separate from the `_cli` | Extract `reconstruct(input_position_dirpaths, config_filepath, output_dirpath, ...)`; make `reconstruct_cli` a thin wrapper that delegates to it. `Auto-fix: needs review`. |
-| 7 | signature | `reconstruct_cli(... monitor: bool = True)` vs the `monitor()` option default `False` | Misleading dead default (click passes the actual value) | Set the `_cli` signature default to `monitor: bool = False` to match the option. `Auto-fix: safe`. |
-| 8 | docstring accuracy | deskew `_get_transform_matrix` documents a `keep_overhang` parameter it does not accept | numpydoc Parameters drifted from the signature | Make the Parameters block match the actual signature. ruff's D-rules won't catch a documented-but-absent param. `Auto-fix: safe`. |
-| 9 | slurm args | `apply_inverse_transfer_function` sets no `slurm_array_parallelism` key; the other processing commands all do | Missing the per-position parallelism cap in `slurm_args` | Add `slurm_array_parallelism` with an explanatory comment. `Auto-fix: needs review` (confirm the intended cap). |
-| 10 | docstring/CLI | `reconstruct_cli` uses a single inline example, no `\b` block, no `# noqa: D301` | Docstring example formatting diverges from the processing commands | Wrap the runnable example(s) in a `\b` block and add the trailing `# noqa: D301`, matching the other commands' style. `Auto-fix: safe`. |
-| 11 | slurm args | flat_field `"slurm_partition": "cpu"`, apply-inv-tf `"cpu"`, virtual_stain `"gpu"` (only deskew uses `"preempted"`) | Partition is not the preferred `"preempted"` | Set `"slurm_partition": "preempted"`. `Auto-fix: needs review` — a GPU workload (virtual_stain) may require a GPU-capable partition, so confirm a preempted variant exists before switching it. |
+| 4 | array-fn naming | flat_field's array function is named `flat_field_correction` | Layer-1 compute function is not named `<verb>_zyx()` | Rename to `flat_field_zyx()` (and its internal call site). `Auto-fix: safe` — confirm no external importers first (the module was already renamed to `flat_field.py`). |
+| 5 | czyx-wrapper naming | wrappers are `_czyx_flat_field`, `_czyx_deskew_data`, `_czyx_fast_deskew_data` | CZYX wrapper is not named `_<verb>_czyx()` | Rename to `_flat_field_czyx`, `_deskew_czyx`, `_fast_deskew_czyx`. `Auto-fix: safe` — private, module-local (only passed to `process_single_position`). |
+| 6 | provenance | virtual_stain writes no `extra_metadata` | Output plate lacks the `{"biahub-<verb>": ...}` provenance block the others record | Record a provenance block. virtual-stain uses a VisCy jsonargparse config, not a biahub `settings` model, so dump the equivalent config rather than skipping it. `Auto-fix: needs review`. |
+| 7 | layered functions | `reconstruct.py` inlines all logic in `reconstruct_cli`; there is no `reconstruct` API function | Every command owes a layer-2 API function `(paths, config, ...)` separate from the `_cli` | Extract `reconstruct(input_position_dirpaths, config_filepath, output_dirpath, ...)`; make `reconstruct_cli` a thin wrapper that delegates to it. `Auto-fix: needs review`. |
+| 8 | signature | `reconstruct_cli(... monitor: bool = True)` vs the `monitor()` option default `False` | Misleading dead default (click passes the actual value) | Set the `_cli` signature default to `monitor: bool = False` to match the option. `Auto-fix: safe`. |
+| 9 | docstring accuracy | deskew `_get_transform_matrix` documents a `keep_overhang` parameter it does not accept | numpydoc Parameters drifted from the signature | Make the Parameters block match the actual signature. ruff's D-rules won't catch a documented-but-absent param. `Auto-fix: safe`. |
+| 10 | slurm args | `apply_inverse_transfer_function` sets no `slurm_array_parallelism` key; the other processing commands all do | Missing the per-position parallelism cap in `slurm_args` | Add `slurm_array_parallelism` with an explanatory comment. `Auto-fix: needs review` (confirm the intended cap). |
+| 11 | docstring/CLI | `reconstruct_cli` uses a single inline example, no `\b` block, no `# noqa: D301` | Docstring example formatting diverges from the processing commands | Wrap the runnable example(s) in a `\b` block and add the trailing `# noqa: D301`, matching the other commands' style. `Auto-fix: safe`. |
+| 12 | slurm args | flat_field `"slurm_partition": "cpu"`, apply-inv-tf `"cpu"`, virtual_stain `"gpu"` (only deskew uses `"preempted"`) | Partition is not the preferred `"preempted"` | Set `"slurm_partition": "preempted"`. `Auto-fix: needs review` — a GPU workload (virtual_stain) may require a GPU-capable partition, so confirm a preempted variant exists before switching it. |
 
 ## How to use this table
 
 - When you find an issue in a target module, name its **category** so the fixer agent can
   batch related fixes.
-- Idiom/comment/signature/docstring fixes (#1–3, #7, #8, #10) are `Auto-fix: safe`.
-- Provenance (#4), the name triad (#5), the missing API function (#6), the slurm-args
-  cap (#9), and the partition (#11) are `Auto-fix: needs review` — they change behavior or
-  ripple across files (`main.py`, filenames, tests, callers).
+- Idiom/comment/naming/signature/docstring fixes (#1–5, #8, #9, #11) are `Auto-fix: safe`.
+- Provenance (#6), the missing API function (#7), the slurm-args cap (#10), and the
+  partition (#12) are `Auto-fix: needs review` — they change behavior or ripple across
+  files (`main.py`, filenames, tests, callers).
 - Do not report a deviation that ruff already enforces (import order, formatting, missing
   docstrings). Check `pyproject.toml [tool.ruff]` if unsure.

--- a/.claude/skills/biahub-cli-consistency/references/known-inconsistencies.md
+++ b/.claude/skills/biahub-cli-consistency/references/known-inconsistencies.md
@@ -1,0 +1,41 @@
+# Known open defects in the reference commands
+
+These are real deviations present in `deskew.py`, `flat_field_correction.py`,
+`virtual_stain.py`, `apply_inverse_transfer_function.py`, and `reconstruct.py` at the time
+this skill was written. **All of them should be fixed** — they are also the *calibration
+set*: a module under review very likely has issues from the same categories. Line numbers
+drift as files change — treat them as pointers, re-locate before reporting.
+
+The point is not just to fix these commands — it is to recognize the **class** of each
+issue when auditing any CLI.
+
+Type-hint correctness is **not** listed here: it is fully governed by the authoritative
+*Option → runtime type* table in `canonical-cli.md`. Any annotation that disagrees with
+that table is a defect to fix, full stop. (Note: calling `Path()` on a value that is
+already a `Path` — e.g. `output_dirpath = Path(output_dirpath)` or wrapping a `/`-joined
+path — is fine as a safety idiom and is **not** a finding.)
+
+| # | Category | Where | Deviation | Fix |
+|---|---|---|---|---|
+| 1 | idiom | virtual_stain `slurm_out_path.mkdir(parents=True, exist_ok=True)` | Diverges from deskew/flat_field/apply-inv-tf | Use `slurm_out_path.mkdir(exist_ok=True)` (drop `parents=True`) — the canonical form. `Auto-fix: safe`. |
+| 2 | idiom | flat_field `num_workers=int(slurm_args["slurm_cpus_per_task"])` vs deskew no cast | Inconsistent `num_workers` coercion | `num_cpus` is already `int` from `estimate_resources`; drop the cast (deskew form) everywhere. `Auto-fix: safe`. |
+| 3 | comments | flat_field `slurm_array_parallelism: 100` has no comment; deskew/virtual_stain do | Missing the "process up to N positions at a time" comment | Add the explanatory inline comment on the parallelism value. `Auto-fix: safe`. |
+| 4 | provenance | virtual_stain writes no `extra_metadata` | Output plate lacks the `{"biahub-<verb>": ...}` provenance block the others record | Record a provenance block. virtual-stain uses a VisCy jsonargparse config, not a biahub `settings` model, so dump the equivalent config rather than skipping it. `Auto-fix: needs review`. |
+| 5 | name triad | `flat_field_correction.py` / `flat_field_correction_cli` vs API fn `flat_field` / command `flat-field` | Module + `_cli` stem disagree with the API-fn/command stem | Converge the whole module on `flat_field` (see canonical-cli.md → "The name triad" rename table). `Auto-fix: needs review` — renames module + `_cli`, touches main.py + test file. |
+| 6 | layered functions | `reconstruct.py` inlines all logic in `reconstruct_cli`; there is no `reconstruct` API function | Every command owes a layer-2 API function `(paths, config, ...)` separate from the `_cli` | Extract `reconstruct(input_position_dirpaths, config_filepath, output_dirpath, ...)`; make `reconstruct_cli` a thin wrapper that delegates to it. `Auto-fix: needs review`. |
+| 7 | signature | `reconstruct_cli(... monitor: bool = True)` vs the `monitor()` option default `False` | Misleading dead default (click passes the actual value) | Set the `_cli` signature default to `monitor: bool = False` to match the option. `Auto-fix: safe`. |
+| 8 | docstring accuracy | deskew `_get_transform_matrix` documents a `keep_overhang` parameter it does not accept | numpydoc Parameters drifted from the signature | Make the Parameters block match the actual signature. ruff's D-rules won't catch a documented-but-absent param. `Auto-fix: safe`. |
+| 9 | slurm args | `apply_inverse_transfer_function` sets no `slurm_array_parallelism` key; the other processing commands all do | Missing the per-position parallelism cap in `slurm_args` | Add `slurm_array_parallelism` with an explanatory comment. `Auto-fix: needs review` (confirm the intended cap). |
+| 10 | docstring/CLI | `reconstruct_cli` uses a single inline example, no `\b` block, no `# noqa: D301` | Docstring example formatting diverges from the processing commands | Wrap the runnable example(s) in a `\b` block and add the trailing `# noqa: D301`, matching the other commands' style. `Auto-fix: safe`. |
+| 11 | slurm args | flat_field `"slurm_partition": "cpu"`, apply-inv-tf `"cpu"`, virtual_stain `"gpu"` (only deskew uses `"preempted"`) | Partition is not the preferred `"preempted"` | Set `"slurm_partition": "preempted"`. `Auto-fix: needs review` — a GPU workload (virtual_stain) may require a GPU-capable partition, so confirm a preempted variant exists before switching it. |
+
+## How to use this table
+
+- When you find an issue in a target module, name its **category** so the fixer agent can
+  batch related fixes.
+- Idiom/comment/signature/docstring fixes (#1–3, #7, #8, #10) are `Auto-fix: safe`.
+- Provenance (#4), the name triad (#5), the missing API function (#6), the slurm-args
+  cap (#9), and the partition (#11) are `Auto-fix: needs review` — they change behavior or
+  ripple across files (`main.py`, filenames, tests, callers).
+- Do not report a deviation that ruff already enforces (import order, formatting, missing
+  docstrings). Check `pyproject.toml [tool.ruff]` if unsure.

--- a/biahub/apply_inverse_transfer_function.py
+++ b/biahub/apply_inverse_transfer_function.py
@@ -77,7 +77,7 @@ def apply_inverse_transfer_function(
     transfer_function_dirpath: Path,
     config_filepath: Path,
     output_dirpath: Path,
-    sbatch_filepath: Path | None = None,
+    sbatch_filepath: str | None = None,
     cluster: str = "slurm",
     monitor: bool = True,
     init_only: bool = False,
@@ -94,7 +94,7 @@ def apply_inverse_transfer_function(
         Path to YAML reconstruction config.
     output_dirpath : Path
         Path to output zarr.
-    sbatch_filepath : Path, optional
+    sbatch_filepath : str, optional
         SBATCH file with slurm parameter overrides.
     cluster : str
         Execution cluster: 'slurm', 'local', or 'debug'.
@@ -124,8 +124,6 @@ def apply_inverse_transfer_function(
         )
         return
 
-    resolved_cluster = get_submitit_cluster(cluster=cluster)
-
     # Fan out one job per position via submitit. With --cluster debug, submitit's
     # DebugExecutor runs the work in-process (the slurm_* parameters are ignored):
     # Nextflow already handles per-position fan-out and resource scheduling, so the
@@ -135,13 +133,15 @@ def apply_inverse_transfer_function(
         "slurm_job_name": "apply-inverse-transfer-function",
         "slurm_mem": f"{mem_gb}G",
         "slurm_cpus_per_task": num_cpus,
+        "slurm_array_parallelism": 100,  # process up to 100 positions at a time
         "slurm_time": time_minutes,
-        "slurm_partition": "cpu",
+        "slurm_partition": "preempted",
     }
 
     if sbatch_filepath:
         slurm_args.update(sbatch_to_submitit(sbatch_filepath))
 
+    resolved_cluster = get_submitit_cluster(cluster=cluster)
     click.echo(f"Preparing jobs on cluster='{resolved_cluster}': {slurm_args}")
     executor = submitit.AutoExecutor(folder=slurm_out_path, cluster=resolved_cluster)
     executor.update_parameters(**slurm_args)
@@ -202,7 +202,7 @@ def apply_inverse_transfer_function_cli(
     transfer_function_dirpath: str | None,
     config_filepath: Path,
     output_dirpath: Path,
-    sbatch_filepath: Path | None = None,
+    sbatch_filepath: str | None = None,
     cluster: str = "slurm",
     monitor: bool = False,
     init_only: bool = False,

--- a/biahub/cli/main.py
+++ b/biahub/cli/main.py
@@ -71,7 +71,7 @@ COMMANDS = [
     },
     {
         "name": "flat-field",
-        "import_path": "biahub.flat_field_correction.flat_field_correction_cli",
+        "import_path": "biahub.flat_field.flat_field_cli",
         "help": "Apply flat field correction to selected channels",
     },
     {

--- a/biahub/deskew.py
+++ b/biahub/deskew.py
@@ -544,11 +544,11 @@ def fast_deskew_zyx(
 
 # Adapt ZYX function to CZYX
 # Needs to be a top-level function for multiprocessing pickling
-def _czyx_deskew_data(data, **kwargs):
+def _deskew_czyx(data, **kwargs):
     return deskew_zyx(data[0], **kwargs)[None]
 
 
-def _czyx_fast_deskew_data(data, device="cuda", num_splits=1, **kwargs):
+def _fast_deskew_czyx(data, device="cuda", num_splits=1, **kwargs):
     """CZYX wrapper for `fast_deskew_zyx`. Handles numpy↔torch conversion.
 
     When `num_splits` > 1 the volume is split along input axis 2
@@ -728,7 +728,7 @@ def deskew(
             jobs.append(
                 executor.submit(
                     process_single_position,
-                    _czyx_fast_deskew_data,
+                    _fast_deskew_czyx,
                     input_position_path,
                     output_position_path,
                     num_workers=slurm_args["slurm_cpus_per_task"],

--- a/biahub/deskew.py
+++ b/biahub/deskew.py
@@ -185,7 +185,6 @@ def _get_transform_matrix(ls_angle_deg: float, px_to_scan_ratio: float):
     ----------
     ls_angle_deg : float
     px_to_scan_ratio : float
-    keep_overhang : bool
 
     Returns
     -------
@@ -278,7 +277,7 @@ def get_deskewed_data_shape(
 def _fill_overhang_with_mean(
     data: np.ndarray,
     dilation_iterations: int = 3,
-    debug_plot_path: Path = None,
+    debug_plot_path: Path | None = None,
 ) -> np.ndarray:
     """Replace zero-padded overhang regions with the mean of the valid signal.
 
@@ -377,7 +376,7 @@ def deskew_zyx(
     device: str = "cpu",
     average_n_slices: int = 1,
     overhang_fill: Literal["zero", "mean"] = "zero",
-    debug_plot_path: Path = None,
+    debug_plot_path: Path | None = None,
 ) -> np.ndarray:
     """Deskews fluorescence data from the mantis microscope.
 
@@ -402,6 +401,12 @@ def deskew_zyx(
         after deskewing, averages every n slices (default = 1 applies no averaging)
     device : str, optional
         torch device to use for computation. Default is 'cpu'.
+    overhang_fill : "zero" or "mean", optional
+        How to fill overhang regions (only used when keep_overhang=True).
+        "mean" replaces with the mean of the valid signal, "zero" leaves the
+        zero-padded overhang as-is. Default is "zero".
+    debug_plot_path : Path, optional
+        If provided, saves a diagnostic figure showing the masks and result.
 
     Returns
     -------
@@ -637,10 +642,10 @@ def _init_output_plate(
 
 
 def deskew(
-    input_position_dirpaths: list[str],
+    input_position_dirpaths: list[Path],
     config_filepath: Path,
-    output_dirpath: str,
-    sbatch_filepath: str = None,
+    output_dirpath: Path,
+    sbatch_filepath: str | None = None,
     cluster: str = "slurm",
     monitor: bool = True,
     init_only: bool = False,
@@ -649,12 +654,12 @@ def deskew(
 
     Parameters
     ----------
-    input_position_dirpaths : list[str]
+    input_position_dirpaths : list[Path]
         Paths to input positions, for example: "input.zarr/0/0/0", "input.zarr/0/0/[0-9]",
         or "input.zarr/*/*/*".
     config_filepath : Path
         Path to YAML configuration file.
-    output_dirpath : str
+    output_dirpath : Path
         Path to "output.zarr" directory.
     sbatch_filepath : str, optional
         SBATCH filepath that contains slurm parameters to overwrite defaults.
@@ -761,10 +766,10 @@ def deskew(
 @monitor()
 @init_only()
 def deskew_cli(
-    input_position_dirpaths: list[str],
+    input_position_dirpaths: list[Path],
     config_filepath: Path,
-    output_dirpath: str,
-    sbatch_filepath: str = None,
+    output_dirpath: Path,
+    sbatch_filepath: str | None = None,
     cluster: str = "slurm",
     monitor: bool = False,
     init_only: bool = False,

--- a/biahub/flat_field.py
+++ b/biahub/flat_field.py
@@ -65,32 +65,6 @@ def _czyx_flat_field(czyx_data: np.ndarray, target_indices: list[int]) -> np.nda
     return out
 
 
-def _resolve_target_indices(
-    settings: FlatFieldCorrectionSettings,
-    all_channel_names: list[str],
-) -> list[int]:
-    """Resolve which channel indices to flat-field correct."""
-    if settings.channel_names is None:
-        target_channel_names = all_channel_names
-        click.echo(f"Flat fielding ALL channels: {all_channel_names}")
-    elif settings.channel_names:
-        for name in settings.channel_names:
-            if name not in all_channel_names:
-                raise click.ClickException(
-                    f"Channel '{name}' not found in input dataset. "
-                    f"Available channels: {all_channel_names}"
-                )
-        target_channel_names = settings.channel_names
-        click.echo(f"Input channels: {all_channel_names}")
-        click.echo(f"Flat field channels: {target_channel_names}")
-        click.echo("Other channels will be copied as-is")
-    else:
-        raise click.ClickException(
-            "Must specify either 'channel_names' or set channel_names to null in config."
-        )
-    return [all_channel_names.index(name) for name in target_channel_names]
-
-
 def _init_output_plate(
     input_position_dirpaths: list[Path],
     output_dirpath: Path,
@@ -124,11 +98,37 @@ def _init_output_plate(
     return (T, C, Z, Y, X), all_channel_names
 
 
+def _resolve_target_indices(
+    settings: FlatFieldCorrectionSettings,
+    all_channel_names: list[str],
+) -> list[int]:
+    """Resolve which channel indices to flat-field correct."""
+    if settings.channel_names is None:
+        target_channel_names = all_channel_names
+        click.echo(f"Flat fielding ALL channels: {all_channel_names}")
+    elif settings.channel_names:
+        for name in settings.channel_names:
+            if name not in all_channel_names:
+                raise click.ClickException(
+                    f"Channel '{name}' not found in input dataset. "
+                    f"Available channels: {all_channel_names}"
+                )
+        target_channel_names = settings.channel_names
+        click.echo(f"Input channels: {all_channel_names}")
+        click.echo(f"Flat field channels: {target_channel_names}")
+        click.echo("Other channels will be copied as-is")
+    else:
+        raise click.ClickException(
+            "Must specify either 'channel_names' or set channel_names to null in config."
+        )
+    return [all_channel_names.index(name) for name in target_channel_names]
+
+
 def flat_field(
-    input_position_dirpaths: list[str],
+    input_position_dirpaths: list[Path],
     config_filepath: Path,
-    output_dirpath: str,
-    sbatch_filepath: str = None,
+    output_dirpath: Path,
+    sbatch_filepath: str | None = None,
     cluster: str = "slurm",
     monitor: bool = True,
     init_only: bool = False,
@@ -137,11 +137,11 @@ def flat_field(
 
     Parameters
     ----------
-    input_position_dirpaths : list[str]
+    input_position_dirpaths : list[Path]
         Paths to the input position directories.
     config_filepath : Path
         Path to the configuration file.
-    output_dirpath : str
+    output_dirpath : Path
         Path to the output directory.
     sbatch_filepath : str, optional
         Path to the SLURM batch file.
@@ -161,7 +161,6 @@ def flat_field(
         input_position_dirpaths, output_dirpath, settings
     )
 
-    T, C, Z, Y, X = input_shape
     num_cpus, gb_ram_per_cpu = estimate_resources(
         shape=input_shape, ram_multiplier=8, max_num_cpus=16
     )
@@ -185,9 +184,9 @@ def flat_field(
         "slurm_job_name": "flat-field",
         "slurm_mem": f"{mem_gb}G",
         "slurm_cpus_per_task": num_cpus,
-        "slurm_array_parallelism": 100,
+        "slurm_array_parallelism": 100,  # process up to 100 positions at a time
         "slurm_time": time_minutes,
-        "slurm_partition": "cpu",
+        "slurm_partition": "preempted",
     }
 
     if sbatch_filepath:
@@ -210,7 +209,7 @@ def flat_field(
                     _czyx_flat_field,
                     input_position_path,
                     output_position_path,
-                    num_workers=int(slurm_args["slurm_cpus_per_task"]),
+                    num_workers=slurm_args["slurm_cpus_per_task"],
                     **flat_field_args,
                 )
             )
@@ -243,11 +242,11 @@ def flat_field(
 @cluster()
 @monitor()
 @init_only()
-def flat_field_correction_cli(
-    input_position_dirpaths: list[str],
+def flat_field_cli(
+    input_position_dirpaths: list[Path],
     config_filepath: Path,
-    output_dirpath: str,
-    sbatch_filepath: str = None,
+    output_dirpath: Path,
+    sbatch_filepath: str | None = None,
     cluster: str = "slurm",
     monitor: bool = False,
     init_only: bool = False,
@@ -278,4 +277,4 @@ def flat_field_correction_cli(
 
 
 if __name__ == "__main__":
-    flat_field_correction_cli()
+    flat_field_cli()

--- a/biahub/flat_field.py
+++ b/biahub/flat_field.py
@@ -1,3 +1,5 @@
+import warnings
+
 from pathlib import Path
 
 import click
@@ -29,7 +31,7 @@ from biahub.cli.utils import (
 from biahub.settings import FlatFieldCorrectionSettings
 
 
-def flat_field_correction(zyx_data: np.ndarray, axis: int = 0) -> np.ndarray:
+def flat_field_zyx(zyx_data: np.ndarray, axis: int = 0) -> np.ndarray:
     """Apply flat field correction by dividing out the median pattern along an axis.
 
     Parameters
@@ -49,7 +51,34 @@ def flat_field_correction(zyx_data: np.ndarray, axis: int = 0) -> np.ndarray:
     return zyx_data / static_pattern * static_pattern.mean()
 
 
-def _czyx_flat_field(czyx_data: np.ndarray, target_indices: list[int]) -> np.ndarray:
+def flat_field_correction(zyx_data: np.ndarray, axis: int = 0) -> np.ndarray:
+    """Apply flat field correction (deprecated alias for :func:`flat_field_zyx`).
+
+    .. deprecated::
+        Renamed to :func:`flat_field_zyx` to follow the ``<verb>_zyx`` layer-1
+        naming convention. This alias will be removed in a future release.
+
+    Parameters
+    ----------
+    zyx_data : np.ndarray
+        The data to apply flat field correction to.
+    axis : int
+        The axis to compute the median along.
+
+    Returns
+    -------
+    np.ndarray
+        Flat-field corrected data (see :func:`flat_field_zyx`).
+    """
+    warnings.warn(
+        "flat_field_correction is deprecated; use flat_field_zyx instead.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    return flat_field_zyx(zyx_data, axis=axis)
+
+
+def _flat_field_czyx(czyx_data: np.ndarray, target_indices: list[int]) -> np.ndarray:
     """Apply flat-field correction to selected channels of a CZYX volume.
 
     Channels listed in ``target_indices`` are corrected; the rest are
@@ -59,7 +88,7 @@ def _czyx_flat_field(czyx_data: np.ndarray, target_indices: list[int]) -> np.nda
     target = set(target_indices)
     for c in range(czyx_data.shape[0]):
         if c in target:
-            out[c] = flat_field_correction(czyx_data[c])
+            out[c] = flat_field_zyx(czyx_data[c])
         else:
             out[c] = czyx_data[c].astype(np.float32)
     return out
@@ -206,7 +235,7 @@ def flat_field(
             jobs.append(
                 executor.submit(
                     process_single_position,
-                    _czyx_flat_field,
+                    _flat_field_czyx,
                     input_position_path,
                     output_position_path,
                     num_workers=slurm_args["slurm_cpus_per_task"],

--- a/biahub/reconstruct.py
+++ b/biahub/reconstruct.py
@@ -28,9 +28,9 @@ def reconstruct_cli(
     input_position_dirpaths: list[Path],
     config_filepath: Path,
     output_dirpath: Path,
-    sbatch_filepath: Path,
-    cluster: str,
-    monitor: bool = True,
+    sbatch_filepath: str | None = None,
+    cluster: str = "slurm",
+    monitor: bool = False,
 ):
     """Reconstruct a dataset using a configuration file.
 
@@ -44,8 +44,9 @@ def reconstruct_cli(
 
     See https://github.com/mehta-lab/waveorder/tree/main/docs/examples for example configuration files.
 
+    \b
     >>> biahub reconstruct -i ./input.zarr/*/*/* -c ./examples/birefringence.yml -o ./output.zarr
-    """
+    """  # noqa: D301
     # glob all positions in input_position_dirpaths
 
     # Handle transfer function path

--- a/biahub/virtual_stain.py
+++ b/biahub/virtual_stain.py
@@ -1,3 +1,4 @@
+import json
 import time
 
 from pathlib import Path
@@ -232,6 +233,7 @@ def _init_output_plate(
     output_dirpath: Path,
     target_channels: list[str],
     output_ome_zarr_version: str | None = None,
+    extra_metadata: dict | None = None,
 ) -> tuple[int, int, int, int, int]:
     """Create (or extend) the empty virtual-stain output plate.
 
@@ -241,6 +243,10 @@ def _init_output_plate(
 
     ``output_ome_zarr_version`` dictates the output store's OME-Zarr version;
     when None the input store's version is preserved.
+
+    Each key of ``extra_metadata`` is written as a top-level zattr on every
+    output position (mirroring ``process_single_position``), recording
+    provenance such as the validated predict config.
 
     Returns the input ``(T, C, Z, Y, X)`` shape.
     """
@@ -258,14 +264,23 @@ def _init_output_plate(
         version=resolve_ome_zarr_version(input_position_dirpaths[0], output_ome_zarr_version),
     )
 
+    if extra_metadata:
+        for input_position_dirpath in input_position_dirpaths:
+            position_key = Path(input_position_dirpath).parts[-3:]
+            with open_ome_zarr(
+                str(Path(output_dirpath).joinpath(*position_key)), mode="r+"
+            ) as output_position:
+                for key, value in extra_metadata.items():
+                    output_position.zattrs[key] = value
+
     return (T, C, Z, Y, X)
 
 
 def virtual_stain(
-    input_position_dirpaths: list[str],
+    input_position_dirpaths: list[Path],
     config_filepath: Path,
-    output_dirpath: str,
-    sbatch_filepath: str = None,
+    output_dirpath: Path,
+    sbatch_filepath: str | None = None,
     cluster: str = "slurm",
     monitor: bool = True,
     init_only: bool = False,
@@ -279,11 +294,11 @@ def virtual_stain(
 
     Parameters
     ----------
-    input_position_dirpaths : list[str]
+    input_position_dirpaths : list[Path]
         Input position directory paths.
     config_filepath : Path
         Path to the VisCy-style predict config.
-    output_dirpath : str
+    output_dirpath : Path
         Output plate path.
     sbatch_filepath : str, optional
         SBATCH file overriding default SLURM parameters.
@@ -315,17 +330,25 @@ def virtual_stain(
 
     # Validate the config against VisCy's schema up front (using the first
     # position for data_path) and read the predicted channel names.
-    _, cfg = load_predict_config(config_filepath, input_position_dirpaths[0])
+    parser, cfg = load_predict_config(config_filepath, input_position_dirpaths[0])
     target_channels = cfg.data.init_args.target_channel
     target_channels = (
         [target_channels] if isinstance(target_channels, str) else target_channels
     )
+
+    # Record the validated predict config (VisCy jsonargparse namespace dumped to
+    # a JSON-serializable dict) as provenance on each output position. Drop the
+    # per-position data_path biahub injected for submit-time validation; it is
+    # not part of the config the user supplied.
+    config_metadata = json.loads(parser.dump(cfg, format="json"))
+    config_metadata.get("data", {}).get("init_args", {}).pop("data_path", None)
 
     input_shape = _init_output_plate(
         input_position_dirpaths,
         output_dirpath,
         target_channels,
         cfg.output_ome_zarr_version,
+        extra_metadata={"cytoland": config_metadata},
     )
 
     # Timepoints are processed sequentially on a single GPU, so resource needs
@@ -384,7 +407,7 @@ def virtual_stain(
 
     job_ids = [job.job_id for job in jobs]  # Access job IDs after batch submission
 
-    slurm_out_path.mkdir(parents=True, exist_ok=True)
+    slurm_out_path.mkdir(exist_ok=True)
     log_path = Path(slurm_out_path / "submitit_jobs_ids.log")
     with log_path.open("w") as log_file:
         log_file.write("\n".join(job_ids))
@@ -412,10 +435,10 @@ def virtual_stain(
 @monitor()
 @init_only()
 def virtual_stain_cli(
-    input_position_dirpaths: list[str],
+    input_position_dirpaths: list[Path],
     config_filepath: Path,
-    output_dirpath: str,
-    sbatch_filepath: str = None,
+    output_dirpath: Path,
+    sbatch_filepath: str | None = None,
     cluster: str = "slurm",
     monitor: bool = False,
     init_only: bool = False,

--- a/nextflow/mantis-v2.nf
+++ b/nextflow/mantis-v2.nf
@@ -7,7 +7,8 @@ nextflow.enable.dsl = 2
 //
 //  This file is the ORCHESTRATION layer. It owns two things the step modules
 //  must not know about:
-//    1. the directory LAYOUT (the DIRECTORY_LAYOUT map below), and
+//    1. the directory LAYOUT (the DIRECTORY_LAYOUT map returned by
+//       directory_layout() below), and
 //    2. the ORDER steps run in and what each step reads/writes.
 //
 //  Each step's subworkflow (e.g. deskew_wf) is path-agnostic and speaks only in
@@ -41,15 +42,22 @@ include { virtual_stain_wf } from './modules/virtual_stain'
 // writes its <dataset>.zarr. The pipeline's raw input/output live in the
 // workflow body, not here (input may not even be a zarr). A Dragonfly pipeline
 // would define its own map; reordering or renaming a step is a one-line edit.
-DIRECTORY_LAYOUT = [
-    // convert    : '0-convert',     // first step when raw input isn't zarr
-    flat_field    : '0-flatfield',
-    deskew        : '1-deskew',
-    reconstruct   : '2-reconstruct',
-    virtual_stain : '3-virtual-stain',
-    // track         : '4-track',
-    // assemble      : '5-assemble',
-]
+//
+// Defined as a function rather than a bare top-level assignment: Nextflow's DSL2
+// parser only allows declarations (include/process/workflow/function) at script
+// scope, so a `DIRECTORY_LAYOUT = [...]` statement fails to compile. The workflow
+// body calls directory_layout() once to get the map.
+def directory_layout() {
+    return [
+        // convert    : '0-convert',     // first step when raw input isn't zarr
+        flat_field    : '0-flatfield',
+        deskew        : '1-deskew',
+        reconstruct   : '2-reconstruct',
+        virtual_stain : '3-virtual-stain',
+        // track         : '4-track',
+        // assemble      : '5-assemble',
+    ]
+}
 
 
 workflow {
@@ -60,8 +68,9 @@ workflow {
     if (!params.reconstruct_config) error "Provide --reconstruct_config"
     if (!params.virtual_stain_config) error "Provide --virtual_stain_config"
 
-    def ds  = dataset_name()
-    def out = params.output
+    def ds     = dataset_name()
+    def out    = params.output
+    def layout = directory_layout()
 
     collect_positions(params.input)
     all_positions = collect_positions.out
@@ -73,7 +82,7 @@ workflow {
     // doesn't care where its input comes from.
     ff_trigger = Channel.value(true)
     ff_input  = params.input
-    ff_output = "${out}/${DIRECTORY_LAYOUT.flat_field}/${ds}.zarr"
+    ff_output = "${out}/${layout.flat_field}/${ds}.zarr"
 
     ff_done = flat_field_wf(all_positions, ff_input, ff_output, params.flat_field_config, ff_trigger)
 
@@ -81,7 +90,7 @@ workflow {
     // Deskew reads flat-field's output and waits on ff_done before starting.
     deskew_trigger = ff_done.done
     deskew_input  = ff_output
-    deskew_output = "${out}/${DIRECTORY_LAYOUT.deskew}/${ds}.zarr"
+    deskew_output = "${out}/${layout.deskew}/${ds}.zarr"
 
     deskew_done = deskew_wf(all_positions, deskew_input, deskew_output, params.deskew_config, deskew_trigger)
 
@@ -91,7 +100,7 @@ workflow {
     // is set by `input_channel_names` in the reconstruct config, not here.
     reconstruct_trigger = deskew_done.done
     reconstruct_input   = deskew_output
-    reconstruct_output  = "${out}/${DIRECTORY_LAYOUT.reconstruct}/${ds}.zarr"
+    reconstruct_output  = "${out}/${layout.reconstruct}/${ds}.zarr"
 
     reconstruct_done = reconstruct_wf(all_positions, reconstruct_input, reconstruct_output, params.reconstruct_config, reconstruct_trigger)
 
@@ -103,7 +112,7 @@ workflow {
     // here.
     virtual_stain_trigger = reconstruct_done.done
     virtual_stain_input   = reconstruct_output
-    virtual_stain_output  = "${out}/${DIRECTORY_LAYOUT.virtual_stain}/${ds}.zarr"
+    virtual_stain_output  = "${out}/${layout.virtual_stain}/${ds}.zarr"
 
     virtual_stain_done = virtual_stain_wf(all_positions, virtual_stain_input, virtual_stain_output, params.virtual_stain_config, virtual_stain_trigger)
 }

--- a/nextflow/nextflow.config
+++ b/nextflow/nextflow.config
@@ -56,16 +56,14 @@ process {
         cpus   = 1
         memory = '8 GB'
     }
-    withLabel: 'cpu' {
-        cpus   = 4
-        memory = '32 GB'
-        time   = '2h'
-    }
-    withLabel: 'gpu' {
-        cpus   = 16
-        memory = '64 GB'
-        time   = '8h'
-    }
+
+    // NOTE: labels 'cpu' and 'gpu' intentionally have NO withLabel body here.
+    // Each module sets cpus/memory/time in its own process body (dynamically from
+    // the init step's RESOURCES payload). A withLabel selector in config overrides
+    // process-body directives, so defining resources here would clobber the
+    // per-position sizing and under-provision the SLURM job (e.g. flat-field's
+    // 16-worker pool OOM-killed inside a 32 GB default). The labels are still used
+    // by the slurm profile below to route each process to its partition.
 }
 
 // Execution profiles select WHERE work runs. The actual per-position resource
@@ -73,8 +71,11 @@ process {
 // init step's RESOURCES payload); the `withLabel` blocks above are the defaults
 // for local runs. A profile overrides the executor and, under SLURM, the
 // partition each label maps to. NOTE: a `withLabel` block inside a profile
-// REPLACES (does not deep-merge with) the same-named block in the base `process`
-// block, so each override below restates the directives it needs.
+// DEEP-MERGES with the same-named block in the base `process` block — it does
+// NOT replace it. Directives the profile restates win; directives it omits are
+// inherited from the base block. So a profile only needs to state what differs
+// (e.g. `queue`, or `executor = 'local'` to override the profile's slurm
+// default), and any base directive it leaves out still applies.
 profiles {
     // Run everything on the local executor (the process-block default). Useful
     // for single-node or debug runs.


### PR DESCRIPTION
Closes #268
Closes #155

## Motivation

biahub commands have drifted in structure and style over time — inconsistent function layering, type hints that don't match the option callbacks, ad-hoc SLURM args, missing provenance metadata, and naming that doesn't line up across the module/CLI/command.

This PR adds a **`biahub-cli-consistency` Claude skill** that standardizes the structure of CLI calls **while still allowing exceptions on a case-by-case basis**. The goal is not a rigid one-size-fits-all template: the skill encodes a canonical structure, but explicitly records *why* a given command is allowed to deviate (e.g. `apply-inv-tf` omits the biahub provenance block because waveorder already writes the equivalent metadata; `virtual-stain` uses a bespoke per-position GPU path instead of `process_single_position`). It reviews and reports — it never edits — so a human stays in the loop on every exception.

## What's in the skill

`.claude/skills/biahub-cli-consistency/`
- **`SKILL.md`** — the reviewer procedure, checklist, and findings-report format.
- **`references/canonical-cli.md`** — the canonical module structure: the three function layers (`<verb>_zyx()` array-in/array-out → `_<verb>_czyx()` multiprocessing wrapper → `<verb>()` API function operating on zarr stores → `<verb>_cli()` thin click wrapper), the name triad, the authoritative *Option → runtime type* table derived from `biahub/cli/parsing.py`, orchestrator body order, decorator stack, and SLURM args.
- **`references/known-inconsistencies.md`** — the concrete open defects in the reference commands, used as a calibration set, each tagged `Auto-fix: safe` or `needs review`.

Key rules it enforces (each with documented exceptions):
- Every command has a **layer-2 API function** (`deskew`, `flat_field`, …) separate from its `_cli`.
- **Array-in/array-out** compute functions (`deskew_zyx`, `flat_field_zyx`) are required only for numerics *internal* to biahub; commands backed by an external library (waveorder, cytoland) are exempt.
- **Type hints match `parsing.py`** exactly (e.g. `input_position_dirpaths: list[Path]`, un-callbacked `click.Path` → `str | None`).
- **Provenance** (`extra_metadata={"biahub-<verb>": settings.model_dump()}`) is required unless a delegated library writes it (only `apply-inv-tf` today).
- `slurm_partition` is `"preempted"` by default; anything else is flagged.

## How to use the skill

The skill **reviews and reports only**; a second agent applies the fixes, so exceptions are approved explicitly rather than applied silently.

1. **Review** — invoke the skill on a target:
   ```
   /biahub-cli-consistency review biahub/<command>.py
   ```
   (or "audit all processing CLIs"). It reads the canonical references, cross-checks `parsing.py` and `main.py`, and returns a per-file findings report — each finding anchored to `file:line` with a category, the canonical rule, a concrete fix, and an `Auto-fix: safe | needs review` tag. Nothing is edited.

2. **Triage** — decide which findings to apply. This is where exceptions are granted: e.g. "apply all `safe` fixes, skip the rename", or "leave virtual-stain's GPU partition as-is — here's why". Provide any input the `needs review` items require (provenance key, parallelism cap, …).

3. **Fix** — dispatch a **separate** agent with the approved findings, instructed to change only those items and then run `make format && make lint && make test`.

4. **Verify** — re-run the skill on the changed files to confirm the defect is gone and nothing new drifted.

> If `/biahub-cli-consistency` doesn't autocomplete, restart the CLI so Claude Code rediscovers `.claude/skills/`; invoking it by natural language also works.

## Commands standardized so far

Using this workflow, the following CLIs were brought onto the canonical structure in this PR:

- `deskew`
- `flat-field`
- `apply-inv-tf`
- `virtual-stain`
- `reconstruct`
