### PR TITLE
feat(qc): standalone QC entrypoint + DynaCell templates (pixel + cell-count)

### DIFF
--- a/nextflow/nextflow.config
+++ b/nextflow/nextflow.config
@@ -9,6 +9,15 @@ params {
     biahub_project    = null
     max_positions     = 0
     max_workers       = 100
+
+    // QC (standalone qc.nf): drives the external imaging-qc CLI. `stages_manifest`
+    // is a CSV (header: zarr_path,config_path) — one row runs one config on one zarr.
+    stages_manifest   = null
+    qc_project        = null   // local imaging-qc checkout for `uv run --project`; null uses the pinned release
+    qc_config_dir     = null   // optional dir of per-stage configs for report-spec generation
+    qc_chunk_size     = 10      // time-chunk size for wave-0 compute (0 = no chunking)
+    qc_report_static  = false   // render a static (non-interactive) report
+    qc_report_dir     = null   // defaults to ${output}/qc/report
 }
 
 process {

--- a/nextflow/qc-standalone.nf
+++ b/nextflow/qc-standalone.nf
@@ -1,0 +1,41 @@
+#!/usr/bin/env nextflow
+//
+// Standalone QC pipeline — runs the external imaging-qc CLI against arbitrary
+// zarr stores listed in a CSV manifest, without the full mantis pipeline.
+// Python owns all dispatch logic via plan-stage (JSON); Nextflow owns fan-out,
+// barriers, and retries.
+//
+//   nextflow run nextflow/qc.nf -c nextflow/nextflow.config -profile slurm \
+//       --stages_manifest stages.csv --output <experiment-dir> \
+//       --qc_project /path/to/imaging-qc-pipeline -resume
+//
+// Manifest is a CSV with header `zarr_path,config_path`; each row is one QC
+// stage (one config on one zarr). Rows run in parallel.
+//
+
+nextflow.enable.dsl = 2
+
+include { qc_stage_wf }   from './modules/qc'
+include { qc_report_wf }  from './modules/qc'
+
+
+workflow {
+    if (!params.stages_manifest) {
+        error "Provide --stages_manifest (CSV with header: zarr_path,config_path)"
+    }
+    if (!params.output) {
+        error "Provide --output (run/output directory)"
+    }
+
+    plan_inputs = Channel
+        .fromPath(params.stages_manifest)
+        .splitCsv(header: true)
+        .map { row -> tuple(row.zarr_path.trim(), row.config_path.trim()) }
+
+    qc = qc_stage_wf(plan_inputs)
+
+    all_qc_done = qc.done.collect()
+
+    def report_dir = params.qc_report_dir ?: "${params.output}/qc/report"
+    qc_report_wf(all_qc_done, report_dir)
+}

--- a/settings/nextflow_templates/qc/qc_assembled_pixel_metrics.yaml
+++ b/settings/nextflow_templates/qc/qc_assembled_pixel_metrics.yaml
@@ -1,0 +1,17 @@
+defaults:
+  - qc_base
+  - _self_
+
+# Pixel-value QC for an assembled (post-assembly) intensity store — the
+# `<name>_imaging.zarr` holding the raw acquired channels. Inherits the metric
+# set from qc_base (intensity_stats, signal_to_noise, blank, tenengrad,
+# bleach_rate) and applies it across all channels.
+#
+# The gate floors in qc_base (signal_to_noise hard_floor, tenengrad hard_floor)
+# are starting defaults, not calibrated constants: set them per experiment from
+# the channels and intensity scale at hand. A mixed brightfield + fluorescence
+# store (e.g. "BF - Oblique" alongside "raw GFP …"/"raw mCherry …") in particular
+# wants per-channel floors rather than one global value.
+
+stage: 5
+display_name: "Assembled Image — Pixel QC"

--- a/settings/nextflow_templates/qc/qc_assembled_pixel_metrics.yaml
+++ b/settings/nextflow_templates/qc/qc_assembled_pixel_metrics.yaml
@@ -6,12 +6,27 @@ defaults:
 # `<name>_imaging.zarr` holding the raw acquired channels. Inherits the metric
 # set from qc_base (intensity_stats, signal_to_noise, blank, tenengrad,
 # bleach_rate) and applies it across all channels.
-#
-# The gate floors in qc_base (signal_to_noise hard_floor, tenengrad hard_floor)
-# are starting defaults, not calibrated constants: set them per experiment from
-# the channels and intensity scale at hand. A mixed brightfield + fluorescence
-# store (e.g. "BF - Oblique" alongside "raw GFP …"/"raw mCherry …") in particular
-# wants per-channel floors rather than one global value.
 
 stage: 5
 display_name: "Assembled Image — Pixel QC"
+
+# Per-channel SNR floors override qc_base's single scalar. Brightfield SNR is not
+# comparable to fluorescence, so "BF - Oblique" is left out of the mapping (an
+# unlisted channel gets no hard floor). The fluorescence values below are STARTING
+# POINTS keyed to this store's channel names, NOT constants calibrated from any
+# dataset — set each from the channel's healthy SNR for the experiment at hand.
+signal_to_noise:
+  granularity: z
+  gate:
+    # `granularity: channel` evaluates the gate per channel, which is what lets the
+    # {channel: value} hard_floor key by name (a channel-pooled gate has no channel
+    # to key by and refuses the mapping).
+    granularity: channel
+    hard_floor:
+      "raw GFP EX488 EM525-45": 5.0
+      "raw mCherry EX561 EM600-37": 5.0
+    hard_ceiling: null
+    outlier_method: zscore
+    outlier_params:
+      n_std: 3.0
+      tail: lower

--- a/settings/nextflow_templates/qc/qc_base.yaml
+++ b/settings/nextflow_templates/qc/qc_base.yaml
@@ -1,0 +1,77 @@
+backend: iohub
+positions: null
+metric_group: default
+log_level: INFO
+upstream_qc_dir: null
+
+metric_groups:
+  default:
+    scope: position
+    metrics:
+      - intensity_stats
+      - signal_to_noise
+      - blank
+      - tenengrad
+  temporal:
+    scope: dependent
+    metrics:
+      - bleach_rate
+
+intensity_stats:
+  grid: 16
+  quantiles: [0.01, 0.05, 0.25, 0.5, 0.75, 0.95, 0.99]
+
+signal_to_noise:
+  granularity: z
+  gate:
+    hard_floor: 5.0
+    hard_ceiling: null
+    outlier_method: zscore
+    outlier_params:
+      n_std: 3.0
+      tail: lower
+
+blank:
+  intensity_threshold: 0.01
+  variance_threshold: 1.0e-6
+  granularity: z
+  channels: null
+  gate:
+    aggregation: any
+    granularity: channel
+
+tenengrad:
+  threshold: 0.0
+  normalize: true
+  granularity: z
+  gate:
+    hard_floor: 0.001
+    hard_ceiling: null
+    outlier_method: zscore
+    outlier_params:
+      n_std: 3.0
+      tail: lower
+
+bleach_rate:
+  gate:
+    hard_floor: null
+    hard_ceiling: null
+    outlier_method: zscore
+    outlier_params:
+      n_std: 3.0
+
+report:
+  mode: full
+  max_timepoints: 5
+  compact: false
+  metric_archetypes:
+    signal_to_noise: facetgrid
+    tenengrad: facetgrid
+    intensity_stats: range_drift
+    bleach_rate: timeseries
+  metric_labels:
+    signal_to_noise: "Signal-to-Noise Ratio"
+    blank: "Blank Detection"
+    tenengrad: "Tenengrad"
+    intensity_stats: "Intensity Statistics"
+    bleach_rate: "Bleach Rate"

--- a/settings/nextflow_templates/qc/qc_tracking_cell_count.yaml
+++ b/settings/nextflow_templates/qc/qc_tracking_cell_count.yaml
@@ -1,0 +1,53 @@
+# Cell-count QC over a segmentation/tracking store (`<name>_tracking.zarr`)
+# rather than an intensity store. In the mantis/DynaCell layout the label classes
+# ARE the channels, so `channels:` selects the label class by name and the C
+# column in the output means the label class. Outputs land in
+# `<name>_tracking_qc/`, beside the label store.
+#
+# Self-contained on purpose: an external --config resolves Hydra defaults only
+# against its own directory, so this cannot reference imaging-qc's internal
+# /common or /segmentation groups — their keys are inlined below.
+
+backend: iohub
+positions: null
+metric_group: masks
+log_level: INFO
+upstream_qc_dir: null
+
+stage: 6
+display_name: "Tracking — Cell Count"
+metrics: null  # derived from metric_groups; override via CLI to run a subset
+
+metric_groups:
+  masks:
+    scope: position
+    metrics:
+      - instance_count
+
+instance_count:
+  # `slice` suits a 2D segmentation (Z=1), which is what the tracking subsets hold
+  # (one label plane per (T, C)). For a 3D segmentation set `volume` so each
+  # instance is counted once instead of once per plane.
+  granularity: slice
+  channels:
+    - nuclei_prediction_labels
+  gate:
+    # A count of zero is an empty frame — a dropped/blank timepoint the
+    # segmentation had nothing to find in. This is the degenerate structural
+    # boundary, not a constant calibrated from any dataset.
+    hard_floor: 1
+    # Per-(T,C,Z) verdicts, so one empty timepoint lands on the slice drop list
+    # instead of failing the whole position.
+    gate_granularity: slice
+    # No relative outlier fence, deliberately: at short T a zscore fence cannot
+    # fire and lower_quantile flags the wrong frames. Add one only with enough
+    # rows per population (n >= 11 for n_std 3.0) or pool with pooling_scope: store.
+
+report:
+  mode: full
+  max_timepoints: 5
+  compact: false
+  metric_archetypes:
+    instance_count: timeseries
+  metric_labels:
+    instance_count: "Instance Count"


### PR DESCRIPTION
## Summary

Wires up the QC submodule #262 brought over as modules-only. It couldn't run: no entrypoint and no params. Adds the entrypoint, the params, and two runnable config templates, and validates the whole path end-to-end on real data.

### Wiring
- **`nextflow/qc-standalone.nf`** — manifest-driven entrypoint (CSV header `zarr_path,config_path`; one row = one config on one zarr). Runs `qc_stage_wf` then `qc_report_wf`. Uses `params.output` to match this branch's config conventions.
- **`nextflow.config`** — qc params: `stages_manifest`, `qc_project`, `qc_config_dir`, `qc_chunk_size`, `qc_report_static`, `qc_report_dir`.

### Templates (`settings/nextflow_templates/qc/`)
Updated from the wire-nextflow templates for the imaging-qc v0.4 surface.
- **`qc_base.yaml`** — shared pixel-metric base (intensity_stats, signal_to_noise, blank, tenengrad, bleach_rate). Dropped top-level `mode: full` (removed in ADR-003 Phase 4); migrated deprecated `outlier_method: global_zscore` → `zscore`.
- **`qc_assembled_pixel_metrics.yaml`** — pixel QC on the assembled `*_imaging.zarr` (inherits `qc_base`, stage 5). Overrides `signal_to_noise` with **per-channel** `hard_floor` (fluorescence channels keyed by name; brightfield left unlisted so it gets no floor). Per-channel floors require `granularity: channel` on the gate — a channel-pooled gate refuses the mapping (D35). Values are per-experiment starting points, not calibrated constants.
- **`qc_tracking_cell_count.yaml`** — `instance_count` on the segmentation/tracking `*_tracking.zarr` (label channel, `hard_floor: 1` flags empty frames, `gate_granularity: slice`). Self-contained: an external `--config` resolves Hydra defaults only against its own directory, so imaging-qc's `/common` + `/segmentation` groups are inlined rather than referenced.

## Validation

`nextflow run nextflow/qc-standalone.nf -profile local --qc_project <imaging-qc v0.4 checkout>` on the DynaCell mantis-v2 QC subsets (2 positions, T=5), against the subsets' documented ground truth:

- **Pixel** (`*_imaging.zarr`): 9/9 processes, 0 failed. `pass=1 fail=1` — the blank position flags on `blank` / per-channel `signal_to_noise` / `tenengrad`; the clean control passes. Per-channel SNR flags fire for the fluorescence channels only (brightfield excluded).
- **Cell-count** (`*_tracking.zarr`): 7/7 processes, 0 failed. Reproduces the documented per-timepoint counts exactly; the empty frames land on the slice drop list under `low_instance_count`, the clean control is clear.

The `compute_step` process rename (from #295) runs correctly under fan-out (`compute_step_w0/w1`).

## Notes
- Chained onto #262 (`refactor-qc`).
- The `hard_floor` values in the templates are example starting points to tune per experiment, per the data-variability invariant — not calibrated from the reference subsets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)