### PR TITLE
perf(tests): run processing serially in CI to cut test runtime ~4x

### DIFF
--- a/biahub/cli/utils.py
+++ b/biahub/cli/utils.py
@@ -410,7 +410,9 @@ def estimate_resources(
 
     T, C, Z, Y, X = shape
     gb_per_element = np.dtype(dtype).itemsize / 2**30  # bytes_per_element / bytes_per_gb
-    num_cpus = min(T * C, max_num_cpus)
+    # In CI/tests, run serially: the test data is tiny, so spawning a worker
+    # pool costs far more (per-process re-imports) than the work itself.
+    num_cpus = 1 if os.environ.get("CI") == "true" else min(T * C, max_num_cpus)
     gb_ram_per_volume = Z * Y * X * gb_per_element
     gb_ram_per_cpu = np.ceil(max(min_ram_per_cpu, gb_ram_per_volume * ram_multiplier))
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -139,3 +139,9 @@ docstring-code-format = true
 [tool.pytest.ini_options]
 addopts = ["--import-mode=importlib"]
 testpaths = ["tests"]
+filterwarnings = [
+    # higra (transitive via ultrack) ships math docstrings with unescaped
+    # backslashes, which Python >=3.12 flags as SyntaxWarning on import. Not
+    # fixable on our end (0.6.13 is the latest release); silence the noise.
+    "ignore:invalid escape sequence:SyntaxWarning",
+]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,7 +4,7 @@ import numpy as np
 import pytest
 import yaml
 
-from iohub.ngff import open_ome_zarr
+from iohub.ngff import TransformationMeta, open_ome_zarr
 
 # Use submitit debug executor (in-process, no forking) for fast tests
 os.environ["CI"] = "true"
@@ -151,9 +151,16 @@ def example_plate(tmp_path):
         channel_names=["GFP", "RFP", "Phase3D", "Orientation", "Retardance", "Birefringence"],
     )
 
+    # Lateral pixel size matches example_deskew_settings.yml (pixel_size_um:
+    # 0.116) so deskew doesn't warn about a config/metadata scale mismatch.
+    scale = (1, 1, 1.0, 0.116, 0.116)
     for row, col, fov in position_list:
         position = plate_dataset.create_position(row, col, fov)
-        position["0"] = np.random.uniform(0.0, 255.0, size=(3, 6, 4, 5, 6)).astype(np.float32)
+        position.create_image(
+            "0",
+            np.random.uniform(0.0, 255.0, size=(3, 6, 4, 5, 6)).astype(np.float32),
+            transform=[TransformationMeta(type="scale", scale=scale)],
+        )
 
     yield plate_path, plate_dataset
 

--- a/tests/test_cli/test_deskew_cli.py
+++ b/tests/test_cli/test_deskew_cli.py
@@ -5,6 +5,7 @@ from click.testing import CliRunner
 
 from biahub import deskew
 from biahub.cli.main import cli
+from biahub.cli.utils import estimate_resources
 
 
 def test_average_n_slices():
@@ -136,6 +137,51 @@ def test_deskew_cli_debug_single_position(tmp_path, example_plate, example_deske
     assert result.exit_code == 0, result.output
     assert output_path.exists()
     assert "Deskew complete:" in result.output
+
+
+def test_deskew_cli_multiprocess(
+    tmp_path, example_plate, example_deskew_settings, monkeypatch
+):
+    """Integration test of the real production path: deskew with num_cpus > 1.
+
+    The suite forces ``num_cpus=1`` in CI (see ``estimate_resources``) so tests
+    don't pay the ProcessPoolExecutor spawn cost. This test drops the ``CI`` flag
+    so deskew runs through the genuine multi-worker path, guarding against
+    regressions that the serial fast-path would otherwise hide (e.g. failures in
+    worker spawning or pickling of the per-position work).
+    """
+    monkeypatch.delenv("CI", raising=False)
+
+    plate_path, _ = example_plate
+    config_path, _ = example_deskew_settings
+    output_path = tmp_path / "output.zarr"
+
+    # With CI unset, the example plate (T*C = 3*6) resolves to more than one
+    # worker, so the run genuinely spawns a process pool.
+    num_cpus, _ = estimate_resources(shape=(3, 6, 4, 5, 6), ram_multiplier=8, max_num_cpus=16)
+    assert num_cpus > 1
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        [
+            "deskew",
+            "-i",
+            str(plate_path) + "/A/1/0",
+            "-c",
+            str(config_path),
+            "-o",
+            str(output_path),
+            "--cluster",
+            "debug",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert output_path.exists()
+    assert "Deskew complete:" in result.output
+    # Confirm the real multi-worker path ran, not the serial fallback.
+    assert "multiprocess pool" in result.output
 
 
 def test_deskew_overhang_only_dataset_error():

--- a/tests/test_cli/test_reconstruct_cli.py
+++ b/tests/test_cli/test_reconstruct_cli.py
@@ -3,7 +3,7 @@ import pytest
 import yaml
 
 from click.testing import CliRunner
-from iohub.ngff import open_ome_zarr
+from iohub.ngff import TransformationMeta, open_ome_zarr
 
 from biahub.cli.main import cli
 
@@ -52,7 +52,13 @@ def reconstruct_plate(tmp_path):
 
     for row, col, fov in position_list:
         position = plate.create_position(row, col, fov)
-        position["0"] = np.random.uniform(1.0, 100.0, size=(1, 1, 5, 8, 8)).astype(np.float32)
+        # Match the pixel sizes declared in reconstruct_config so waveorder
+        # doesn't emit a PixelSizeMismatchWarning during reconstruction.
+        position.create_image(
+            "0",
+            np.random.uniform(1.0, 100.0, size=(1, 1, 5, 8, 8)).astype(np.float32),
+            transform=[TransformationMeta(type="scale", scale=(1, 1, 0.25, 0.1, 0.1))],
+        )
 
     plate.close()
     return plate_path

--- a/tests/test_cli/test_track_cli.py
+++ b/tests/test_cli/test_track_cli.py
@@ -97,7 +97,6 @@ def test_track_cli_local(
         f.write("#SBATCH --array-parallelism=1\n")  # Force only 1 job at a time
         f.write("#LOCAL --cpus-per-task=1\n")
         f.write("#LOCAL --timeout-min=5\n")
-        f.write("#LOCAL --array-parallelism=1\n")  # Force local to use only 1 process
 
     plate_path, _ = example_tracking_plate
     config_path, _ = example_track_settings


### PR DESCRIPTION
## Summary

The local/CI test suite runs in **~113s** (2m3s wall), despite the test data being tiny (`(3,6,4,5,6)` arrays, a few hundred voxels). The cost is not compute — it's **process-pool spawn overhead**.

Each CLI test runs its per-position work through iohub's `process_single_position`, which fans out `(time, channel)` chunks via a `spawn`-based `ProcessPoolExecutor`. The worker count comes from `estimate_resources()`:

```python
num_cpus = min(T * C, max_num_cpus)   # = min(3*6, 16) = 16 for the test plate
```

So a test processing ~18 trivial chunks spawns **16 fresh Python processes**, and — because it's `spawn`, not `fork` — every worker **re-imports the whole torch/iohub/waveorder stack (~8s each)**. The `CI=debug` submitit optimization only collapses the outer (position) layer; it does nothing for this inner pool.

This lines up with the measured durations — the slow tests are exactly the ones that split into many fine-grained tasks (deskew alone was ~42s), while `concatenate` was already fast because it passes one coarse chunk and runs serially.

## Fix

Return `num_cpus=1` when `CI=true` (already set for every run in `tests/conftest.py`), forcing serial in-process execution:

```python
num_cpus = 1 if os.environ.get("CI") == "true" else min(T * C, max_num_cpus)
```

Output is identical (serial vs parallel produces the same result); production behavior (env unset) is unchanged. This is the single chokepoint feeding `num_cpus → slurm_cpus_per_task → num_workers`, so one line covers deskew, flat_field, process_data, segment, register, stabilize, concatenate, and track.

## Integration test

Added `test_deskew_cli_multiprocess`, which drops the `CI` flag via `monkeypatch.delenv` so deskew runs through the **genuine multi-worker path** (asserts `num_cpus > 1` and that a `"multiprocess pool"` actually starts). This guards against regressions the serial fast-path would otherwise hide (e.g. worker spawning or pickling of the per-position work).

## Results

| | Baseline | This PR |
|---|---|---|
| pytest wall | 113s | **~29s** |
| `user` CPU time | 10m53s | **2m41s** |
| `test_deskew_cli` | 31.9s | 0.38s |
| result | 107 passed, 1 skipped | **108 passed, 1 skipped** |

(The suite is ~29s rather than ~19s because the new integration test deliberately spends ~10s exercising the real process pool.)

## Notes

- Works for local runs too, precisely because `tests/conftest.py` sets `os.environ["CI"]="true"` at import — every local `pytest` is treated as CI.
- One test is not accelerated: `test_apply_inv_tf_cli_debug_single_position` (~3.4s) uses waveorder's `wo_estimate_resources`, not this function — out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)