### PR TITLE
refactor(concatenate): drop --resolve-config, resolve on --concat-data-paths

### DIFF
--- a/biahub/concatenate.py
+++ b/biahub/concatenate.py
@@ -552,17 +552,14 @@ def concatenate(
 @monitor()
 @init_only()
 @click.option(
-    "--resolve-config",
-    "resolve_config_mode",
-    is_flag=True,
-    default=False,
-    help="Resolve placeholder concat_data_paths and write output config.",
-)
-@click.option(
     "--concat-data-paths",
     multiple=True,
     type=str,
-    help="Override concat_data_paths from config (repeat flag, used with --resolve-config).",
+    help=(
+        "Resolve mode: inject these concat_data_paths into the config and write "
+        "the resolved config to -o (a YAML file), then exit. Repeat the flag once "
+        "per source store."
+    ),
 )
 def concatenate_cli(
     config_filepath: Path,
@@ -571,7 +568,6 @@ def concatenate_cli(
     cluster: str = "slurm",
     monitor: bool = False,
     init_only: bool = False,
-    resolve_config_mode: bool = False,
     concat_data_paths: tuple[str, ...] = (),
 ):
     r"""Concatenate datasets (with optional cropping).
@@ -581,8 +577,9 @@ def concatenate_cli(
     >>> biahub concatenate -c ./concat.yml -o ./output.zarr
 
     \b
-    Resolve placeholder paths (Nextflow config prep, runs on the login node):
-    >>> biahub concatenate --resolve-config \
+    Resolve placeholder paths (Nextflow config prep, runs on the login node).
+    Passing --concat-data-paths selects resolve mode; -o is the resolved YAML:
+    >>> biahub concatenate \
         -c concat.yml -o resolved.yml \
         --concat-data-paths "deskew.zarr/*/*/*" \
         --concat-data-paths "reconstruct.zarr/*/*/*"
@@ -599,9 +596,10 @@ def concatenate_cli(
     config_path = config_filepath
     output_path = output_dirpath
 
-    if resolve_config_mode:
-        if not concat_data_paths:
-            raise click.UsageError("--resolve-config requires --concat-data-paths")
+    # Passing --concat-data-paths means "resolve the config": inject the paths
+    # and write the resolved config to -o (a YAML file), then exit. This is the
+    # only use of --concat-data-paths, so its presence selects resolve mode.
+    if concat_data_paths:
         _resolve_concatenate_config(config_path, output_path, concat_data_paths)
         return
 

--- a/nextflow/mantis-v2.nf
+++ b/nextflow/mantis-v2.nf
@@ -126,7 +126,7 @@ workflow {
     // (`concatenate --cluster debug` iterates every position in-process); which
     // channels/crops come from each source is set by the concatenate config, not
     // here. The config's concat_data_paths are placeholders — the subworkflow
-    // injects the three source paths via --resolve-config.
+    // injects the three source paths via --concat-data-paths (resolve mode).
     assemble_trigger = virtual_stain_done.done
     assemble_output  = "${out}/${layout.assemble}/${ds}.zarr"
 

--- a/nextflow/modules/assembly.nf
+++ b/nextflow/modules/assembly.nf
@@ -18,8 +18,9 @@
 // Like the other steps, a cheap `--init` step on the login node creates the
 // output plate (create_empty_plate is idempotent) and emits the RESOURCES line
 // that sizes the compute node. Path injection: the source zarr paths are
-// Nextflow runtime values, so `--resolve-config` templates them into
-// concat_data_paths — also a login-node step — before init/run read the config.
+// Nextflow runtime values, so passing `--concat-data-paths` templates them into
+// concat_data_paths (resolve mode) — also a login-node step — before init/run
+// read the config.
 
 include { parse_resources; biahub_cmd; slurm_logs; slurm_log_dir } from './common'
 
@@ -39,15 +40,15 @@ process resolve_concatenate_config {
     path "concatenate_resolved.yml"
 
     // Write the resolved config alongside the source config (config_dir) so it
-    // sits with the rest of the run's configs. `rm -f` first because
-    // `--resolve-config -o` refuses to overwrite an existing file, so a rerun
-    // would otherwise fail on the stale copy.
+    // sits with the rest of the run's configs. `rm -f` first because resolve
+    // mode's `-o` refuses to overwrite an existing file, so a rerun would
+    // otherwise fail on the stale copy.
     script:
     def resolved = "${config_dir}/concatenate_resolved.yml"
     """
     mkdir -p "${config_dir}"
     rm -f "${resolved}"
-    ${biahub_cmd()} concatenate --resolve-config \
+    ${biahub_cmd()} concatenate \
         -c "${config}" \
         -o "${resolved}" \
         --concat-data-paths "${deskew_zarr}/*/*/*" \

--- a/tests/test_cli/test_concatenate_cli.py
+++ b/tests/test_cli/test_concatenate_cli.py
@@ -8,11 +8,12 @@ from biahub.cli.main import cli
 
 
 def test_resolve_config_blank_concat_data_paths(tmp_path):
-    """`--resolve-config` must fill a blank concat_data_paths in the source config.
+    """Passing --concat-data-paths resolves a blank concat_data_paths config.
 
-    Regression guard: the Nextflow config leaves concat_data_paths empty for the
-    pipeline to inject, so resolution must apply the override before validating
-    (concat_data_paths is a required non-empty list on ConcatenateSettings).
+    Regression guard: --concat-data-paths selects resolve mode and fills the
+    (intentionally blank, for Nextflow to inject) concat_data_paths, applying the
+    override before validating — concat_data_paths is a required non-empty list
+    on ConcatenateSettings.
     """
     config_path = tmp_path / "concatenate.yml"
     config_path.write_text(
@@ -27,7 +28,6 @@ def test_resolve_config_blank_concat_data_paths(tmp_path):
         cli,
         [
             "concatenate",
-            "--resolve-config",
             "-c",
             str(config_path),
             "-o",


### PR DESCRIPTION
## Summary

Follow-up to #279 (now merged). Removes the redundant `--resolve-config` flag from `biahub concatenate`: `--concat-data-paths` was only ever used to resolve the config, so its **presence** now selects resolve mode.

- **Resolve** (Nextflow config prep, login node): `biahub concatenate -c concat.yml -o resolved.yml --concat-data-paths "deskew.zarr/*/*/*" --concat-data-paths "reconstruct.zarr/*/*/*"` → injects the paths and writes the resolved YAML, then exits.
- **Init / run** (unchanged): no `--concat-data-paths` → `--init` creates the plate + emits RESOURCES, or the default runs the concatenation.

The `-o` semantics still switch with the mode (resolved YAML file vs. output zarr dir); that's now keyed on whether `--concat-data-paths` is present — the same signal that distinguished the two modes before.

## Changes

- `biahub/concatenate.py`: remove the `--resolve-config` option and `resolve_config_mode`; enter resolve mode when `concat_data_paths` is non-empty. Update help text and docstring.
- `nextflow/modules/assembly.nf`: `resolve_concatenate_config` drops `--resolve-config` (just passes `--concat-data-paths`).
- `nextflow/mantis-v2.nf`: comment updated.
- `tests/test_cli/test_concatenate_cli.py`: resolve regression test drops the flag.

## Testing

- 16 tests pass (`test_concatenate.py` + `test_cli/test_concatenate_cli.py`); ruff clean.
- Behavior check: passing `--concat-data-paths` writes the resolved config (exit 0) with the injected paths.
- Nextflow DSL validated via `nextflow run mantis-v2.nf -preview` (26.04.3) → `[SUCCESS]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)