### PR TITLE
feat(tile_stitch): honour monarch.recon_dtype as the stored output dtype

### DIFF
--- a/biahub/tile_stitch/orchestration.py
+++ b/biahub/tile_stitch/orchestration.py
@@ -64,12 +64,26 @@ def _is_plate_position(path: Path) -> bool:
         return False
 
 
-def _chunk_shape(tile_spatial: tuple[int, ...]) -> tuple[int, ...]:
-    """Keep float32 TCZYX chunks near 64 MB for parallel zarrs writes."""
+def _output_dtype(config: TileStitchReconSettings):
+    """Return the stored output dtype, taken from ``monarch.recon_dtype``.
+
+    ``ReconDtype`` is a ``StrEnum`` of numpy dtype names, so it converts directly.
+    """
+    import numpy as np
+
+    return np.dtype(str(config.monarch.recon_dtype))
+
+
+def _chunk_shape(tile_spatial: tuple[int, ...], itemsize: int) -> tuple[int, ...]:
+    """Keep TCZYX chunks near 64 MB for parallel zarrs writes.
+
+    ``itemsize`` follows the stored dtype, so a float16 run gets chunks with twice the
+    leading extent rather than half-size chunks.
+    """
     import math
 
     lead, *rest = tile_spatial
-    rest_bytes = math.prod(rest) * 4
+    rest_bytes = math.prod(rest) * itemsize
     cap = max(1, _CHUNK_BYTES_CAP // max(1, rest_bytes))
     return (1, 1, min(lead, cap), *rest)
 
@@ -184,7 +198,7 @@ def prepare_stitch_run(
         channel=channel,
         output_channel_name=f"{channel}_recon",
         full_shape=full_shape,
-        chunk_shape=_chunk_shape(tile_spatial),
+        chunk_shape=_chunk_shape(tile_spatial, _output_dtype(config).itemsize),
         scale=scale,
         plate_mode=plate_mode,
         position_keys=tuple(tuple(path.parts[-3:]) for path in position_paths),
@@ -193,11 +207,10 @@ def prepare_stitch_run(
 
 def create_stitch_output(prepared: PreparedStitchRun) -> None:
     """Create the validated run's destination OME-Zarr hierarchy."""
-    import numpy as np
-
     from iohub.ngff import open_ome_zarr
     from iohub.ngff.models import TransformationMeta
 
+    dtype = _output_dtype(prepared.config)
     prepared.run_dir.mkdir(parents=True, exist_ok=True)
     if prepared.plate_mode:
         from iohub.ngff.utils import create_empty_plate
@@ -209,7 +222,7 @@ def create_stitch_output(prepared: PreparedStitchRun) -> None:
             shape=prepared.full_shape,
             chunks=prepared.chunk_shape,
             scale=prepared.scale,
-            dtype=np.float32,
+            dtype=dtype,
         )
         return
 
@@ -222,7 +235,7 @@ def create_stitch_output(prepared: PreparedStitchRun) -> None:
         output.create_zeros(
             "0",
             shape=prepared.full_shape,
-            dtype=np.float32,
+            dtype=dtype,
             chunks=prepared.chunk_shape,
             transform=[TransformationMeta(type="scale", scale=list(prepared.scale))],
         )

--- a/tests/tile_stitch/test_orchestration.py
+++ b/tests/tile_stitch/test_orchestration.py
@@ -16,24 +16,27 @@ from biahub.tile_stitch.orchestration import (
 )
 
 
-def _config(time_indices: str | list[int] = "all") -> TileStitchReconSettings:
-    return TileStitchReconSettings.model_validate(
-        {
-            "tile_stitch": {
-                "tile": {
-                    "tile_size": {"z": 4, "y": 16, "x": 16},
-                    "overlap": {"z": 0, "y": 4, "x": 4},
-                },
-                "blend": {"kind": "uniform_mean"},
-                "recon": {
-                    "input_channel_names": ["phase"],
-                    "reconstruction_dimension": 3,
-                    "phase": {},
-                },
+def _config(
+    time_indices: str | list[int] = "all", recon_dtype: str | None = None
+) -> TileStitchReconSettings:
+    settings: dict = {
+        "tile_stitch": {
+            "tile": {
+                "tile_size": {"z": 4, "y": 16, "x": 16},
+                "overlap": {"z": 0, "y": 4, "x": 4},
             },
-            "time_indices": time_indices,
-        }
-    )
+            "blend": {"kind": "uniform_mean"},
+            "recon": {
+                "input_channel_names": ["phase"],
+                "reconstruction_dimension": 3,
+                "phase": {},
+            },
+        },
+        "time_indices": time_indices,
+    }
+    if recon_dtype is not None:
+        settings["monarch"] = {"recon_dtype": recon_dtype}
+    return TileStitchReconSettings.model_validate(settings)
 
 
 def _position(path: Path, shape: tuple[int, ...]) -> None:
@@ -67,15 +70,43 @@ def test_prepare_run_separates_static_program_and_work_units(tmp_path: Path):
         assert tuple(output.data.chunks) == prepared.chunk_shape
 
 
-
-
 def test_chunk_shape_caps_production_tiles_near_64_mb():
-    chunk_shape = _chunk_shape((2372, 110, 600))
+    itemsize = np.dtype(np.float32).itemsize
+    chunk_shape = _chunk_shape((2372, 110, 600), itemsize)
 
     assert chunk_shape == (1, 1, 242, 110, 600)
-    assert int(np.prod(chunk_shape)) * np.dtype(np.float32).itemsize <= 64_000_000
-    assert _chunk_shape((4, 16, 16)) == (1, 1, 4, 16, 16)
-    assert _chunk_shape((10, 10_000, 10_000)) == (1, 1, 1, 10_000, 10_000)
+    assert int(np.prod(chunk_shape)) * itemsize <= 64_000_000
+    assert _chunk_shape((4, 16, 16), itemsize) == (1, 1, 4, 16, 16)
+    assert _chunk_shape((10, 10_000, 10_000), itemsize) == (1, 1, 1, 10_000, 10_000)
+
+
+@pytest.mark.parametrize(
+    ("recon_dtype", "expected"),
+    [(None, np.float32), ("float32", np.float32), ("float16", np.float16)],
+)
+def test_output_store_honours_recon_dtype(tmp_path: Path, recon_dtype, expected):
+    """``monarch.recon_dtype`` is documented as the STORED dtype, so the store follows it."""
+    input_path = tmp_path / "input.zarr"
+    _position(input_path, (1, 1, 4, 24, 24))
+
+    prepared = prepare_stitch_run(
+        [input_path], _config(recon_dtype=recon_dtype), tmp_path / "result"
+    )
+    create_stitch_output(prepared)
+
+    with open_ome_zarr(prepared.final_output, layout="fov", mode="r") as output:
+        assert output.data.dtype == expected
+        assert tuple(output.data.chunks) == prepared.chunk_shape
+
+
+def test_chunk_shape_scales_leading_extent_with_itemsize():
+    """A narrower dtype fits more z per chunk rather than producing half-size chunks."""
+    f32 = _chunk_shape((2372, 110, 600), 4)
+    f16 = _chunk_shape((2372, 110, 600), 2)
+
+    assert f16[2] == 2 * f32[2]
+    assert int(np.prod(f16)) * 2 <= 64_000_000
+
 
 def test_prepare_run_rejects_empty_timepoint_selection(tmp_path: Path):
     input_path = tmp_path / "input.zarr"


### PR DESCRIPTION
## What

`create_stitch_output` hardcoded `np.float32`, so a `recon_dtype: float16` run still wrote a **float32** store — double the output bytes on disk. `ReconDtype`'s own docstring says *"Dtype the recon is **stored** + RDMA-transmitted in"*, so this implements documented-but-missing behaviour rather than adding a knob.

- `_output_dtype(config)` derives the store dtype from `monarch.recon_dtype` (`StrEnum` of numpy dtype names, so it converts directly).
- `create_stitch_output` uses it in both the plate and FOV branches.
- `_chunk_shape` now takes `itemsize` instead of assuming 4 bytes, so a narrower dtype fits **more z per chunk** (float16: z 242 → 484, both landing at 63.9 MB) rather than emitting chunks at half the 64 MB target.

Default is unchanged (`ReconDtype.FLOAT32`) — existing configs are unaffected.

## Why it matters here

For the 2026_04_07 DaXi timelapse recon, output is `(2368, 1436, 4445)` per (timepoint, channel). At float32 that's **56.3 GiB** each; 64 timepoints × 2 channels ≈ **7.2 TiB** of intermediate recon output. float16 halves it, which materially changes what fits on `/hpc/projects/waveorder`.

## Tests

- `test_output_store_honours_recon_dtype` — parametrised over unset / `float32` / `float16`, asserts the store dtype and chunk agreement.
- `test_chunk_shape_scales_leading_extent_with_itemsize` — asserts f16 doubles the z extent and stays under the cap.
- Existing `_chunk_shape` assertions updated to pass `itemsize` explicitly (kept required rather than defaulted — a wrong default silently halves chunk sizes).

Chunk math and lint verified. The full suite needs the `feature/device-transfer-api` waveorder that this base branch pins, which isn't installed in my environment.

## ⚠️ Unrelated blocker on this base branch

`feature/tile-stitch-dataflow` repins waveorder to `feature/device-transfer-api`. That branch forked from `feat/anisotropic-yx-pixel-size` at `0d85183` — **one commit before** `f9cbd7e "pass in pinhole for fluorescence reconstructions (#570)"` — and it is the *only* commit it lacks.

Consequence: on this base branch `confocal_pinhole_diameter` has **0 pass-throughs**, so it is silently ignored and fluorescence reconstructs **widefield**. Cherry-picking `f9cbd7e` onto `feature/device-transfer-api` fixes it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)