### PR TITLE
fix(registration): complete AntsRegistrationSettings so the ants config path runs

### DIFF
--- a/biahub/settings.py
+++ b/biahub/settings.py
@@ -258,7 +258,46 @@ class AffineTransformSettings(MyBaseModel):
 
 
 class AntsRegistrationSettings(MyBaseModel):
+    """Settings for the ANTs registration backend.
+
+    Field names and defaults mirror the keyword arguments of
+    ``biahub.registration.ants.preprocess_czyx``, which is what consumes them.
+
+    Attributes
+    ----------
+    sobel_filter : bool
+        Apply a Sobel filter (3D gradient magnitude) to both volumes before
+        registering, so ANTs matches structural edges rather than raw
+        intensity. Needed for cross-modality pairs such as fluorescence
+        against a virtual-staining prediction.
+    crop : bool
+        Crop both volumes to their overlapping region with the LIR algorithm
+        before registering.
+    ref_mask_radius : float | None
+        Radius of a circular mask applied to the reference channel, as a
+        fraction of image width in ``(0, 1]``. ``None`` applies no mask.
+    clip : bool
+        Clip both volumes to hardcoded intensity limits. Those limits assume a
+        **phase** reference (``np.clip(ref, 0, 0.5)``); leave this off for any
+        other reference, e.g. a virtual-staining prediction whose values range
+        well above 0.5.
+    """
+
     sobel_filter: bool = False
+    crop: bool = False
+    ref_mask_radius: float | None = None
+    clip: bool = False
+
+    @field_validator("ref_mask_radius")
+    @classmethod
+    def check_ref_mask_radius(cls, v):
+        # preprocess_czyx raises on this too, but only after the data is
+        # loaded -- catching it at config-parse time is much cheaper.
+        if v is not None and not (0 < v <= 1):
+            raise ValueError(
+                "ref_mask_radius must be given as a fraction of image width, i.e. (0, 1]."
+            )
+        return v
 
 
 class ManualRegistrationSettings(MyBaseModel):

--- a/settings/example_estimate_registration_settings_ants.yml
+++ b/settings/example_estimate_registration_settings_ants.yml
@@ -1,0 +1,64 @@
+# Name of the fixed (reference) image channel used for registration
+target_channel_name: Phase3D
+
+# Name of the moving image channel to align with the target
+source_channel_name: GFP EX488 EM525-45
+
+# Method to estimate registration parameters
+# "manual" user manually selects matching features
+# "beads" automatic detection of bead matches
+# "ants" uses ANTs registration with optimization
+estimation_method: ants
+
+ants_registration_settings:
+  # Apply a Sobel filter (3D gradient magnitude) to both volumes before
+  # registering, so ANTs matches structural edges rather than raw intensity.
+  # Needed for cross-modality pairs, e.g. fluorescence against a phase or
+  # virtual-staining reference.
+  sobel_filter: True
+
+  # Crop both volumes to their overlapping region (LIR) before registering.
+  crop: False
+
+  # Circular mask on the reference channel, as a fraction of image width in
+  # (0, 1]. Leave empty for no mask.
+  ref_mask_radius:
+
+  # Clip both volumes to hardcoded intensity limits. Those limits assume a
+  # PHASE reference (np.clip(ref, 0, 0.5)) -- leave this off for any other
+  # reference, such as a virtual-staining prediction whose values range well
+  # above 0.5, or it will flatten the reference.
+  clip: False
+
+# Settings for affine transformation estimation
+affine_transform_settings:
+  t_reference: first # "first" or "previous"
+  use_prev_t_transform: True # Use the previous timepoint transform as the initial transform
+  compute_approx_transform: False # Compute the approximate transform before optimizing
+  transform_type: affine # "euclidean", "similarity", or "affine"
+  approx_transform: # Initial guess for the 4x4 affine transform
+    - - 1.0
+      - 0.0
+      - 0.0
+      - 0.0
+    - - 0.0
+      - 1.0
+      - 0.0
+      - 0.0
+    - - 0.0
+      - 0.0
+      - 1.0
+      - 0.0
+    - - 0.0
+      - 0.0
+      - 0.0
+      - 1.0
+
+# Validation and interpolation settings for transform smoothing
+eval_transform_settings:
+  validation_window_size: 10 # number of timepoints to average over
+  validation_tolerance: 100.0 # max difference between transforms
+  interpolation_window_size: 3 # size of the window for interpolation
+  interpolation_type: "linear" # "linear" or "cubic"
+
+verbose: True

--- a/tests/test_example_settings.py
+++ b/tests/test_example_settings.py
@@ -1,3 +1,6 @@
+import inspect
+import re
+
 from pathlib import Path
 
 import numpy as np
@@ -29,6 +32,7 @@ example_settings_params = [
     ("example_concatenate_settings_organelle_dynamics.yml", ConcatenateSettings),
     ("example_concatenate_settings.yml", ConcatenateSettings),
     ("example_deskew_settings.yml", DeskewSettings),
+    ("example_estimate_registration_settings_ants.yml", EstimateRegistrationSettings),
     ("example_estimate_registration_settings_beads.yml", EstimateRegistrationSettings),
     ("example_estimate_registration_settings_manual.yml", EstimateRegistrationSettings),
     ("example_estimate_registration_settings.yml", EstimateRegistrationSettings),
@@ -174,6 +178,53 @@ def test_example_stabilize_timelapse_settings(example_stabilize_timelapse_settin
 def test_example_estimate_registration_settings(example_estimate_registration_settings):
     _, settings = example_estimate_registration_settings
     EstimateRegistrationSettings(**settings)
+
+
+def test_ants_settings_cover_estimate_tczyx_reads():
+    """`AntsRegistrationSettings` must expose every field `estimate_tczyx` reads.
+
+    Regression test: the model previously defined only ``sobel_filter`` while
+    ``estimate_tczyx`` also read ``crop``, ``ref_mask_radius`` and ``clip``, so
+    the config-driven ANTs path raised ``AttributeError`` before reaching ANTs.
+    """
+    from biahub.registration.ants import estimate_tczyx
+    from biahub.settings import AntsRegistrationSettings
+
+    source = inspect.getsource(estimate_tczyx)
+    read = set(re.findall(r"ants_registration_settings\.(\w+)", source))
+    assert read, "no ants_registration_settings reads found -- update this test"
+
+    missing = read - set(AntsRegistrationSettings.model_fields)
+    assert not missing, (
+        f"AntsRegistrationSettings is missing fields read by estimate_tczyx: {missing}"
+    )
+
+
+def test_ants_settings_defaults_match_preprocess_czyx():
+    """Defaults must agree with ``preprocess_czyx``, which consumes them.
+
+    Config-driven and direct calls should behave identically when the user
+    sets nothing.
+    """
+    from biahub.registration.ants import preprocess_czyx
+    from biahub.settings import AntsRegistrationSettings
+
+    settings = AntsRegistrationSettings()
+    params = inspect.signature(preprocess_czyx).parameters
+    for field in AntsRegistrationSettings.model_fields:
+        assert field in params, f"{field} is not a preprocess_czyx parameter"
+        assert getattr(settings, field) == params[field].default, (
+            f"default mismatch for {field}: settings={getattr(settings, field)} "
+            f"preprocess_czyx={params[field].default}"
+        )
+
+
+@pytest.mark.parametrize("radius", [0, -0.2, 1.5])
+def test_ants_ref_mask_radius_rejects_out_of_range(radius):
+    from biahub.settings import AntsRegistrationSettings
+
+    with pytest.raises(ValidationError):
+        AntsRegistrationSettings(ref_mask_radius=radius)
 
 
 def test_example_stitch_settings(example_stitch_settings):


### PR DESCRIPTION
Bug fix. `biahub estimate-registration` with `estimation_method: ants` has never been runnable from a config.

## The bug

`estimate_tczyx` reads four fields off `AntsRegistrationSettings`:

```python
# biahub/registration/ants.py:507-510
crop=ants_registration_settings.crop,
ref_mask_radius=ants_registration_settings.ref_mask_radius,
clip=ants_registration_settings.clip,
sobel_filter=ants_registration_settings.sobel_filter,
```

The model defined only `sobel_filter`, so the config-driven path raised `AttributeError` before reaching ANTs. Only direct `estimate_czyx` calls worked, which is how this went unnoticed.

## The fix

Add `crop`, `ref_mask_radius` and `clip`, with defaults matching `preprocess_czyx`'s signature so config-driven and direct calls behave identically when unset.

`ref_mask_radius` is validated at config-parse time. `preprocess_czyx` already rejects out-of-range values, but only after the data is loaded — failing on the config is much cheaper.

The `clip` docstring records a trap worth knowing: its limits are hardcoded for a **phase** reference (`np.clip(ref, 0, 0.5)`), so it flattens anything else — a virtual-staining prediction ranges well above 0.5.

## Why no test caught it

There were example configs for `beads` and `manual` but none for `ants`, and `test_all_example_settings_tested` only checks that every *existing* file is tested. The untested path was invisible.

This adds the missing example config plus two regression tests that keep the model and its consumer in sync:

- `test_ants_settings_cover_estimate_tczyx_reads` greps `estimate_tczyx` for `ants_registration_settings.<field>` and asserts the model covers every one, so adding a read without a field fails the suite.
- `test_ants_settings_defaults_match_preprocess_czyx` asserts the defaults agree with the function that consumes them.

Both were verified to **fail** against the old model rather than pass vacuously.

## Scope

Three files, additive. No existing QC or registration behaviour is touched — zero diff against `QCBeadsRegistrationSettings`, `EvalTransformSettings`, `evaluate_transforms`, `validate_transforms` and `overlap_score`. Every `settings.py` change is inside the `AntsRegistrationSettings` class.

34 settings tests pass, ruff clean.
