### PR TITLE
fix(qc): reconcile qc_processes.nf with imaging-qc v0.4 CLI (ADR-003)

### DIFF
--- a/nextflow/modules/qc.nf
+++ b/nextflow/modules/qc.nf
@@ -1,11 +1,11 @@
-include { plan_stage }                         from './qc_processes'
-include { run_step as run_step_w0 }            from './qc_processes'
-include { run_step as run_step_w1 }            from './qc_processes'
-include { run_step as run_step_w2 }            from './qc_processes'
-include { finalize_wave }                      from './qc_processes'
-include { finalize_stage }                     from './qc_processes'
-include { generate_report_spec }                from './qc_processes'
-include { run_report }                          from './qc_processes'
+include { plan_stage }                       from './qc_processes'
+include { compute_step as compute_step_w0 }  from './qc_processes'
+include { compute_step as compute_step_w1 }  from './qc_processes'
+include { compute_step as compute_step_w2 }  from './qc_processes'
+include { finalize_wave }                    from './qc_processes'
+include { finalize_stage }                   from './qc_processes'
+include { generate_report_spec }             from './qc_processes'
+include { run_report }                       from './qc_processes'
 
 
 // ---------------------------------------------------------------------------
@@ -40,7 +40,7 @@ workflow qc_stage_wf {
 
     // Wave 0: position-scoped (may be chunked)
     w0_in = items.w0.map { z,c,wid,sid,pos,cid,ti -> [z,c,sid,pos,cid,ti,[:]] }
-    w0_done = run_step_w0(w0_in)
+    w0_done = compute_step_w0(w0_in)
     w0_count = w0_done.count()
 
     // Finalize wave 0 (merge chunks before dependent wave)
@@ -55,14 +55,14 @@ workflow qc_stage_wf {
     w1_in = items.w1
         .combine(fw0_count)
         .map { z,c,wid,sid,pos,cid,ti,n -> [z,c,sid,pos,null,null,[:]] }
-    w1_done = run_step_w1(w1_in)
+    w1_done = compute_step_w1(w1_in)
     w1_count = w1_done.mix(fw0).count()
 
     // Wave 2: store-scoped (after wave 1)
     w2_in = items.w2
         .combine(w1_count)
         .map { z,c,wid,sid,pos,cid,ti,n -> [z,c,sid,null,null,null,[:]] }
-    w2_done = run_step_w2(w2_in)
+    w2_done = compute_step_w2(w2_in)
 
     // Finalize stage: aggregate + gate + summary
     all_done = w0_done.mix(w1_done, w2_done).count()

--- a/nextflow/modules/qc_processes.nf
+++ b/nextflow/modules/qc_processes.nf
@@ -26,7 +26,7 @@ process plan_stage {
 }
 
 
-process run_step {
+process compute_step {
     tag "${zarr_path}/${position ?: 'store'}/${step_id}"
     label 'cpu'
     clusterOptions { slurm_logs('qc') }

--- a/nextflow/modules/qc_processes.nf
+++ b/nextflow/modules/qc_processes.nf
@@ -3,7 +3,7 @@ include { slurm_logs; slurm_log_dir; biahub_cmd } from './common'
 def qc_cmd() {
     return params.qc_project ?
         "uv run --project ${params.qc_project} imaging-qc" :
-        "uv run --from 'imaging-qc-pipeline @ git+https://github.com/czbiohub-sf/imaging-qc-pipeline@v0.3.2' imaging-qc"
+        "uv run --from 'imaging-qc-pipeline @ git+https://github.com/czbiohub-sf/imaging-qc-pipeline@v0.4.0a1' imaging-qc"
 }
 
 
@@ -46,7 +46,7 @@ process run_step {
     def pos_arg = position ? "--positions '${position}'" : ""
     def chunk_arg = (chunk_id && time_indices) ? "--chunk-id ${chunk_id} --time-indices ${time_indices}" : ""
     """
-    ${qc_cmd()} run-step --config ${config_path} --step-id ${step_id} \
+    ${qc_cmd()} compute --config ${config_path} --step-id ${step_id} \
         ${pos_arg} ${chunk_arg} ${zarr_path}
     """
 }
@@ -69,7 +69,7 @@ process finalize_wave {
 
     script:
     """
-    ${qc_cmd()} finalize-wave --config ${config_path} --wave-id ${wave_id} ${zarr_path}
+    ${qc_cmd()} consolidate --config ${config_path} --wave-id ${wave_id} ${zarr_path}
     """
 }
 
@@ -91,7 +91,8 @@ process finalize_stage {
 
     script:
     """
-    ${qc_cmd()} finalize-stage --config ${config_path} ${zarr_path}
+    ${qc_cmd()} consolidate --config ${config_path} ${zarr_path}
+    ${qc_cmd()} gate --config ${config_path} ${zarr_path}
     """
 }
 


### PR DESCRIPTION
## Summary

imaging-qc v0.4 (ADR-003, "one orchestration path") renamed the QC CLI surface this module drives. Chained onto #262 (`refactor-qc`), which brought `qc_processes.nf` over from the wire-nextflow example. Applies the verb renames + version pin:

- `run_step`:       `run-step`       → `compute`
- `finalize_wave`:  `finalize-wave`  → `consolidate`
- `finalize_stage`: `finalize-stage` → `consolidate` + `gate` (the removed verb was those two behind one name; report stays separate in `qc_report_wf`)
- pin: `v0.3.2` → `v0.4.0a1`

`generate_report_spec` (moved to `biahub generate-report-spec` by this PR's parent) is untouched.

## Verified

End-to-end against a local imaging-qc v0.4 checkout (`--qc_project`): `plan-stage` emits a v3 plan (waves 0,1), `compute` / `consolidate` / `gate` all exit 0, `QC_SUMMARY` intact, and a failing gate still exits 0 (gate failures are not pipeline failures).

## Draft — flips to ready once the tag exists

The pin targets `v0.4.0a1`, which is not cut yet on imaging-qc (the version-bump PR is open there). Until then only the `--qc_project` local-checkout path works; the default `git+...@v0.4.0a1` pin will 404. Mark ready once the tag lands.

## Adjacent follow-up (not this PR)

- **Template gap:** the QC config templates (`qc_base.yaml` + stage files) aren't in the refactor chain — they still carry top-level `mode: full`, which imaging-qc v0.4 rejects (exit 2). That line must be dropped wherever the templates are brought into `refactor-qc`. The files don't exist on this branch.
- Making `refactor-qc` mergeable directly into `main` (rather than via `refactor-assembly`) is separate work; resolving the contract here first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)