### PR TITLE
refactor: Single-shot concatenate on a reserved compute node (mantis-v2 assemble)

### DIFF
--- a/biahub/cli/utils.py
+++ b/biahub/cli/utils.py
@@ -379,6 +379,7 @@ def estimate_resources(
     dtype: DTypeLike = np.float32,
     ram_multiplier: float = 1.0,
     max_num_cpus: int = 64,
+    min_num_cpus: int = 1,
     min_ram_per_cpu: int = 4,
 ):
     """
@@ -396,6 +397,9 @@ def estimate_resources(
         should be at least 3. Default is 1.0.
     max_num_cpus : int, optional
         Maximum number of available CPUs. Default is 64.
+    min_num_cpus : int, optional
+        Minimum number of CPUs to request (ignored in CI, which runs serially).
+        Default is 1.
     min_ram_per_cpu : int, optional
         Minimum amount of RAM per CPU in GB. Default is 4.
 
@@ -412,7 +416,9 @@ def estimate_resources(
     gb_per_element = np.dtype(dtype).itemsize / 2**30  # bytes_per_element / bytes_per_gb
     # In CI/tests, run serially: the test data is tiny, so spawning a worker
     # pool costs far more (per-process re-imports) than the work itself.
-    num_cpus = 1 if os.environ.get("CI") == "true" else min(T * C, max_num_cpus)
+    num_cpus = (
+        1 if os.environ.get("CI") == "true" else min(max(min_num_cpus, T * C), max_num_cpus)
+    )
     gb_ram_per_volume = Z * Y * X * gb_per_element
     gb_ram_per_cpu = np.ceil(max(min_ram_per_cpu, gb_ram_per_volume * ram_multiplier))
 

--- a/biahub/cli/utils.py
+++ b/biahub/cli/utils.py
@@ -379,7 +379,6 @@ def estimate_resources(
     dtype: DTypeLike = np.float32,
     ram_multiplier: float = 1.0,
     max_num_cpus: int = 64,
-    min_num_cpus: int = 1,
     min_ram_per_cpu: int = 4,
 ):
     """
@@ -397,9 +396,6 @@ def estimate_resources(
         should be at least 3. Default is 1.0.
     max_num_cpus : int, optional
         Maximum number of available CPUs. Default is 64.
-    min_num_cpus : int, optional
-        Minimum number of CPUs to request (ignored in CI, which runs serially).
-        Default is 1.
     min_ram_per_cpu : int, optional
         Minimum amount of RAM per CPU in GB. Default is 4.
 
@@ -416,9 +412,7 @@ def estimate_resources(
     gb_per_element = np.dtype(dtype).itemsize / 2**30  # bytes_per_element / bytes_per_gb
     # In CI/tests, run serially: the test data is tiny, so spawning a worker
     # pool costs far more (per-process re-imports) than the work itself.
-    num_cpus = (
-        1 if os.environ.get("CI") == "true" else min(max(min_num_cpus, T * C), max_num_cpus)
-    )
+    num_cpus = 1 if os.environ.get("CI") == "true" else min(T * C, max_num_cpus)
     gb_ram_per_volume = Z * Y * X * gb_per_element
     gb_ram_per_cpu = np.ceil(max(min_ram_per_cpu, gb_ram_per_volume * ram_multiplier))
 

--- a/biahub/concatenate.py
+++ b/biahub/concatenate.py
@@ -457,10 +457,7 @@ def concatenate(
     T, C, Z, Y, X = prep["shape"]
     batch_size = settings.shards_ratio[0] if settings.shards_ratio else 1
     num_cpus, gb_ram_per_cpu = estimate_resources(
-        shape=(T // batch_size, C, Z, Y, X),
-        ram_multiplier=4 * batch_size,
-        max_num_cpus=16,
-        min_num_cpus=8,
+        shape=(T // batch_size, C, Z, Y, X), ram_multiplier=4 * batch_size, max_num_cpus=16
     )
     mem_gb = num_cpus * gb_ram_per_cpu
     time_minutes = 60

--- a/biahub/concatenate.py
+++ b/biahub/concatenate.py
@@ -14,6 +14,7 @@ from biahub.cli.monitor import monitor_jobs
 from biahub.cli.parsing import (
     cluster,
     config_filepath,
+    init_only,
     monitor,
     output_dirpath,
     sbatch_filepath,
@@ -281,12 +282,13 @@ def _resolve_time_indices(settings: ConcatenateSettings, all_shapes: list[tuple]
 
 
 def _prepare_concatenate(settings: ConcatenateSettings, output_dirpath: Path) -> dict:
-    """Derive metadata, create the output plate, and estimate SLURM resources.
+    """Derive metadata and create the output plate.
 
-    Shared by ``--init`` and the full run so the channel/slice metadata (and the
-    expensive ``get_channel_combiner_metadata`` call) is computed exactly once per
-    invocation. Creates the output plate, emits the RESOURCES line, and returns
-    everything the submit loop needs.
+    Runs the channel/slice metadata resolution (the expensive
+    ``get_channel_combiner_metadata`` call), creates the output plate, and
+    returns everything the submit loop needs plus the input ``shape`` used by
+    ``concatenate`` to estimate SLURM resources. ``create_empty_plate`` is
+    idempotent, so calling this from both ``--init`` and the full run is safe.
     """
     slicing_params = [settings.Z_slice, settings.Y_slice, settings.X_slice]
     (
@@ -382,13 +384,6 @@ def _prepare_concatenate(settings: ConcatenateSettings, output_dirpath: Path) ->
     )
     click.echo(f"Created {output_dirpath} ({len(output_position_paths)} positions)")
 
-    batch_size = settings.shards_ratio[0] if settings.shards_ratio else 1
-    num_cpus, gb_ram_per_cpu = estimate_resources(
-        shape=(T // batch_size, C, Z, Y, X), ram_multiplier=4 * batch_size, max_num_cpus=16
-    )
-    time_minutes = 60
-    echo_resources(num_cpus, num_cpus * gb_ram_per_cpu, time_minutes=time_minutes)
-
     return {
         "all_data_paths": all_data_paths,
         "output_position_paths": output_position_paths,
@@ -396,9 +391,7 @@ def _prepare_concatenate(settings: ConcatenateSettings, output_dirpath: Path) ->
         "output_channel_idx_list": output_channel_idx_list,
         "all_slicing_params": all_slicing_params,
         "input_time_indices": input_time_indices,
-        "num_cpus": num_cpus,
-        "gb_ram_per_cpu": gb_ram_per_cpu,
-        "time_minutes": time_minutes,
+        "shape": (T, C, Z, Y, X),
     }
 
 
@@ -422,6 +415,7 @@ def concatenate(
     cluster: str = "slurm",
     block: bool = False,
     monitor: bool = True,
+    init_only: bool = False,
 ):
     """Concatenate datasets (with optional cropping).
 
@@ -442,19 +436,34 @@ def concatenate(
         by default False
     monitor : bool, optional
         Whether to monitor the jobs, by default True
+    init_only : bool, optional
+        Only create the output store and emit RESOURCES, then exit; skip the
+        per-position copy. By default False.
     """
     slurm_out_path = output_dirpath.parent / "slurm_output"
 
     prep = _prepare_concatenate(settings, output_dirpath)
     input_time_indices = prep["input_time_indices"]
 
+    T, C, Z, Y, X = prep["shape"]
+    batch_size = settings.shards_ratio[0] if settings.shards_ratio else 1
+    num_cpus, gb_ram_per_cpu = estimate_resources(
+        shape=(T // batch_size, C, Z, Y, X), ram_multiplier=4 * batch_size, max_num_cpus=16
+    )
+    mem_gb = num_cpus * gb_ram_per_cpu
+    time_minutes = 60
+    echo_resources(num_cpus, mem_gb, time_minutes=time_minutes)
+
+    if init_only:
+        return
+
     # Prepare SLURM arguments
     slurm_args = {
         "slurm_job_name": "concatenate",
-        "slurm_mem": f"{prep['num_cpus'] * prep['gb_ram_per_cpu']}G",
-        "slurm_cpus_per_task": prep["num_cpus"],
+        "slurm_mem": f"{mem_gb}G",
+        "slurm_cpus_per_task": num_cpus,
         "slurm_array_parallelism": 100,  # process up to 100 positions at a time
-        "slurm_time": prep["time_minutes"],
+        "slurm_time": time_minutes,
         "slurm_partition": "preempted",
     }
 
@@ -530,6 +539,7 @@ def concatenate(
 @sbatch_filepath()
 @cluster()
 @monitor()
+@init_only()
 @click.option(
     "--resolve-config",
     "resolve_config_mode",
@@ -549,6 +559,7 @@ def concatenate_cli(
     sbatch_filepath: str | None = None,
     cluster: str = "slurm",
     monitor: bool = False,
+    init_only: bool = False,
     resolve_config_mode: bool = False,
     concat_data_paths: tuple[str, ...] = (),
 ):
@@ -566,6 +577,10 @@ def concatenate_cli(
         --concat-data-paths "reconstruct.zarr/*/*/*"
 
     \b
+    Emit RESOURCES + create the output plate (Nextflow init, login node):
+    >>> biahub concatenate --init -c resolved.yml -o output.zarr
+
+    \b
     Single-shot run on a reserved compute node (Nextflow assemble step):
     'debug' iterates every position in-process; the CLI blocks until done.
     >>> biahub concatenate --cluster debug -c resolved.yml -o output.zarr
@@ -581,7 +596,8 @@ def concatenate_cli(
 
     settings = yaml_to_model(config_path, ConcatenateSettings)
 
-    # Default: full end-to-end concatenation.
+    # Default: full end-to-end concatenation (or --init to only create the plate
+    # and emit RESOURCES).
     # For in-node clusters ('debug' runs in-process, 'local' spawns
     # subprocesses) the jobs execute lazily and only run when their result is
     # awaited, so block here — otherwise the command would return before any
@@ -595,6 +611,7 @@ def concatenate_cli(
         cluster=cluster,
         block=block,
         monitor=monitor,
+        init_only=init_only,
     )
 
 

--- a/biahub/concatenate.py
+++ b/biahub/concatenate.py
@@ -456,8 +456,14 @@ def concatenate(
 
     T, C, Z, Y, X = prep["shape"]
     batch_size = settings.shards_ratio[0] if settings.shards_ratio else 1
+    # min_ram_per_cpu=8 gives 8 GB/cpu (128 GB total at 16 cpus), matching the
+    # memory the assemble step ran well with; the ZYX-volume estimate alone
+    # under-provisions here.
     num_cpus, gb_ram_per_cpu = estimate_resources(
-        shape=(T // batch_size, C, Z, Y, X), ram_multiplier=4 * batch_size, max_num_cpus=16
+        shape=(T // batch_size, C, Z, Y, X),
+        ram_multiplier=4 * batch_size,
+        max_num_cpus=16,
+        min_ram_per_cpu=8,
     )
     mem_gb = num_cpus * gb_ram_per_cpu
     time_minutes = 60

--- a/biahub/concatenate.py
+++ b/biahub/concatenate.py
@@ -5,6 +5,7 @@ from pathlib import Path
 import click
 import numpy as np
 import submitit
+import yaml
 
 from iohub import open_ome_zarr
 from iohub.ngff.utils import create_empty_plate, process_single_position
@@ -400,11 +401,19 @@ def _resolve_concatenate_config(
     output_config: Path,
     concat_data_paths: tuple[str, ...],
 ):
-    """Resolve placeholder concat_data_paths without cropping."""
-    settings = yaml_to_model(config_path, ConcatenateSettings)
-    output_model = settings.model_copy()
-    output_model.concat_data_paths = list(concat_data_paths)
-    model_to_yaml(output_model, output_config)
+    """Fill in concat_data_paths and write the resolved config.
+
+    The source config's ``concat_data_paths`` is a placeholder — typically left
+    blank so Nextflow can inject the upstream store paths at runtime — so the
+    override is applied to the raw YAML *before* validation. ConcatenateSettings
+    requires ``concat_data_paths`` to be a non-empty list, which a blank
+    placeholder is not.
+    """
+    with open(config_path) as f:
+        raw = yaml.safe_load(f)
+    raw["concat_data_paths"] = list(concat_data_paths)
+    settings = ConcatenateSettings(**raw)
+    model_to_yaml(settings, output_config)
     click.echo(f"Resolved config written to {output_config}")
 
 

--- a/biahub/concatenate.py
+++ b/biahub/concatenate.py
@@ -456,14 +456,10 @@ def concatenate(
 
     T, C, Z, Y, X = prep["shape"]
     batch_size = settings.shards_ratio[0] if settings.shards_ratio else 1
-    # min_ram_per_cpu=8 gives 8 GB/cpu (128 GB total at 16 cpus), matching the
-    # memory the assemble step ran well with; the ZYX-volume estimate alone
-    # under-provisions here.
     num_cpus, gb_ram_per_cpu = estimate_resources(
         shape=(T // batch_size, C, Z, Y, X),
-        ram_multiplier=4 * batch_size,
+        ram_multiplier=8 * batch_size,
         max_num_cpus=16,
-        min_ram_per_cpu=8,
     )
     mem_gb = num_cpus * gb_ram_per_cpu
     time_minutes = 60

--- a/biahub/concatenate.py
+++ b/biahub/concatenate.py
@@ -1,4 +1,5 @@
 import glob
+import os
 
 from pathlib import Path
 
@@ -12,8 +13,9 @@ from natsort import natsorted
 
 from biahub.cli.monitor import monitor_jobs
 from biahub.cli.parsing import (
+    cluster,
     config_filepath,
-    local,
+    init_only,
     monitor,
     output_dirpath,
     sbatch_filepath,
@@ -21,13 +23,27 @@ from biahub.cli.parsing import (
 )
 from biahub.cli.utils import (
     copy_n_paste,
+    echo_resources,
     estimate_resources,
     get_output_paths,
     get_submitit_cluster,
+    model_to_yaml,
     resolve_ome_zarr_version,
     yaml_to_model,
 )
 from biahub.settings import ConcatenateSettings
+
+
+def _unique_source_plates(data_paths: list[Path]) -> list[Path]:
+    """Deduplicated source plate paths from position paths, preserving order."""
+    seen = set()
+    plates = []
+    for p in data_paths:
+        plate = Path(p).parents[2]
+        if plate not in seen:
+            seen.add(plate)
+            plates.append(plate)
+    return plates
 
 
 def get_path_slice_param(slice_param, path_index, total_paths):
@@ -248,34 +264,32 @@ def calculate_cropped_size(
     return cropped_shape_zyx
 
 
-def concatenate(
-    settings: ConcatenateSettings,
-    output_dirpath: Path,
-    sbatch_filepath: str | None = None,
-    local: bool = False,
-    block: bool = False,
-    monitor: bool = True,
-):
-    """Concatenate datasets (with optional cropping).
+def _resolve_time_indices(settings: ConcatenateSettings, all_shapes: list[tuple]) -> list[int]:
+    """Resolve input time indices from settings and shapes."""
+    T = all_shapes[0][0]
+    if settings.time_indices == "all":
+        if not all(s[0] == T for s in all_shapes):
+            click.echo(
+                "Warning: Datasets have different number of time points. "
+                "Taking the smallest number of time points."
+            )
+        T = min(s[0] for s in all_shapes)
+        return list(range(T))
+    elif isinstance(settings.time_indices, list):
+        return settings.time_indices
+    elif isinstance(settings.time_indices, int):
+        return [settings.time_indices]
+    return list(range(T))
 
-    Parameters
-    ----------
-    settings : ConcatenateSettings
-        Configuration settings for concatenation
-    output_dirpath : Path
-        Path to the output dataset
-    sbatch_filepath : str | None, optional
-        Path to the SLURM batch file, by default None
-    local : bool, optional
-        Whether to run locally or on a cluster, by default False
-    block : bool, optional
-        Whether to block until all the jobs are complete,
-        by default False
-    monitor : bool, optional
-        Whether to monitor the jobs, by default True
+
+def _prepare_concatenate(settings: ConcatenateSettings, output_dirpath: Path) -> dict:
+    """Derive metadata, create the output plate, and estimate SLURM resources.
+
+    Shared by ``--init`` and the full run so the channel/slice metadata (and the
+    expensive ``get_channel_combiner_metadata`` call) is computed exactly once per
+    invocation. Creates the output plate, emits the RESOURCES line, and returns
+    everything the submit loop needs.
     """
-    slurm_out_path = output_dirpath.parent / "slurm_output"
-
     slicing_params = [settings.Z_slice, settings.Y_slice, settings.X_slice]
     (
         all_data_paths,
@@ -286,7 +300,8 @@ def concatenate(
     ) = get_channel_combiner_metadata(
         settings.concat_data_paths, settings.channel_names, slicing_params
     )
-    output_position_paths_list = get_output_paths(
+
+    output_position_paths = get_output_paths(
         all_data_paths,
         output_dirpath,
         ensure_unique_positions=settings.ensure_unique_positions,
@@ -311,14 +326,13 @@ def concatenate(
         settings.Z_slice == "all"
         and settings.Y_slice == "all"
         and settings.X_slice == "all"
-        and not all([shape[-3:] == all_shapes[0][-3:] for shape in all_shapes])
+        and not all(shape[-3:] == all_shapes[0][-3:] for shape in all_shapes)
     ):
         raise ValueError(
             "Datasets have different shapes. All ZYX shapes must match to concatenate when using 'all' for slicing."
         )
 
-    # Check the voxel sizes
-    if not all([voxel_size == all_voxel_sizes[0] for voxel_size in all_voxel_sizes]):
+    if not all(voxel_size == all_voxel_sizes[0] for voxel_size in all_voxel_sizes):
         click.echo(
             "Warning: Datasets have different voxel sizes. Taking the first voxel size."
         )
@@ -326,43 +340,29 @@ def concatenate(
     T, C, Z, Y, X = all_shapes[0]
     output_voxel_size = all_voxel_sizes[0]
 
-    if all([dtype == all_dtypes[0] for dtype in all_dtypes]):
+    if all(dtype == all_dtypes[0] for dtype in all_dtypes):
         dtype = all_dtypes[0]
     else:
         click.echo("Warning: not all dtypes match. Casting data at float32.")
         dtype = np.float32
 
-    # Logic to parse time indices
-    if settings.time_indices == "all":
-        if not all([shape[0] == T for shape in all_shapes]):
-            click.echo(
-                "Warning: Datasets have different number of time points. Taking the smallest number of time points."
-            )
-        T = min([shape[0] for shape in all_shapes])
-        input_time_indices = list(range(T))
-    elif isinstance(settings.time_indices, list):
-        input_time_indices = settings.time_indices
-    elif isinstance(settings.time_indices, int):
-        input_time_indices = [settings.time_indices]
+    input_time_indices = _resolve_time_indices(settings, all_shapes)
 
-    # If input shapes are different but slicing is specified, inform the user
-    if not all([shape[-3:] == all_shapes[0][-3:] for shape in all_shapes]):
+    # If input shapes differ but slicing is specified, inform the user
+    if not all(shape[-3:] == all_shapes[0][-3:] for shape in all_shapes):
         click.echo(
             "Warning: Datasets have different shapes, but slicing parameters are specified. Will validate output shapes after cropping."
         )
 
     cropped_shape_zyx = calculate_cropped_size(all_slicing_params[0])
-
-    # Ensure that the cropped shape is within the bounds of the original shape
     if cropped_shape_zyx[0] > Z or cropped_shape_zyx[1] > Y or cropped_shape_zyx[2] > X:
         raise ValueError("The cropped shape is larger than the original shape.")
 
-    # TODO: make assertion for chunk size?
     if settings.chunks_czyx is not None:
         chunk_size = [1] + list(settings.chunks_czyx)
     else:
         chunk_size = settings.chunks_czyx
-    # Logic for creation of zarr and metadata
+
     output_metadata = {
         "shape": (len(input_time_indices), len(all_channel_names)) + tuple(cropped_shape_zyx),
         "chunks": chunk_size,
@@ -375,25 +375,155 @@ def concatenate(
         "dtype": dtype,
     }
 
-    # Create the output zarr mirroring source_position_dirpaths
+    source_plates = _unique_source_plates(all_data_paths)
     create_empty_plate(
         store_path=output_dirpath,
-        position_keys=[p.parts[-3:] for p in output_position_paths_list],
+        position_keys=[p.parts[-3:] for p in output_position_paths],
+        metadata_sources=list(reversed(source_plates)),
         **output_metadata,
     )
+    click.echo(f"Created {output_dirpath} ({len(output_position_paths)} positions)")
 
-    # Estimate resources
     batch_size = settings.shards_ratio[0] if settings.shards_ratio else 1
     num_cpus, gb_ram_per_cpu = estimate_resources(
         shape=(T // batch_size, C, Z, Y, X), ram_multiplier=4 * batch_size, max_num_cpus=16
     )
+    time_minutes = 60
+    echo_resources(num_cpus, num_cpus * gb_ram_per_cpu, time_minutes=time_minutes)
+
+    return {
+        "all_data_paths": all_data_paths,
+        "output_position_paths": output_position_paths,
+        "input_channel_idx_list": input_channel_idx_list,
+        "output_channel_idx_list": output_channel_idx_list,
+        "all_slicing_params": all_slicing_params,
+        "input_time_indices": input_time_indices,
+        "num_cpus": num_cpus,
+        "gb_ram_per_cpu": gb_ram_per_cpu,
+        "time_minutes": time_minutes,
+    }
+
+
+def _run_concatenate_one_position(
+    settings: ConcatenateSettings,
+    output_dirpath: Path,
+    position: str,
+):
+    """Copy and crop data from all input stores for one position into output."""
+    slicing_params = [settings.Z_slice, settings.Y_slice, settings.X_slice]
+
+    (
+        all_data_paths,
+        _all_channel_names,
+        input_channel_idx_list,
+        output_channel_idx_list,
+        all_slicing_params,
+    ) = get_channel_combiner_metadata(
+        settings.concat_data_paths, settings.channel_names, slicing_params
+    )
+
+    all_shapes = []
+    for path in all_data_paths:
+        with open_ome_zarr(path) as ds:
+            all_shapes.append(ds.data.shape)
+
+    input_time_indices = _resolve_time_indices(settings, all_shapes)
+
+    for (
+        input_path,
+        input_ch_idx,
+        output_ch_idx,
+        zyx_slicing_params,
+    ) in zip(
+        all_data_paths,
+        input_channel_idx_list,
+        output_channel_idx_list,
+        all_slicing_params,
+        strict=True,
+    ):
+        fov_key = "/".join(Path(input_path).parts[-3:])
+        if fov_key != position:
+            continue
+
+        output_position_path = output_dirpath / position
+
+        # Preserve extra_metadata written by create_empty_plate's
+        # metadata_sources — process_single_position overwrites it with None
+        # when the kwarg is absent (iohub <= 0.3.7) — and record this step's
+        # own provenance alongside it.
+        with open_ome_zarr(str(output_position_path), layout="fov", mode="r") as pos:
+            existing_extra = pos.zattrs.get("extra_metadata")
+        merged_extra = {**(existing_extra or {}), "biahub-concatenate": settings.model_dump()}
+
+        process_single_position(
+            copy_n_paste,
+            input_position_path=input_path,
+            output_position_path=output_position_path,
+            num_workers=os.cpu_count() or 1,
+            input_channel_indices=input_ch_idx,
+            output_channel_indices=output_ch_idx,
+            input_time_indices=input_time_indices,
+            output_time_indices=list(range(len(input_time_indices))),
+            extra_metadata=merged_extra,
+            zyx_slicing_params=zyx_slicing_params,
+        )
+
+    click.echo(f"Concatenation done: {position}")
+
+
+def _resolve_concatenate_config(
+    config_path: Path,
+    output_config: Path,
+    concat_data_paths: tuple[str, ...],
+):
+    """Resolve placeholder concat_data_paths without cropping."""
+    settings = yaml_to_model(config_path, ConcatenateSettings)
+    output_model = settings.model_copy()
+    output_model.concat_data_paths = list(concat_data_paths)
+    model_to_yaml(output_model, output_config)
+    click.echo(f"Resolved config written to {output_config}")
+
+
+def concatenate(
+    settings: ConcatenateSettings,
+    output_dirpath: Path,
+    sbatch_filepath: str | None = None,
+    cluster: str = "slurm",
+    block: bool = False,
+    monitor: bool = True,
+):
+    """Concatenate datasets (with optional cropping).
+
+    Parameters
+    ----------
+    settings : ConcatenateSettings
+        Configuration settings for concatenation
+    output_dirpath : Path
+        Path to the output dataset
+    sbatch_filepath : str | None, optional
+        Path to the SLURM batch file, by default None
+    cluster : str, optional
+        Execution cluster: 'slurm' submits to a Slurm cluster, 'local' runs jobs
+        as subprocesses on this machine, 'debug' runs jobs in-process in the
+        foreground. By default 'slurm'.
+    block : bool, optional
+        Whether to block until all the jobs are complete,
+        by default False
+    monitor : bool, optional
+        Whether to monitor the jobs, by default True
+    """
+    slurm_out_path = output_dirpath.parent / "slurm_output"
+
+    prep = _prepare_concatenate(settings, output_dirpath)
+    input_time_indices = prep["input_time_indices"]
+
     # Prepare SLURM arguments
     slurm_args = {
         "slurm_job_name": "concatenate",
-        "slurm_mem_per_cpu": f"{gb_ram_per_cpu}G",
-        "slurm_cpus_per_task": num_cpus,
+        "slurm_mem": f"{prep['num_cpus'] * prep['gb_ram_per_cpu']}G",
+        "slurm_cpus_per_task": prep["num_cpus"],
         "slurm_array_parallelism": 100,  # process up to 100 positions at a time
-        "slurm_time": 60,
+        "slurm_time": prep["time_minutes"],
         "slurm_partition": "preempted",
     }
 
@@ -401,14 +531,11 @@ def concatenate(
     if sbatch_filepath:
         slurm_args.update(sbatch_to_submitit(sbatch_filepath))
 
-    # Run locally or submit to SLURM
-    cluster = get_submitit_cluster(local)
-
-    # Prepare and submit jobs
-    executor = submitit.AutoExecutor(folder=slurm_out_path, cluster=cluster)
+    resolved_cluster = get_submitit_cluster(cluster=cluster)
+    executor = submitit.AutoExecutor(folder=slurm_out_path, cluster=resolved_cluster)
     executor.update_parameters(**slurm_args)
 
-    click.echo(f"Submitting {cluster} jobs...")
+    click.echo(f"Submitting {resolved_cluster} jobs...")
     jobs = []
 
     with submitit.helpers.clean_env(), executor.batch():
@@ -419,15 +546,23 @@ def concatenate(
             output_channel_idx,
             zyx_slicing_params,
         ) in zip(
-            all_data_paths,
-            output_position_paths_list,
-            input_channel_idx_list,
-            output_channel_idx_list,
-            all_slicing_params,
+            prep["all_data_paths"],
+            prep["output_position_paths"],
+            prep["input_channel_idx_list"],
+            prep["output_channel_idx_list"],
+            prep["all_slicing_params"],
             strict=True,
         ):
-            # Create slicing parameters for this specific path
-            copy_n_paste_kwargs = {"zyx_slicing_params": zyx_slicing_params}
+            # Preserve extra_metadata written by create_empty_plate's
+            # metadata_sources — process_single_position overwrites it with None
+            # when the kwarg is absent (iohub <= 0.3.7) — and record this step's
+            # own provenance alongside it.
+            with open_ome_zarr(str(output_position_path), layout="fov", mode="r") as pos:
+                existing_extra = pos.zattrs.get("extra_metadata")
+            merged_extra = {
+                **(existing_extra or {}),
+                "biahub-concatenate": settings.model_dump(),
+            }
 
             job = executor.submit(
                 process_single_position,
@@ -438,15 +573,16 @@ def concatenate(
                 output_channel_indices=output_channel_idx,
                 input_time_indices=input_time_indices,
                 output_time_indices=list(range(len(input_time_indices))),
-                num_workers=int(slurm_args["slurm_cpus_per_task"]),
-                **copy_n_paste_kwargs,
+                num_workers=slurm_args["slurm_cpus_per_task"],
+                extra_metadata=merged_extra,
+                zyx_slicing_params=zyx_slicing_params,
             )
             jobs.append(job)
 
     job_ids = [job.job_id for job in jobs]  # Access job IDs after batch submission
 
     slurm_out_path.mkdir(exist_ok=True)
-    log_path = Path(slurm_out_path / "submitit_jobs_ids.log")
+    log_path = slurm_out_path / "submitit_jobs_ids.log"
     with log_path.open("w") as log_file:
         log_file.write("\n".join(job_ids))
 
@@ -454,32 +590,106 @@ def concatenate(
         _ = [job.result() for job in jobs]
 
     if monitor:
-        monitor_jobs(jobs, all_data_paths)
+        monitor_jobs(jobs, prep["all_data_paths"])
 
 
 @click.command("concatenate")
 @config_filepath()
 @output_dirpath()
 @sbatch_filepath()
-@local()
+@cluster()
 @monitor()
+@init_only()
+@click.option(
+    "--position",
+    "-p",
+    type=str,
+    default=None,
+    help="Position key to process (e.g. B/3/000000). Required with --cluster debug.",
+)
+@click.option(
+    "--resolve-config",
+    "resolve_config_mode",
+    is_flag=True,
+    default=False,
+    help="Resolve placeholder concat_data_paths and write output config.",
+)
+@click.option(
+    "--concat-data-paths",
+    multiple=True,
+    type=str,
+    help="Override concat_data_paths from config (repeat flag, used with --resolve-config).",
+)
 def concatenate_cli(
     config_filepath: Path,
-    output_dirpath: str,
+    output_dirpath: Path,
     sbatch_filepath: str | None = None,
-    local: bool = False,
-    monitor: bool = True,
+    cluster: str = "slurm",
+    monitor: bool = False,
+    init_only: bool = False,
+    position: str | None = None,
+    resolve_config_mode: bool = False,
+    concat_data_paths: tuple[str, ...] = (),
 ):
-    """Concatenate datasets (with optional cropping).
+    r"""Concatenate datasets (with optional cropping).
 
-    >>> biahub concatenate -c ./concat.yml -o ./output_concat.zarr
+    \b
+    Full end-to-end (SLURM fan-out):
+    >>> biahub concatenate -c ./concat.yml -o ./output.zarr
+
+    \b
+    Resolve placeholder paths (Nextflow config prep, runs on the login node):
+    >>> biahub concatenate --resolve-config \
+        -c concat.yml -o resolved.yml \
+        --concat-data-paths "deskew.zarr/*/*/*" \
+        --concat-data-paths "reconstruct.zarr/*/*/*"
+
+    \b
+    Single-shot run on a reserved compute node (Nextflow assemble step):
+    'debug' iterates every position in-process; the CLI blocks until done.
+    >>> biahub concatenate --cluster debug -c resolved.yml -o output.zarr
+
+    \b
+    Initialize output plate only (metadata + RESOURCES, no data copy):
+    >>> biahub concatenate --init -c resolved.yml -o output.zarr
+
+    \b
+    Per-position run (in-process, one FOV):
+    >>> biahub concatenate --cluster debug \
+        -c resolved.yml -o output.zarr -p B/3/000000
     """
+    config_path = config_filepath
+    output_path = output_dirpath
+
+    if resolve_config_mode:
+        if not concat_data_paths:
+            raise click.UsageError("--resolve-config requires --concat-data-paths")
+        _resolve_concatenate_config(config_path, output_path, concat_data_paths)
+        return
+
+    settings = yaml_to_model(config_path, ConcatenateSettings)
+
+    if init_only:
+        _prepare_concatenate(settings, output_path)
+        return
+
+    if position is not None:
+        _run_concatenate_one_position(settings, output_path, position)
+        return
+
+    # Default: full end-to-end concatenation.
+    # For in-node clusters ('debug' runs in-process, 'local' spawns
+    # subprocesses) the jobs execute lazily and only run when their result is
+    # awaited, so block here — otherwise the command would return before any
+    # data is written. 'slurm' keeps the submit-and-detach behaviour (optionally
+    # followed with --monitor), matching the other CLIs.
+    block = cluster in ("debug", "local")
     concatenate(
-        settings=yaml_to_model(config_filepath, ConcatenateSettings),
-        output_dirpath=Path(output_dirpath),
+        settings=settings,
+        output_dirpath=output_path,
         sbatch_filepath=sbatch_filepath,
-        local=local,
-        block=False,
+        cluster=cluster,
+        block=block,
         monitor=monitor,
     )
 

--- a/biahub/concatenate.py
+++ b/biahub/concatenate.py
@@ -1,5 +1,4 @@
 import glob
-import os
 
 from pathlib import Path
 
@@ -15,7 +14,6 @@ from biahub.cli.monitor import monitor_jobs
 from biahub.cli.parsing import (
     cluster,
     config_filepath,
-    init_only,
     monitor,
     output_dirpath,
     sbatch_filepath,
@@ -404,73 +402,6 @@ def _prepare_concatenate(settings: ConcatenateSettings, output_dirpath: Path) ->
     }
 
 
-def _run_concatenate_one_position(
-    settings: ConcatenateSettings,
-    output_dirpath: Path,
-    position: str,
-):
-    """Copy and crop data from all input stores for one position into output."""
-    slicing_params = [settings.Z_slice, settings.Y_slice, settings.X_slice]
-
-    (
-        all_data_paths,
-        _all_channel_names,
-        input_channel_idx_list,
-        output_channel_idx_list,
-        all_slicing_params,
-    ) = get_channel_combiner_metadata(
-        settings.concat_data_paths, settings.channel_names, slicing_params
-    )
-
-    all_shapes = []
-    for path in all_data_paths:
-        with open_ome_zarr(path) as ds:
-            all_shapes.append(ds.data.shape)
-
-    input_time_indices = _resolve_time_indices(settings, all_shapes)
-
-    for (
-        input_path,
-        input_ch_idx,
-        output_ch_idx,
-        zyx_slicing_params,
-    ) in zip(
-        all_data_paths,
-        input_channel_idx_list,
-        output_channel_idx_list,
-        all_slicing_params,
-        strict=True,
-    ):
-        fov_key = "/".join(Path(input_path).parts[-3:])
-        if fov_key != position:
-            continue
-
-        output_position_path = output_dirpath / position
-
-        # Preserve extra_metadata written by create_empty_plate's
-        # metadata_sources — process_single_position overwrites it with None
-        # when the kwarg is absent (iohub <= 0.3.7) — and record this step's
-        # own provenance alongside it.
-        with open_ome_zarr(str(output_position_path), layout="fov", mode="r") as pos:
-            existing_extra = pos.zattrs.get("extra_metadata")
-        merged_extra = {**(existing_extra or {}), "biahub-concatenate": settings.model_dump()}
-
-        process_single_position(
-            copy_n_paste,
-            input_position_path=input_path,
-            output_position_path=output_position_path,
-            num_workers=os.cpu_count() or 1,
-            input_channel_indices=input_ch_idx,
-            output_channel_indices=output_ch_idx,
-            input_time_indices=input_time_indices,
-            output_time_indices=list(range(len(input_time_indices))),
-            extra_metadata=merged_extra,
-            zyx_slicing_params=zyx_slicing_params,
-        )
-
-    click.echo(f"Concatenation done: {position}")
-
-
 def _resolve_concatenate_config(
     config_path: Path,
     output_config: Path,
@@ -599,14 +530,6 @@ def concatenate(
 @sbatch_filepath()
 @cluster()
 @monitor()
-@init_only()
-@click.option(
-    "--position",
-    "-p",
-    type=str,
-    default=None,
-    help="Position key to process (e.g. B/3/000000). Required with --cluster debug.",
-)
 @click.option(
     "--resolve-config",
     "resolve_config_mode",
@@ -626,8 +549,6 @@ def concatenate_cli(
     sbatch_filepath: str | None = None,
     cluster: str = "slurm",
     monitor: bool = False,
-    init_only: bool = False,
-    position: str | None = None,
     resolve_config_mode: bool = False,
     concat_data_paths: tuple[str, ...] = (),
 ):
@@ -648,15 +569,6 @@ def concatenate_cli(
     Single-shot run on a reserved compute node (Nextflow assemble step):
     'debug' iterates every position in-process; the CLI blocks until done.
     >>> biahub concatenate --cluster debug -c resolved.yml -o output.zarr
-
-    \b
-    Initialize output plate only (metadata + RESOURCES, no data copy):
-    >>> biahub concatenate --init -c resolved.yml -o output.zarr
-
-    \b
-    Per-position run (in-process, one FOV):
-    >>> biahub concatenate --cluster debug \
-        -c resolved.yml -o output.zarr -p B/3/000000
     """
     config_path = config_filepath
     output_path = output_dirpath
@@ -668,14 +580,6 @@ def concatenate_cli(
         return
 
     settings = yaml_to_model(config_path, ConcatenateSettings)
-
-    if init_only:
-        _prepare_concatenate(settings, output_path)
-        return
-
-    if position is not None:
-        _run_concatenate_one_position(settings, output_path, position)
-        return
 
     # Default: full end-to-end concatenation.
     # For in-node clusters ('debug' runs in-process, 'local' spawns

--- a/biahub/concatenate.py
+++ b/biahub/concatenate.py
@@ -448,7 +448,10 @@ def concatenate(
     T, C, Z, Y, X = prep["shape"]
     batch_size = settings.shards_ratio[0] if settings.shards_ratio else 1
     num_cpus, gb_ram_per_cpu = estimate_resources(
-        shape=(T // batch_size, C, Z, Y, X), ram_multiplier=4 * batch_size, max_num_cpus=16
+        shape=(T // batch_size, C, Z, Y, X),
+        ram_multiplier=4 * batch_size,
+        max_num_cpus=16,
+        min_num_cpus=8,
     )
     mem_gb = num_cpus * gb_ram_per_cpu
     time_minutes = 60

--- a/nextflow/mantis-v2.nf
+++ b/nextflow/mantis-v2.nf
@@ -27,6 +27,7 @@ params.deskew_config = null
 params.flat_field_config = null
 params.reconstruct_config = null
 params.virtual_stain_config = null
+params.concatenate_config = null
 params.biahub_project = null
 params.max_positions = 0
 
@@ -35,6 +36,7 @@ include { deskew_wf } from './modules/deskew'
 include { flat_field_wf } from './modules/flat_field'
 include { reconstruct_wf } from './modules/reconstruct'
 include { virtual_stain_wf } from './modules/virtual_stain'
+include { assemble_wf } from './modules/assembly'
 
 // Output directory layout for the reconstruction steps — single source of
 // truth. Each entry is a subdirectory under params.output where that step
@@ -48,7 +50,7 @@ DIRECTORY_LAYOUT = [
     reconstruct   : '2-reconstruct',
     virtual_stain : '3-virtual-stain',
     // track         : '4-track',
-    // assemble      : '5-assemble',
+    assemble      : '5-assemble',
 ]
 
 
@@ -59,6 +61,7 @@ workflow {
     if (!params.deskew_config)      error "Provide --deskew_config"
     if (!params.reconstruct_config) error "Provide --reconstruct_config"
     if (!params.virtual_stain_config) error "Provide --virtual_stain_config"
+    if (!params.concatenate_config) error "Provide --concatenate_config"
 
     def ds  = dataset_name()
     def out = params.output
@@ -106,4 +109,24 @@ workflow {
     virtual_stain_output  = "${out}/${DIRECTORY_LAYOUT.virtual_stain}/${ds}.zarr"
 
     virtual_stain_done = virtual_stain_wf(all_positions, virtual_stain_input, virtual_stain_output, params.virtual_stain_config, virtual_stain_trigger)
+
+    // ----- Assemble ---------------------------------------------------------
+    // Concatenate the deskew, reconstruct, and virtual-stain outputs channel-wise
+    // into a single multichannel plate, waiting on virtual_stain_done. Unlike the
+    // per-position steps this runs single-shot on ONE reserved compute node
+    // (`concatenate --cluster debug` iterates every position in-process); which
+    // channels/crops come from each source is set by the concatenate config, not
+    // here. The config's concat_data_paths are placeholders — the subworkflow
+    // injects the three source paths via --resolve-config.
+    assemble_trigger = virtual_stain_done.done
+    assemble_output  = "${out}/${DIRECTORY_LAYOUT.assemble}/${ds}.zarr"
+
+    assemble_wf(
+        deskew_output,
+        reconstruct_output,
+        virtual_stain_output,
+        assemble_output,
+        params.concatenate_config,
+        assemble_trigger
+    )
 }

--- a/nextflow/modules/assembly.nf
+++ b/nextflow/modules/assembly.nf
@@ -87,9 +87,13 @@ process init_concatenate {
 // reclaimed mid-run the whole task restarts (the global errorStrategy retries
 // it). Acceptable while the step is quick; route to a non-preempted partition
 // if it grows long.
+// The single-shot copy is memory-bandwidth-bound, so exclude the slow, small-
+// memory cpu-c nodes (2017 Intel Xeon Gold 6126, 24 cores, 128 GB/node) — they
+// ran this ~6x slower than the AMD EPYC nodes. All other cpu-* nodes are EPYC
+// with >=750 GB, so a plain --exclude of cpu-c is enough.
 process run_concatenate {
     label 'cpu'
-    clusterOptions { slurm_logs('assemble') }
+    clusterOptions { "${slurm_logs('assemble')} --exclude=cpu-c-[1-4]" }
     cpus   { meta.cpus }
     memory { "${meta.mem_gb} GB" }
     time   { "${meta.time_minutes * task.attempt} min" }

--- a/nextflow/modules/assembly.nf
+++ b/nextflow/modules/assembly.nf
@@ -1,4 +1,5 @@
-// Assembly subworkflow: resolve concat config → single-shot concatenate.
+// Assembly subworkflow: resolve concat config → init (RESOURCES) → single-shot
+// concatenate.
 //
 // Unlike the per-position steps (deskew, reconstruct, …), concatenate combines
 // N source stores channel-wise at each position, so there is no single `-i` to
@@ -14,11 +15,13 @@
 // `--cluster local` (submitit spawns one subprocess per position) and size the
 // resources for the concurrent fan-out.
 //
-// Path injection: the source zarr paths are Nextflow runtime values, so
-// `--resolve-config` templates them into concat_data_paths — a cheap login-node
-// step — before the compute step reads the resolved config.
+// Like the other steps, a cheap `--init` step on the login node creates the
+// output plate (create_empty_plate is idempotent) and emits the RESOURCES line
+// that sizes the compute node. Path injection: the source zarr paths are
+// Nextflow runtime values, so `--resolve-config` templates them into
+// concat_data_paths — also a login-node step — before init/run read the config.
 
-include { biahub_cmd; slurm_logs; slurm_log_dir } from './common'
+include { parse_resources; biahub_cmd; slurm_logs; slurm_log_dir } from './common'
 
 
 process resolve_concatenate_config {
@@ -55,10 +58,31 @@ process resolve_concatenate_config {
 }
 
 
+// Create the output plate and emit the RESOURCES line used to size the compute
+// node. Cheap and metadata-only, so it stays on the login node (cpu_local).
+process init_concatenate {
+    label 'cpu_local'
+
+    input:
+    path resolved_config
+    val output_zarr
+
+    output:
+    stdout
+
+    script:
+    """
+    mkdir -p "${slurm_log_dir('assemble')}"
+    ${biahub_cmd()} concatenate --init \
+        -c "${resolved_config}" \
+        -o "${output_zarr}"
+    """
+}
+
+
 // Single-shot concatenation of the whole plate on a reserved compute node.
-// Resources are static (sized for the whole plate run, not one position) rather
-// than driven by a `--init` RESOURCES payload — the single-shot model does not
-// need the separate init/list-positions step. Tune cpus/memory/time to the data.
+// cpus/memory/time come from the RESOURCES payload emitted by init_concatenate
+// (parsed via parse_resources), matching the other CLIs.
 // NOTE: label 'cpu' routes to the 'preempted' partition; if the node is
 // reclaimed mid-run the whole task restarts (the global errorStrategy retries
 // it). Acceptable while the step is quick; route to a non-preempted partition
@@ -66,23 +90,22 @@ process resolve_concatenate_config {
 process run_concatenate {
     label 'cpu'
     clusterOptions { slurm_logs('assemble') }
-    cpus 16
-    memory '128 GB'
-    time '4h'
+    cpus   { meta.cpus }
+    memory { "${meta.mem_gb} GB" }
+    time   { "${meta.time_minutes * task.attempt} min" }
 
     input:
-    path resolved_config
     val output_zarr
+    val resolved_config_path
+    val meta
 
     output:
     val output_zarr
 
     script:
     """
-    mkdir -p "${slurm_log_dir('assemble')}"
-    rm -rf "${output_zarr}"
     ${biahub_cmd()} concatenate --cluster debug \
-        -c "${resolved_config}" \
+        -c "${resolved_config_path}" \
         -o "${output_zarr}"
     """
 }
@@ -106,12 +129,14 @@ workflow assemble_wf {
 
     main:
     def config_dir = new File(config.toString()).parent
+    def resolved_config_path = "${config_dir}/concatenate_resolved.yml"
 
     resolved = resolve_concatenate_config(
         deskew_zarr, reconstruct_zarr, virtual_stain_zarr,
         config_dir, config, prev_done.map { 'done' }
     )
-    as_done = run_concatenate(resolved, output_zarr)
+    resources = init_concatenate(resolved, output_zarr).map { parse_resources(it) }
+    as_done = run_concatenate(output_zarr, resolved_config_path, resources)
 
     emit:
     done = as_done

--- a/nextflow/modules/assembly.nf
+++ b/nextflow/modules/assembly.nf
@@ -1,0 +1,113 @@
+// Assembly subworkflow: resolve concat config → single-shot concatenate.
+//
+// Unlike the per-position steps (deskew, reconstruct, …), concatenate combines
+// N source stores channel-wise at each position, so there is no single `-i` to
+// fan out over. Rather than Nextflow-managed per-position fan-out, this step
+// runs the WHOLE plate in ONE task: `concatenate --cluster debug` iterates
+// every position in-process (see biahub/concatenate.py). The task is a reserved
+// SLURM compute node (label 'cpu'), NOT the login node, so the login node stays
+// free. `--cluster debug` runs in-process and submits no SLURM jobs of its own,
+// so there is no scheduler-in-scheduler nesting.
+//
+// This is the "reserve a compute node + --cluster debug" approach. To parallelise
+// positions across the reserved node's cores later, switch the run step to
+// `--cluster local` (submitit spawns one subprocess per position) and size the
+// resources for the concurrent fan-out.
+//
+// Path injection: the source zarr paths are Nextflow runtime values, so
+// `--resolve-config` templates them into concat_data_paths — a cheap login-node
+// step — before the compute step reads the resolved config.
+
+include { biahub_cmd; slurm_logs; slurm_log_dir } from './common'
+
+
+process resolve_concatenate_config {
+    label 'cpu_local'
+
+    input:
+    val deskew_zarr
+    val reconstruct_zarr
+    val virtual_stain_zarr
+    val output_dir
+    val config
+    val trigger
+
+    output:
+    path "concatenate_resolved.yml"
+
+    script:
+    def resolved = "${output_dir}/concatenate_resolved.yml"
+    """
+    mkdir -p "${output_dir}"
+    ${biahub_cmd()} concatenate --resolve-config \
+        -c "${config}" \
+        -o "${resolved}" \
+        --concat-data-paths "${deskew_zarr}/*/*/*" \
+        --concat-data-paths "${reconstruct_zarr}/*/*/*" \
+        --concat-data-paths "${virtual_stain_zarr}/*/*/*"
+    cp "${resolved}" concatenate_resolved.yml
+    """
+}
+
+
+// Single-shot concatenation of the whole plate on a reserved compute node.
+// Resources are static (sized for the whole plate run, not one position) rather
+// than driven by a `--init` RESOURCES payload — the single-shot model does not
+// need the separate init/list-positions step. Tune cpus/memory/time to the data.
+// NOTE: label 'cpu' routes to the 'preempted' partition; if the node is
+// reclaimed mid-run the whole task restarts (the global errorStrategy retries
+// it). Acceptable while the step is quick; route to a non-preempted partition
+// if it grows long.
+process run_concatenate {
+    label 'cpu'
+    clusterOptions { slurm_logs('assemble') }
+    cpus 16
+    memory '128 GB'
+    time '4h'
+
+    input:
+    path resolved_config
+    val output_zarr
+
+    output:
+    val output_zarr
+
+    script:
+    """
+    mkdir -p "${slurm_log_dir('assemble')}"
+    rm -rf "${output_zarr}"
+    ${biahub_cmd()} concatenate --cluster debug \
+        -c "${resolved_config}" \
+        -o "${output_zarr}"
+    """
+}
+
+
+// take:
+//   deskew_zarr        LF source store to concatenate
+//   reconstruct_zarr   phase source store to concatenate
+//   virtual_stain_zarr virtual-stain source store to concatenate
+//   output_zarr        path to the assembled output plate.zarr
+//   config             path to the concatenate settings YAML (placeholder paths)
+//   prev_done          gating channel — assembly starts once this emits
+workflow assemble_wf {
+    take:
+    deskew_zarr
+    reconstruct_zarr
+    virtual_stain_zarr
+    output_zarr
+    config
+    prev_done
+
+    main:
+    def output_dir = new File(output_zarr).parent
+
+    resolved = resolve_concatenate_config(
+        deskew_zarr, reconstruct_zarr, virtual_stain_zarr,
+        output_dir, config, prev_done.map { 'done' }
+    )
+    as_done = run_concatenate(resolved, output_zarr)
+
+    emit:
+    done = as_done
+}

--- a/nextflow/modules/assembly.nf
+++ b/nextflow/modules/assembly.nf
@@ -28,17 +28,22 @@ process resolve_concatenate_config {
     val deskew_zarr
     val reconstruct_zarr
     val virtual_stain_zarr
-    val output_dir
+    val config_dir
     val config
     val trigger
 
     output:
     path "concatenate_resolved.yml"
 
+    // Write the resolved config alongside the source config (config_dir) so it
+    // sits with the rest of the run's configs. `rm -f` first because
+    // `--resolve-config -o` refuses to overwrite an existing file, so a rerun
+    // would otherwise fail on the stale copy.
     script:
-    def resolved = "${output_dir}/concatenate_resolved.yml"
+    def resolved = "${config_dir}/concatenate_resolved.yml"
     """
-    mkdir -p "${output_dir}"
+    mkdir -p "${config_dir}"
+    rm -f "${resolved}"
     ${biahub_cmd()} concatenate --resolve-config \
         -c "${config}" \
         -o "${resolved}" \
@@ -100,11 +105,11 @@ workflow assemble_wf {
     prev_done
 
     main:
-    def output_dir = new File(output_zarr).parent
+    def config_dir = new File(config.toString()).parent
 
     resolved = resolve_concatenate_config(
         deskew_zarr, reconstruct_zarr, virtual_stain_zarr,
-        output_dir, config, prev_done.map { 'done' }
+        config_dir, config, prev_done.map { 'done' }
     )
     as_done = run_concatenate(resolved, output_zarr)
 

--- a/tests/test_cli/test_concatenate_cli.py
+++ b/tests/test_cli/test_concatenate_cli.py
@@ -7,6 +7,43 @@ from iohub.ngff import open_ome_zarr
 from biahub.cli.main import cli
 
 
+def test_resolve_config_blank_concat_data_paths(tmp_path):
+    """`--resolve-config` must fill a blank concat_data_paths in the source config.
+
+    Regression guard: the Nextflow config leaves concat_data_paths empty for the
+    pipeline to inject, so resolution must apply the override before validating
+    (concat_data_paths is a required non-empty list on ConcatenateSettings).
+    """
+    config_path = tmp_path / "concatenate.yml"
+    config_path.write_text(
+        "concat_data_paths:\n\n"
+        "time_indices: all\n"
+        "channel_names:\n- all\n- all\n"
+        'output_ome_zarr_version: "0.5"\n'
+    )
+    resolved = tmp_path / "concatenate_resolved.yml"
+
+    result = CliRunner().invoke(
+        cli,
+        [
+            "concatenate",
+            "--resolve-config",
+            "-c",
+            str(config_path),
+            "-o",
+            str(resolved),
+            "--concat-data-paths",
+            "deskew.zarr/*/*/*",
+            "--concat-data-paths",
+            "reconstruct.zarr/*/*/*",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    out = yaml.safe_load(resolved.read_text())
+    assert out["concat_data_paths"] == ["deskew.zarr/*/*/*", "reconstruct.zarr/*/*/*"]
+
+
 def test_cluster_debug_single_shot(create_custom_plate, tmp_path):
     """`concatenate --cluster debug` (no -p) must run the whole plate in-process
     and block until every position is written.

--- a/tests/test_cli/test_concatenate_cli.py
+++ b/tests/test_cli/test_concatenate_cli.py
@@ -1,0 +1,66 @@
+import numpy as np
+import yaml
+
+from click.testing import CliRunner
+from iohub.ngff import open_ome_zarr
+
+from biahub.cli.main import cli
+
+
+def test_cluster_debug_single_shot(create_custom_plate, tmp_path):
+    """`concatenate --cluster debug` (no -p) must run the whole plate in-process
+    and block until every position is written.
+
+    Regression guard: submitit's DebugJob executes lazily, so without the CLI
+    blocking on the results the command would exit having written nothing.
+    """
+    position_list = [("A", "1", "0"), ("B", "1", "0")]
+    plate_1_path, plate_1 = create_custom_plate(
+        tmp_path / "deskew", position_list=position_list, channel_names=["BF"]
+    )
+    plate_2_path, plate_2 = create_custom_plate(
+        tmp_path / "reconstruct", position_list=position_list, channel_names=["Phase3D"]
+    )
+
+    config_path = tmp_path / "concat.yml"
+    config_path.write_text(
+        yaml.dump(
+            {
+                "concat_data_paths": [
+                    str(plate_1_path) + "/*/*/*",
+                    str(plate_2_path) + "/*/*/*",
+                ],
+                "channel_names": ["all", "all"],
+                "time_indices": "all",
+                "Z_slice": "all",
+                "Y_slice": "all",
+                "X_slice": "all",
+                "output_ome_zarr_version": "0.4",
+                "ensure_unique_positions": False,
+            }
+        )
+    )
+
+    output_zarr = tmp_path / "output.zarr"
+
+    result = CliRunner().invoke(
+        cli,
+        [
+            "concatenate",
+            "--cluster",
+            "debug",
+            "-c",
+            str(config_path),
+            "-o",
+            str(output_zarr),
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+
+    for key in ("A/1/0", "B/1/0"):
+        with open_ome_zarr(str(output_zarr / key), mode="r") as ds:
+            data = ds["0"][:]
+            assert set(ds.channel_names) == {"BF", "Phase3D"}
+            assert data.shape[1] == 2
+            assert not np.all(data == 0)

--- a/tests/test_concatenate.py
+++ b/tests/test_concatenate.py
@@ -38,7 +38,7 @@ def test_concatenate_channels(create_custom_plate, tmp_path, sbatch_file):
         settings=settings,
         output_dirpath=output_path,
         sbatch_filepath=sbatch_file,
-        local=True,
+        cluster="local",
         block=True,
         monitor=False,
     )
@@ -83,7 +83,7 @@ def test_concatenate_specific_channels(create_custom_plate, tmp_path, sbatch_fil
         settings=settings,
         output_dirpath=output_path,
         sbatch_filepath=sbatch_file,
-        local=True,
+        cluster="local",
         block=True,
         monitor=False,
     )
@@ -120,7 +120,7 @@ def test_concatenate_with_time_indices(create_custom_plate, tmp_path, sbatch_fil
         settings=settings,
         output_dirpath=output_path,
         sbatch_filepath=sbatch_file,
-        local=True,
+        cluster="local",
         block=True,
         monitor=False,
     )
@@ -170,7 +170,7 @@ def test_concatenate_with_single_slice_to_all(create_custom_plate, tmp_path, sba
         settings=settings,
         output_dirpath=output_path,
         sbatch_filepath=sbatch_file,
-        local=True,
+        cluster="local",
         block=True,
         monitor=False,
     )
@@ -222,7 +222,7 @@ def test_concatenate_with_cropping(create_custom_plate, tmp_path, sbatch_file):
         settings=settings,
         output_dirpath=output_path,
         sbatch_filepath=sbatch_file,
-        local=True,
+        cluster="local",
         block=True,
         monitor=False,
     )
@@ -290,7 +290,7 @@ def test_concatenate_with_custom_chunks(
         settings=settings,
         output_dirpath=output_path,
         sbatch_filepath=sbatch_file,
-        local=True,
+        cluster="local",
         monitor=False,
         block=True,
     )
@@ -350,7 +350,7 @@ def test_concatenate_multiple_plates(create_custom_plate, tmp_path, sbatch_file)
         settings=settings,
         output_dirpath=output_path,
         sbatch_filepath=sbatch_file,
-        local=True,
+        cluster="local",
         block=True,
         monitor=False,
     )
@@ -397,7 +397,7 @@ def test_concatenate_mismatched_with_cropping(create_custom_plate, tmp_path, sba
         settings=settings,
         output_dirpath=output_path,
         sbatch_filepath=sbatch_file,
-        local=True,
+        cluster="local",
         block=True,
         monitor=False,
     )
@@ -448,7 +448,7 @@ def test_concatenate_with_mixed_slice_formats(create_custom_plate, tmp_path, sba
         settings=settings,
         output_dirpath=output_path,
         sbatch_filepath=sbatch_file,
-        local=True,
+        cluster="local",
         block=True,
         monitor=False,
     )
@@ -497,7 +497,7 @@ def test_concatenate_with_unique_positions(create_custom_plate, tmp_path, sbatch
         settings=settings_unique,
         output_dirpath=output_path_unique,
         sbatch_filepath=sbatch_file,
-        local=True,
+        cluster="local",
         block=True,
         monitor=False,
     )


### PR DESCRIPTION
## Summary

Standardizes the `concatenate` CLI and integrates it into the mantis-v2 Nextflow pipeline as the **assemble** step — without per-position fan-out. Instead of Nextflow fanning out one node per position (which forced `--position`/`--init`/`--resolve-config` plumbing), concatenate runs the **whole plate single-shot on one reserved compute node**.

**This single-shot design was preferred over the per-position fan-out in #261 for its simplicity** — fewer CLI modes and no per-position Nextflow plumbing. It also branches cleanly from `main` and does **not** include `estimate-crop` (not needed for mantis-v2; that part still lives in #261).

## CLI (`biahub/concatenate.py`)

Ported from `96f81df` to align with the canonical command template:
- Add `--cluster {slurm,local,debug}` (replacing the legacy `--local`), route the full run through `get_submitit_cluster`, merge `biahub-concatenate` provenance into the preserved source-plate `extra_metadata`, use `slurm_mem`.
- Resource estimation lives in `concatenate()` (like the other CLIs): `_prepare_concatenate` resolves metadata + creates the plate and returns the input shape; `concatenate()` estimates, echoes `RESOURCES`, and returns early on `--init`.
- **Fix a blocking trap:** submitit's `DebugJob` runs *lazily*, so the default path blocks for in-node clusters (`debug`/`local`) — otherwise `concatenate --cluster debug` would exit having written nothing. `slurm` keeps submit-and-detach.
- `--resolve-config` injects `--concat-data-paths` into the raw YAML before validation, so the source config can leave `concat_data_paths` blank for Nextflow to fill.

## Nextflow (`nextflow/modules/assembly.nf`, `mantis-v2.nf`)

- `resolve_concatenate_config` (login node) writes `concatenate_resolved.yml` next to the source config, injecting the deskew/reconstruct/virtual-stain paths.
- `init_concatenate` (login node) creates the plate (idempotent) and emits `RESOURCES`.
- `run_concatenate` runs the plate single-shot on one reserved compute node (`concatenate --cluster debug`, in-process, no nested SLURM). cpus/memory/time come from the parsed `RESOURCES`; memory is 8 GB/cpu (128 GB), and the slow cpu-c nodes (2017 Intel Xeon Gold 6126, 128 GB) are excluded via `--exclude=cpu-c-[1-4]` since the copy is memory-bandwidth-bound.
- Wired into `mantis-v2.nf` after virtual-stain.

## Testing

- `tests/test_concatenate.py` + `tests/test_cli/test_concatenate_cli.py` (single-shot `--cluster debug`, `--resolve-config` blank-paths regression) → **16 passed**. Ruff clean.
- **Nextflow DSL validated** via `nextflow run mantis-v2.nf -preview` on both 24.10.5 and 26.04.3.
- Run end-to-end on real mantis-v2 test data: 9 positions, 6 merged channels, `(86, 1600, 1370)` output.

## Follow-ups / tuning

- Trying the **`--cluster local`** variant (parallelize positions across the node's cores) is a one-line swap in `run_concatenate`.
- `label 'cpu'` routes to the **preempted** partition; a mid-run reclaim restarts the whole task (global `errorStrategy` retries).

🤖 Generated with [Claude Code](https://claude.com/claude-code)