### PR TITLE
fix(virtual-stain): suffix output channels with _prediction

### DIFF
--- a/biahub/virtual_stain.py
+++ b/biahub/virtual_stain.py
@@ -255,10 +255,13 @@ def _init_output_plate(
         scale = input_dataset.scale
     T, C, Z, Y, X = input_shape
 
+    # Match viscy's HCSPredictionWriter naming contract: output channels are the
+    # target channels suffixed with "_prediction" (e.g. "nuclei" -> "nuclei_prediction").
+    # Downstream biahub steps (settings, track, airtable) key off this suffix. See #288.
     create_empty_plate(
         store_path=output_dirpath,
         position_keys=[Path(p).parts[-3:] for p in input_position_dirpaths],
-        channel_names=target_channels,
+        channel_names=[f"{ch}_prediction" for ch in target_channels],
         shape=(T, len(target_channels), Z, Y, X),
         scale=scale,
         version=resolve_ome_zarr_version(input_position_dirpaths[0], output_ome_zarr_version),


### PR DESCRIPTION
## Summary

`biahub virtual-stain` named its output channels **verbatim** from `cfg.data.init_args.target_channel`, dropping the `_prediction` suffix that viscy's `HCSPredictionWriter` used to append. With the same config, prediction stores came out as `nuclei` / `membrane` instead of `nuclei_prediction` / `membrane_prediction`, and had to be renamed by hand.

This restores the viscy naming contract by concatenating `_prediction` onto each target channel in `_init_output_plate`:

```python
channel_names=[f"{ch}_prediction" for ch in target_channels],
```

## Why

The `_prediction` suffix is an implicit contract the rest of the pipeline relies on:

- `biahub/settings.py` defaults `input_channel` / `target_channel` to `"nuclei_prediction"`
- `biahub/track.py` `mem_nuc_contour(nuclei_prediction, membrane_prediction)`
- viscy's airtable `filter_raw_channels` treats `nuclei_prediction` / `membrane_prediction` as virtual stains

The `cytoland` provenance metadata still records the original `target_channel` (`nuclei`/`membrane`) — correct, since that's the model's training target; only the output channel *labels* get the suffix. The write path indexes positionally, so no other code changes are needed.

Closes #288