### PR TITLE
Feat/resume interrupted positions

### DIFF
--- a/biahub/apply_inverse_transfer_function.py
+++ b/biahub/apply_inverse_transfer_function.py
@@ -24,6 +24,7 @@ from biahub.cli.parsing import (
     sbatch_to_submitit,
 )
 from biahub.cli.utils import (
+    PROVENANCE_METADATA_KEYS,
     echo_resources,
     estimate_resources,
     get_submitit_cluster,
@@ -68,6 +69,7 @@ def _init_output_plate(
         position_keys=[Path(p).parts[-3:] for p in input_position_dirpaths],
         **output_metadata,
         metadata_sources=input_plate,
+        metadata_keys=PROVENANCE_METADATA_KEYS,
     )
 
     return input_shape, channel_names

--- a/biahub/cli/parsing.py
+++ b/biahub/cli/parsing.py
@@ -305,6 +305,25 @@ def monitor() -> Callable:
     return decorator
 
 
+def resume() -> Callable:
+    def decorator(f: Callable) -> Callable:
+        return click.option(
+            "--resume/--no-resume",
+            "resume",
+            default=False,
+            show_default=True,
+            help=(
+                "Skip the (time, channel) units this position already finished in an "
+                "earlier attempt instead of recomputing the whole position. For retrying "
+                "a run that was interrupted, e.g. by Slurm preemption. A finished unit is "
+                "skipped without re-deriving it, so pass --no-resume (or use a fresh "
+                "output store) when the settings changed."
+            ),
+        )(f)
+
+    return decorator
+
+
 def num_processes() -> Callable:
     def decorator(f: Callable) -> Callable:
         return click.option(

--- a/biahub/cli/utils.py
+++ b/biahub/cli/utils.py
@@ -1,3 +1,4 @@
+import hashlib
 import json
 import logging
 import os
@@ -43,6 +44,19 @@ def echo_resources(num_cpus: int, mem_gb: int, time_minutes: int) -> None:
     # cannot serialize.
     payload = {"cpus": int(num_cpus), "mem_gb": int(mem_gb), "time_minutes": int(time_minutes)}
     click.echo("RESOURCES:" + json.dumps(payload))
+
+
+def settings_fingerprint(settings) -> str:
+    """Stable short hash of a settings model.
+
+    Passed to ``process_single_position(resume_token=...)`` so that the
+    per-unit completion records a resumed run relies on belong to the settings
+    that produced them. Re-running a step with a changed config against an
+    existing output store then recomputes instead of skipping units whose data
+    would now be different.
+    """
+    payload = json.dumps(settings.model_dump(mode="json"), sort_keys=True, default=str)
+    return hashlib.sha256(payload.encode()).hexdigest()[:16]
 
 
 def get_submitit_cluster(

--- a/biahub/cli/utils.py
+++ b/biahub/cli/utils.py
@@ -16,6 +16,23 @@ from tqdm import tqdm
 
 logger = logging.getLogger(__name__)
 
+#: ``fnmatch`` patterns for the per-position zattrs keys that steps carry
+#: forward into their output store, passed as ``create_empty_plate``'s
+#: ``metadata_keys``. These are the provenance records each step stamps on its
+#: output — keeping them means a derived plate still describes how it was made.
+#:
+#: This is deliberately an allowlist rather than a denylist. Everything else an
+#: upstream store happens to carry is dropped, which matters most for the
+#: acquisition writer's ``ome_writers`` blob: it holds one record per raw
+#: Z-frame (~18 MB per position on a mantis plate), and its frame indices stop
+#: describing the data as soon as a step changes the shape. Copying it forward
+#: made every ``--init`` step read and rewrite tens of MB per position, and
+#: taxed every subsequent read of the position for no benefit.
+#:
+#: ``normalization`` (written by the reconstruction step) is intentionally
+#: absent — it describes that step's inputs, not its output.
+PROVENANCE_METADATA_KEYS = ("biahub-*", "waveorder", "cytoland")
+
 
 def echo_resources(num_cpus: int, mem_gb: int, time_minutes: int) -> None:
     """Emit the per-position resource request consumed by the Nextflow pipeline.

--- a/biahub/concatenate.py
+++ b/biahub/concatenate.py
@@ -23,6 +23,7 @@ from biahub.cli.parsing import (
     sbatch_to_submitit,
 )
 from biahub.cli.utils import (
+    PROVENANCE_METADATA_KEYS,
     copy_n_paste,
     echo_resources,
     estimate_resources,
@@ -383,6 +384,7 @@ def _prepare_concatenate(settings: ConcatenateSettings, output_dirpath: Path) ->
         store_path=output_dirpath,
         position_keys=[p.parts[-3:] for p in output_position_paths],
         metadata_sources=list(reversed(source_plates)),
+        metadata_keys=PROVENANCE_METADATA_KEYS,
         **output_metadata,
     )
     click.echo(f"Created {output_dirpath} ({len(output_position_paths)} positions)")

--- a/biahub/concatenate.py
+++ b/biahub/concatenate.py
@@ -18,6 +18,7 @@ from biahub.cli.parsing import (
     init_only,
     monitor,
     output_dirpath,
+    resume,
     sbatch_filepath,
     sbatch_to_submitit,
 )
@@ -29,6 +30,7 @@ from biahub.cli.utils import (
     get_submitit_cluster,
     model_to_yaml,
     resolve_ome_zarr_version,
+    settings_fingerprint,
     yaml_to_model,
 )
 from biahub.settings import ConcatenateSettings
@@ -425,6 +427,7 @@ def concatenate(
     block: bool = False,
     monitor: bool = True,
     init_only: bool = False,
+    resume: bool = False,
 ):
     """Concatenate datasets (with optional cropping).
 
@@ -448,6 +451,12 @@ def concatenate(
     init_only : bool, optional
         Only create the output store and emit RESOURCES, then exit; skip the
         per-position copy. By default False.
+    resume : bool, optional
+        Skip the (time, channel) units a previous attempt already finished,
+        rather than recopying the whole plate. This step is a single long job
+        covering every position, so a preemption or walltime kill near the end
+        otherwise discards hours of work. See
+        ``iohub.ngff.utils.process_single_position``.
     """
     slurm_out_path = output_dirpath.parent / "slurm_output"
 
@@ -525,6 +534,8 @@ def concatenate(
                 input_time_indices=input_time_indices,
                 output_time_indices=list(range(len(input_time_indices))),
                 num_workers=slurm_args["slurm_cpus_per_task"],
+                resume=resume,
+                resume_token=settings_fingerprint(settings),
                 extra_metadata=merged_extra,
                 zyx_slicing_params=zyx_slicing_params,
             )
@@ -551,6 +562,7 @@ def concatenate(
 @cluster()
 @monitor()
 @init_only()
+@resume()
 @click.option(
     "--concat-data-paths",
     multiple=True,
@@ -568,6 +580,7 @@ def concatenate_cli(
     cluster: str = "slurm",
     monitor: bool = False,
     init_only: bool = False,
+    resume: bool = False,
     concat_data_paths: tuple[str, ...] = (),
 ):
     r"""Concatenate datasets (with optional cropping).
@@ -621,6 +634,7 @@ def concatenate_cli(
         block=block,
         monitor=monitor,
         init_only=init_only,
+        resume=resume,
     )
 
 

--- a/biahub/concatenate.py
+++ b/biahub/concatenate.py
@@ -462,7 +462,7 @@ def concatenate(
         max_num_cpus=16,
     )
     mem_gb = num_cpus * gb_ram_per_cpu
-    time_minutes = 60
+    time_minutes = 360
     echo_resources(num_cpus, mem_gb, time_minutes=time_minutes)
 
     if init_only:

--- a/biahub/deskew.py
+++ b/biahub/deskew.py
@@ -28,6 +28,7 @@ from biahub.cli.parsing import (
     sbatch_to_submitit,
 )
 from biahub.cli.utils import (
+    PROVENANCE_METADATA_KEYS,
     echo_resources,
     estimate_resources,
     get_submitit_cluster,
@@ -638,6 +639,7 @@ def _init_output_plate(
             input_position_dirpaths[0], settings.output_ome_zarr_version
         ),
         metadata_sources=input_plate,
+        metadata_keys=PROVENANCE_METADATA_KEYS,
     )
 
     return (T, C, Z, Y, X), channel_names

--- a/biahub/deskew.py
+++ b/biahub/deskew.py
@@ -23,6 +23,7 @@ from biahub.cli.parsing import (
     input_position_dirpaths,
     monitor,
     output_dirpath,
+    resume,
     sbatch_filepath,
     sbatch_to_submitit,
 )
@@ -31,6 +32,7 @@ from biahub.cli.utils import (
     estimate_resources,
     get_submitit_cluster,
     resolve_ome_zarr_version,
+    settings_fingerprint,
     yaml_to_model,
 )
 from biahub.settings import DeskewSettings
@@ -649,6 +651,7 @@ def deskew(
     cluster: str = "slurm",
     monitor: bool = True,
     init_only: bool = False,
+    resume: bool = False,
 ):
     """Deskew oblique plane light-sheet dataset, processing time point and channels in parallel.
 
@@ -671,6 +674,10 @@ def deskew(
         Monitor of submitted SLURM jobs.
     init_only : bool, optional
         Only initialize the output store and exit; skip per-position processing.
+    resume : bool, optional
+        Skip the (time, channel) units a previous attempt already finished,
+        rather than recomputing the whole position. For retrying an interrupted
+        run; see ``iohub.ngff.utils.process_single_position``.
     """
     output_dirpath = Path(output_dirpath)
     slurm_out_path = output_dirpath.parent / "slurm_output"
@@ -736,6 +743,8 @@ def deskew(
                     input_position_path,
                     output_position_path,
                     num_workers=slurm_args["slurm_cpus_per_task"],
+                    resume=resume,
+                    resume_token=settings_fingerprint(settings),
                     **deskew_args,
                 )
             )
@@ -769,6 +778,7 @@ def deskew(
 @cluster()
 @monitor()
 @init_only()
+@resume()
 def deskew_cli(
     input_position_dirpaths: list[Path],
     config_filepath: Path,
@@ -777,6 +787,7 @@ def deskew_cli(
     cluster: str = "slurm",
     monitor: bool = False,
     init_only: bool = False,
+    resume: bool = False,
 ):
     """Deskew oblique plane light-sheet dataset. Deskew parameters can be estimated with estimate-deskew.
 
@@ -802,6 +813,7 @@ def deskew_cli(
         cluster=cluster,
         monitor=monitor,
         init_only=init_only,
+        resume=resume,
     )
 
 

--- a/biahub/flat_field.py
+++ b/biahub/flat_field.py
@@ -23,6 +23,7 @@ from biahub.cli.parsing import (
     sbatch_to_submitit,
 )
 from biahub.cli.utils import (
+    PROVENANCE_METADATA_KEYS,
     echo_resources,
     estimate_resources,
     get_submitit_cluster,
@@ -124,6 +125,7 @@ def _init_output_plate(
         ),
         dtype=np.float32,
         metadata_sources=input_plate,
+        metadata_keys=PROVENANCE_METADATA_KEYS,
     )
 
     return (T, C, Z, Y, X), all_channel_names

--- a/biahub/flat_field.py
+++ b/biahub/flat_field.py
@@ -18,6 +18,7 @@ from biahub.cli.parsing import (
     input_position_dirpaths,
     monitor,
     output_dirpath,
+    resume,
     sbatch_filepath,
     sbatch_to_submitit,
 )
@@ -26,6 +27,7 @@ from biahub.cli.utils import (
     estimate_resources,
     get_submitit_cluster,
     resolve_ome_zarr_version,
+    settings_fingerprint,
     yaml_to_model,
 )
 from biahub.settings import FlatFieldCorrectionSettings
@@ -161,6 +163,7 @@ def flat_field(
     cluster: str = "slurm",
     monitor: bool = True,
     init_only: bool = False,
+    resume: bool = False,
 ):
     """Apply flat field correction across T and selected C axes.
 
@@ -181,6 +184,10 @@ def flat_field(
         If True, monitor the submitted jobs.
     init_only : bool, optional
         Only initialize the output store and exit; skip per-position processing.
+    resume : bool, optional
+        Skip the (time, channel) units a previous attempt already finished,
+        rather than recomputing the whole position. For retrying an interrupted
+        run; see ``iohub.ngff.utils.process_single_position``.
     """
     output_dirpath = Path(output_dirpath)
     slurm_out_path = output_dirpath.parent / "slurm_output"
@@ -244,6 +251,8 @@ def flat_field(
                     input_position_path,
                     output_position_path,
                     num_workers=slurm_args["slurm_cpus_per_task"],
+                    resume=resume,
+                    resume_token=settings_fingerprint(settings),
                     **flat_field_args,
                 )
             )
@@ -276,6 +285,7 @@ def flat_field(
 @cluster()
 @monitor()
 @init_only()
+@resume()
 def flat_field_cli(
     input_position_dirpaths: list[Path],
     config_filepath: Path,
@@ -284,6 +294,7 @@ def flat_field_cli(
     cluster: str = "slurm",
     monitor: bool = False,
     init_only: bool = False,
+    resume: bool = False,
 ):
     """Apply flat field correction across T and selected C axes.
 
@@ -307,6 +318,7 @@ def flat_field_cli(
         cluster=cluster,
         monitor=monitor,
         init_only=init_only,
+        resume=resume,
     )
 
 

--- a/biahub/track.py
+++ b/biahub/track.py
@@ -28,6 +28,7 @@ from biahub.cli.parsing import (
 )
 from biahub.cli.resolve_function import resolve_function
 from biahub.cli.utils import (
+    PROVENANCE_METADATA_KEYS,
     echo_resources,
     estimate_resources,
     get_submitit_cluster,
@@ -955,6 +956,7 @@ def _init_output_plate(
         ),
         dtype=np.uint32,
         metadata_sources=input_plate,
+        metadata_keys=PROVENANCE_METADATA_KEYS,
     )
 
     # Record provenance on each output position, mirroring the extra_metadata

--- a/biahub/virtual_stain.py
+++ b/biahub/virtual_stain.py
@@ -25,6 +25,7 @@ from biahub.cli.parsing import (
     sbatch_to_submitit,
 )
 from biahub.cli.utils import (
+    PROVENANCE_METADATA_KEYS,
     echo_resources,
     estimate_resources,
     get_submitit_cluster,
@@ -245,9 +246,15 @@ def _init_output_plate(
     ``output_ome_zarr_version`` dictates the output store's OME-Zarr version;
     when None the input store's version is preserved.
 
+    Upstream provenance zattrs are carried over from the input plate, as in
+    the other steps, so the output records the whole chain that produced it
+    and not just this step. See ``PROVENANCE_METADATA_KEYS`` for what is
+    inherited (and, as importantly, what is left behind).
+
     Each key of ``extra_metadata`` is written as a top-level zattr on every
     output position (mirroring ``process_single_position``), recording
-    provenance such as the validated predict config.
+    provenance such as the validated predict config. These are written after
+    the inherited keys, so this step's own record wins on a name collision.
 
     Returns the input ``(T, C, Z, Y, X)`` shape.
     """
@@ -256,6 +263,7 @@ def _init_output_plate(
         scale = input_dataset.scale
     T, C, Z, Y, X = input_shape
 
+    input_plate = Path(input_position_dirpaths[0]).parents[2]
     create_empty_plate(
         store_path=output_dirpath,
         position_keys=[Path(p).parts[-3:] for p in input_position_dirpaths],
@@ -263,6 +271,8 @@ def _init_output_plate(
         shape=(T, len(target_channels), Z, Y, X),
         scale=scale,
         version=resolve_ome_zarr_version(input_position_dirpaths[0], output_ome_zarr_version),
+        metadata_sources=input_plate,
+        metadata_keys=PROVENANCE_METADATA_KEYS,
     )
 
     if extra_metadata:

--- a/nextflow/modules/assembly.nf
+++ b/nextflow/modules/assembly.nf
@@ -108,8 +108,14 @@ process run_concatenate {
     val output_zarr
 
     script:
+    // --resume matters more here than for the per-position steps: this is a
+    // single job covering every position, so a preemption or walltime kill near
+    // the end would otherwise discard hours of copying. The retry recomputes
+    // only the (t, c) units that had not finished. The completion record is
+    // keyed by the resolved settings, so a config change recomputes instead of
+    // being skipped.
     """
-    ${biahub_cmd()} concatenate --cluster debug \
+    ${biahub_cmd()} concatenate --cluster debug --resume \
         -c "${resolved_config_path}" \
         -o "${output_zarr}"
     """

--- a/nextflow/modules/deskew.nf
+++ b/nextflow/modules/deskew.nf
@@ -57,8 +57,12 @@ process run_deskew {
     val position
 
     script:
+    // --resume: a preempted task finishes the write it is in and stops early, so
+    // the retry (or a later `nextflow -resume`) recomputes only the (t, c) units
+    // this position had not finished. The completion record is keyed by the
+    // resolved settings, so a config change recomputes instead of being skipped.
     """
-    ${biahub_cmd()} deskew --cluster debug \
+    ${biahub_cmd()} deskew --cluster debug --resume \
         -i "${input_zarr}/${position}" \
         -o "${output_zarr}" \
         -c "${config}"

--- a/nextflow/modules/flat_field.nf
+++ b/nextflow/modules/flat_field.nf
@@ -56,8 +56,12 @@ process run_flat_field {
     val position
 
     script:
+    // --resume: a preempted task finishes the write it is in and stops early, so
+    // the retry (or a later `nextflow -resume`) recomputes only the (t, c) units
+    // this position had not finished. The completion record is keyed by the
+    // resolved settings, so a config change recomputes instead of being skipped.
     """
-    ${biahub_cmd()} flat-field --cluster debug \
+    ${biahub_cmd()} flat-field --cluster debug --resume \
         -i "${input_zarr}/${position}" \
         -o "${output_zarr}" \
         -c "${config}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,20 +85,18 @@ index-strategy = "unsafe-best-match"
 # Pin cytoland to the commit from VisCy PR #465 (non-square TTA and helpers).
 # Revert to the PyPI release once that PR is merged and published.
 cytoland = { git = "https://github.com/mehta-lab/VisCy", subdirectory = "applications/cytoland", rev = "4b62365c0df25929bffc7f01b3bb2d1c11d69cce" }
-# Pin iohub to czbiohub-sf/iohub#dev/biahub-pipeline, a short-lived branch that
-# combines the two iohub features this pipeline needs, each of which is up for
-# review on its own branch:
-#   feat/interrupt-safe-writes          replaces a shard torn by a preempted job
-#     instead of reading it back (the recurring "checksum is invalid" abort) and
-#     adds the per-unit resume this branch drives via --resume. Note that the
-#     resume records now sit BESIDE the store, in a `.iohub-progress/` sibling
-#     of the output zarr, rather than inside the array directory — so copying
-#     or deleting a store no longer carries or clears its progress state.
-#   feat/filter-copied-position-metadata  adds create_empty_plate's
-#     metadata_keys, so a step copies only the provenance zattrs it wants
-#     instead of every non-OME key (see PROVENANCE_METADATA_KEYS).
-# Repoint at each feature branch as it merges, then at the PyPI release.
-iohub = { git = "https://github.com/czbiohub-sf/iohub", rev = "c4984be5ea39e601d30687cd9b60f630e021eff1" }
+# Pin iohub to czbiohub-sf/iohub main, which now carries the two features this
+# pipeline needs — both merged, but after the v0.3.10 release:
+#   #455  replaces a shard torn by a preempted job instead of reading it back
+#     (the recurring "checksum is invalid" abort) and adds the per-unit resume
+#     this branch drives via --resume. Note the resume records sit BESIDE the
+#     store, in a `.iohub-progress/` sibling of the output zarr, so copying or
+#     deleting a store no longer carries or clears its progress state.
+#   #454  adds create_empty_plate's metadata_keys, so a step copies only the
+#     provenance zattrs it wants instead of every non-OME key (see
+#     PROVENANCE_METADATA_KEYS).
+# Drop this source and raise the iohub floor once a release includes both.
+iohub = { git = "https://github.com/czbiohub-sf/iohub", rev = "f3c40a4abfda790cf915fd9ccb04ca98fbf15925" }
 
 [tool.hatch.metadata]
 allow-direct-references = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,11 +85,17 @@ index-strategy = "unsafe-best-match"
 # Pin cytoland to the commit from VisCy PR #465 (non-square TTA and helpers).
 # Revert to the PyPI release once that PR is merged and published.
 cytoland = { git = "https://github.com/mehta-lab/VisCy", subdirectory = "applications/cytoland", rev = "4b62365c0df25929bffc7f01b3bb2d1c11d69cce" }
-# Pin iohub to czbiohub-sf/iohub#feat/interrupt-safe-writes, which replaces a
-# shard torn by a preempted job instead of reading it back (the recurring
-# "checksum is invalid" abort) and adds the per-unit resume this branch drives
-# via --resume. Revert to the PyPI release once that is merged and published.
-iohub = { git = "https://github.com/czbiohub-sf/iohub", rev = "714f0e2ede4faebd56f6a2ea7466afcd1d5a8b44" }
+# Pin iohub to czbiohub-sf/iohub#dev/biahub-pipeline, a short-lived branch that
+# combines the two iohub features this pipeline needs, each of which is up for
+# review on its own branch:
+#   feat/interrupt-safe-writes          replaces a shard torn by a preempted job
+#     instead of reading it back (the recurring "checksum is invalid" abort) and
+#     adds the per-unit resume this branch drives via --resume.
+#   feat/filter-copied-position-metadata  adds create_empty_plate's
+#     metadata_keys, so a step copies only the provenance zattrs it wants
+#     instead of every non-OME key (see PROVENANCE_METADATA_KEYS).
+# Repoint at each feature branch as it merges, then at the PyPI release.
+iohub = { git = "https://github.com/czbiohub-sf/iohub", rev = "fc851fd8a9dafb4a82bda138e4449cfe76eee5e8" }
 
 [tool.hatch.metadata]
 allow-direct-references = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,12 +90,15 @@ cytoland = { git = "https://github.com/mehta-lab/VisCy", subdirectory = "applica
 # review on its own branch:
 #   feat/interrupt-safe-writes          replaces a shard torn by a preempted job
 #     instead of reading it back (the recurring "checksum is invalid" abort) and
-#     adds the per-unit resume this branch drives via --resume.
+#     adds the per-unit resume this branch drives via --resume. Note that the
+#     resume records now sit BESIDE the store, in a `.iohub-progress/` sibling
+#     of the output zarr, rather than inside the array directory — so copying
+#     or deleting a store no longer carries or clears its progress state.
 #   feat/filter-copied-position-metadata  adds create_empty_plate's
 #     metadata_keys, so a step copies only the provenance zattrs it wants
 #     instead of every non-OME key (see PROVENANCE_METADATA_KEYS).
 # Repoint at each feature branch as it merges, then at the PyPI release.
-iohub = { git = "https://github.com/czbiohub-sf/iohub", rev = "d28c9fbf1fbf22de958af29eab7746c3e6bd80e5" }
+iohub = { git = "https://github.com/czbiohub-sf/iohub", rev = "c4984be5ea39e601d30687cd9b60f630e021eff1" }
 
 [tool.hatch.metadata]
 allow-direct-references = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,7 +89,7 @@ cytoland = { git = "https://github.com/mehta-lab/VisCy", subdirectory = "applica
 # shard torn by a preempted job instead of reading it back (the recurring
 # "checksum is invalid" abort) and adds the per-unit resume this branch drives
 # via --resume. Revert to the PyPI release once that is merged and published.
-iohub = { git = "https://github.com/czbiohub-sf/iohub", rev = "aca8fbfe02259323f2917070bb5399b1e3900469" }
+iohub = { git = "https://github.com/czbiohub-sf/iohub", rev = "714f0e2ede4faebd56f6a2ea7466afcd1d5a8b44" }
 
 [tool.hatch.metadata]
 allow-direct-references = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,7 +95,7 @@ cytoland = { git = "https://github.com/mehta-lab/VisCy", subdirectory = "applica
 #     metadata_keys, so a step copies only the provenance zattrs it wants
 #     instead of every non-OME key (see PROVENANCE_METADATA_KEYS).
 # Repoint at each feature branch as it merges, then at the PyPI release.
-iohub = { git = "https://github.com/czbiohub-sf/iohub", rev = "fc851fd8a9dafb4a82bda138e4449cfe76eee5e8" }
+iohub = { git = "https://github.com/czbiohub-sf/iohub", rev = "bf2799bc757f3855170c4047a6a5e7a52a8a0085" }
 
 [tool.hatch.metadata]
 allow-direct-references = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,6 +85,11 @@ index-strategy = "unsafe-best-match"
 # Pin cytoland to the commit from VisCy PR #465 (non-square TTA and helpers).
 # Revert to the PyPI release once that PR is merged and published.
 cytoland = { git = "https://github.com/mehta-lab/VisCy", subdirectory = "applications/cytoland", rev = "4b62365c0df25929bffc7f01b3bb2d1c11d69cce" }
+# Pin iohub to czbiohub-sf/iohub#feat/interrupt-safe-writes, which replaces a
+# shard torn by a preempted job instead of reading it back (the recurring
+# "checksum is invalid" abort) and adds the per-unit resume this branch drives
+# via --resume. Revert to the PyPI release once that is merged and published.
+iohub = { git = "https://github.com/czbiohub-sf/iohub", rev = "72011bd7fe345bed23267daa21b18e2e97ea9d21" }
 
 [tool.hatch.metadata]
 allow-direct-references = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,7 +95,7 @@ cytoland = { git = "https://github.com/mehta-lab/VisCy", subdirectory = "applica
 #     metadata_keys, so a step copies only the provenance zattrs it wants
 #     instead of every non-OME key (see PROVENANCE_METADATA_KEYS).
 # Repoint at each feature branch as it merges, then at the PyPI release.
-iohub = { git = "https://github.com/czbiohub-sf/iohub", rev = "bf2799bc757f3855170c4047a6a5e7a52a8a0085" }
+iohub = { git = "https://github.com/czbiohub-sf/iohub", rev = "d28c9fbf1fbf22de958af29eab7746c3e6bd80e5" }
 
 [tool.hatch.metadata]
 allow-direct-references = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,7 +89,7 @@ cytoland = { git = "https://github.com/mehta-lab/VisCy", subdirectory = "applica
 # shard torn by a preempted job instead of reading it back (the recurring
 # "checksum is invalid" abort) and adds the per-unit resume this branch drives
 # via --resume. Revert to the PyPI release once that is merged and published.
-iohub = { git = "https://github.com/czbiohub-sf/iohub", rev = "72011bd7fe345bed23267daa21b18e2e97ea9d21" }
+iohub = { git = "https://github.com/czbiohub-sf/iohub", rev = "aca8fbfe02259323f2917070bb5399b1e3900469" }
 
 [tool.hatch.metadata]
 allow-direct-references = true

--- a/uv.lock
+++ b/uv.lock
@@ -363,7 +363,7 @@ requires-dist = [
     { name = "dask", extras = ["array"] },
     { name = "humanize" },
     { name = "imageio-ffmpeg" },
-    { name = "iohub", git = "https://github.com/czbiohub-sf/iohub?rev=d28c9fbf1fbf22de958af29eab7746c3e6bd80e5" },
+    { name = "iohub", git = "https://github.com/czbiohub-sf/iohub?rev=c4984be5ea39e601d30687cd9b60f630e021eff1" },
     { name = "largestinteriorrectangle" },
     { name = "llvmlite", specifier = ">=0.41.0" },
     { name = "markdown" },
@@ -1786,8 +1786,8 @@ wheels = [
 
 [[package]]
 name = "iohub"
-version = "0.3.11.dev18+d28c9fb"
-source = { git = "https://github.com/czbiohub-sf/iohub?rev=d28c9fbf1fbf22de958af29eab7746c3e6bd80e5#d28c9fbf1fbf22de958af29eab7746c3e6bd80e5" }
+version = "0.3.11.dev21+c4984be"
+source = { git = "https://github.com/czbiohub-sf/iohub?rev=c4984be5ea39e601d30687cd9b60f630e021eff1#c4984be5ea39e601d30687cd9b60f630e021eff1" }
 dependencies = [
     { name = "blosc2" },
     { name = "dask", extra = ["array"] },

--- a/uv.lock
+++ b/uv.lock
@@ -363,7 +363,7 @@ requires-dist = [
     { name = "dask", extras = ["array"] },
     { name = "humanize" },
     { name = "imageio-ffmpeg" },
-    { name = "iohub", git = "https://github.com/czbiohub-sf/iohub?rev=c4984be5ea39e601d30687cd9b60f630e021eff1" },
+    { name = "iohub", git = "https://github.com/czbiohub-sf/iohub?rev=f3c40a4abfda790cf915fd9ccb04ca98fbf15925" },
     { name = "largestinteriorrectangle" },
     { name = "llvmlite", specifier = ">=0.41.0" },
     { name = "markdown" },
@@ -1786,8 +1786,8 @@ wheels = [
 
 [[package]]
 name = "iohub"
-version = "0.3.11.dev21+c4984be"
-source = { git = "https://github.com/czbiohub-sf/iohub?rev=c4984be5ea39e601d30687cd9b60f630e021eff1#c4984be5ea39e601d30687cd9b60f630e021eff1" }
+version = "0.3.11.dev10+f3c40a4"
+source = { git = "https://github.com/czbiohub-sf/iohub?rev=f3c40a4abfda790cf915fd9ccb04ca98fbf15925#f3c40a4abfda790cf915fd9ccb04ca98fbf15925" }
 dependencies = [
     { name = "blosc2" },
     { name = "dask", extra = ["array"] },
@@ -5773,7 +5773,7 @@ dependencies = [
 
 [[package]]
 name = "viscy-transforms"
-version = "0.1.0a0"
+version = "0.0.0.post215.dev0+4b62365"
 source = { git = "https://github.com/mehta-lab/VisCy?subdirectory=packages%2Fviscy-transforms&rev=4b62365c0df25929bffc7f01b3bb2d1c11d69cce#4b62365c0df25929bffc7f01b3bb2d1c11d69cce" }
 dependencies = [
     { name = "kornia" },

--- a/uv.lock
+++ b/uv.lock
@@ -363,7 +363,7 @@ requires-dist = [
     { name = "dask", extras = ["array"] },
     { name = "humanize" },
     { name = "imageio-ffmpeg" },
-    { name = "iohub", specifier = ">=0.3.8" },
+    { name = "iohub", git = "https://github.com/czbiohub-sf/iohub?rev=fc851fd8a9dafb4a82bda138e4449cfe76eee5e8" },
     { name = "largestinteriorrectangle" },
     { name = "llvmlite", specifier = ">=0.41.0" },
     { name = "markdown" },
@@ -1786,12 +1786,13 @@ wheels = [
 
 [[package]]
 name = "iohub"
-version = "0.3.8"
-source = { registry = "https://pypi.org/simple" }
+version = "0.3.11.dev12+fc851fd"
+source = { git = "https://github.com/czbiohub-sf/iohub?rev=fc851fd8a9dafb4a82bda138e4449cfe76eee5e8#fc851fd8a9dafb4a82bda138e4449cfe76eee5e8" }
 dependencies = [
     { name = "blosc2" },
     { name = "dask", extra = ["array"] },
     { name = "natsort" },
+    { name = "nd2" },
     { name = "ndtiff" },
     { name = "pandas" },
     { name = "pillow" },
@@ -1803,10 +1804,6 @@ dependencies = [
     { name = "xarray" },
     { name = "zarr" },
     { name = "zarrs" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/ce/72/c5941fb52dc71ba78d08c05c90d4a7e15a4d7fc25000f7a5b4af20d96a72/iohub-0.3.8.tar.gz", hash = "sha256:db9e7f941058573ea6eb72028081bc830332dc28c7d59c74f7111cf4730cf793", size = 842230, upload-time = "2026-06-22T18:54:19.801Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/5a/55/8ddc8152eb3d38f94d3d5e15a95d210e044b70917071c31c97fd03148b76/iohub-0.3.8-py3-none-any.whl", hash = "sha256:4d34317104a635e5f23fb002352880292ecc04b0ea5286ee86347aaa649066c4", size = 97164, upload-time = "2026-06-22T18:54:18.582Z" },
 ]
 
 [[package]]
@@ -2821,6 +2818,23 @@ wheels = [
 ]
 
 [[package]]
+name = "nd2"
+version = "0.11.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "dask", extra = ["array"] },
+    { name = "numpy" },
+    { name = "ome-types" },
+    { name = "pydantic-core", marker = "python_full_version >= '3.13'" },
+    { name = "resource-backed-dask-array" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e3/e7/2bf7dcb2c011aad251d7041ff592c8ceab30fa6d5c40b654434f0e25e5ba/nd2-0.11.3.tar.gz", hash = "sha256:c153fccee87ef3df27accd18cf813502ceb19289de266a61cc29a5346c43fc91", size = 880585, upload-time = "2026-03-27T19:55:35.165Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/79/51/4f3af9658395bf5549b424b8620df790ba60513d0c093222a55ec5cbb720/nd2-0.11.3-py3-none-any.whl", hash = "sha256:5cf735dc02bb7b8fb400f657f8c04e73f51c28c1032c644a7746948c13be38f9", size = 102111, upload-time = "2026-03-27T19:55:33.398Z" },
+]
+
+[[package]]
 name = "ndindex"
 version = "1.10.1"
 source = { registry = "https://pypi.org/simple" }
@@ -3280,6 +3294,21 @@ wheels = [
 ]
 
 [[package]]
+name = "ome-types"
+version = "0.6.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+    { name = "pydantic-core", marker = "python_full_version >= '3.13'" },
+    { name = "pydantic-extra-types" },
+    { name = "xsdata" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/48/4c/d252c1619c733eec9b4d2d21fe369fd21a2594954b396bf4352edea1e272/ome_types-0.6.3.tar.gz", hash = "sha256:eef4138cda5edfdcb2a44cfb90b714a59ead1b69e4c5ce5f9892ad397ccaaa68", size = 121784, upload-time = "2025-11-26T00:28:24.34Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fc/6a/1000cad1700ab0af4d1b1d0a9c23c34badddb4f547c008bde2a6c61968f1/ome_types-0.6.3-py3-none-any.whl", hash = "sha256:ce9753ff351bbc534ee5c5038d3cf60b1e4c13d69ad2e6b5a5b75de2a52521a5", size = 245802, upload-time = "2025-11-26T00:28:22.853Z" },
+]
+
+[[package]]
 name = "ome-zarr"
 version = "0.16.0"
 source = { registry = "https://pypi.org/simple" }
@@ -3490,71 +3519,73 @@ wheels = [
 
 [[package]]
 name = "pillow"
-version = "12.2.0"
+version = "12.3.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/8c/21/c2bcdd5906101a30244eaffc1b6e6ce71a31bd0742a01eb89e660ebfac2d/pillow-12.2.0.tar.gz", hash = "sha256:a830b1a40919539d07806aa58e1b114df53ddd43213d9c8b75847eee6c0182b5", size = 46987819, upload-time = "2026-04-01T14:46:17.687Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/1c/3d/bb7fca845737cf9d7dbde16ed1843984665ff2e0a518f5db43e77ec540b9/pillow-12.3.0.tar.gz", hash = "sha256:3b8182a766685eaa002637e28b4ec8d6b18819a0c71f579bf0dbaa5830297cce", size = 47025035, upload-time = "2026-07-01T11:56:38.965Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/58/be/7482c8a5ebebbc6470b3eb791812fff7d5e0216c2be3827b30b8bb6603ed/pillow-12.2.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:2d192a155bbcec180f8564f693e6fd9bccff5a7af9b32e2e4bf8c9c69dbad6b5", size = 5308279, upload-time = "2026-04-01T14:43:13.246Z" },
-    { url = "https://files.pythonhosted.org/packages/d8/95/0a351b9289c2b5cbde0bacd4a83ebc44023e835490a727b2a3bd60ddc0f4/pillow-12.2.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:f3f40b3c5a968281fd507d519e444c35f0ff171237f4fdde090dd60699458421", size = 4695490, upload-time = "2026-04-01T14:43:15.584Z" },
-    { url = "https://files.pythonhosted.org/packages/de/af/4e8e6869cbed569d43c416fad3dc4ecb944cb5d9492defaed89ddd6fe871/pillow-12.2.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:03e7e372d5240cc23e9f07deca4d775c0817bffc641b01e9c3af208dbd300987", size = 6284462, upload-time = "2026-04-01T14:43:18.268Z" },
-    { url = "https://files.pythonhosted.org/packages/e9/9e/c05e19657fd57841e476be1ab46c4d501bffbadbafdc31a6d665f8b737b6/pillow-12.2.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:b86024e52a1b269467a802258c25521e6d742349d760728092e1bc2d135b4d76", size = 8094744, upload-time = "2026-04-01T14:43:20.716Z" },
-    { url = "https://files.pythonhosted.org/packages/2b/54/1789c455ed10176066b6e7e6da1b01e50e36f94ba584dc68d9eebfe9156d/pillow-12.2.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7371b48c4fa448d20d2714c9a1f775a81155050d383333e0a6c15b1123dda005", size = 6398371, upload-time = "2026-04-01T14:43:23.443Z" },
-    { url = "https://files.pythonhosted.org/packages/43/e3/fdc657359e919462369869f1c9f0e973f353f9a9ee295a39b1fea8ee1a77/pillow-12.2.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:62f5409336adb0663b7caa0da5c7d9e7bdbaae9ce761d34669420c2a801b2780", size = 7087215, upload-time = "2026-04-01T14:43:26.758Z" },
-    { url = "https://files.pythonhosted.org/packages/8b/f8/2f6825e441d5b1959d2ca5adec984210f1ec086435b0ed5f52c19b3b8a6e/pillow-12.2.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:01afa7cf67f74f09523699b4e88c73fb55c13346d212a59a2db1f86b0a63e8c5", size = 6509783, upload-time = "2026-04-01T14:43:29.56Z" },
-    { url = "https://files.pythonhosted.org/packages/67/f9/029a27095ad20f854f9dba026b3ea6428548316e057e6fc3545409e86651/pillow-12.2.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:fc3d34d4a8fbec3e88a79b92e5465e0f9b842b628675850d860b8bd300b159f5", size = 7212112, upload-time = "2026-04-01T14:43:32.091Z" },
-    { url = "https://files.pythonhosted.org/packages/be/42/025cfe05d1be22dbfdb4f264fe9de1ccda83f66e4fc3aac94748e784af04/pillow-12.2.0-cp312-cp312-win32.whl", hash = "sha256:58f62cc0f00fd29e64b29f4fd923ffdb3859c9f9e6105bfc37ba1d08994e8940", size = 6378489, upload-time = "2026-04-01T14:43:34.601Z" },
-    { url = "https://files.pythonhosted.org/packages/5d/7b/25a221d2c761c6a8ae21bfa3874988ff2583e19cf8a27bf2fee358df7942/pillow-12.2.0-cp312-cp312-win_amd64.whl", hash = "sha256:7f84204dee22a783350679a0333981df803dac21a0190d706a50475e361c93f5", size = 7084129, upload-time = "2026-04-01T14:43:37.213Z" },
-    { url = "https://files.pythonhosted.org/packages/10/e1/542a474affab20fd4a0f1836cb234e8493519da6b76899e30bcc5d990b8b/pillow-12.2.0-cp312-cp312-win_arm64.whl", hash = "sha256:af73337013e0b3b46f175e79492d96845b16126ddf79c438d7ea7ff27783a414", size = 2463612, upload-time = "2026-04-01T14:43:39.421Z" },
-    { url = "https://files.pythonhosted.org/packages/4a/01/53d10cf0dbad820a8db274d259a37ba50b88b24768ddccec07355382d5ad/pillow-12.2.0-cp313-cp313-ios_13_0_arm64_iphoneos.whl", hash = "sha256:8297651f5b5679c19968abefd6bb84d95fe30ef712eb1b2d9b2d31ca61267f4c", size = 4100837, upload-time = "2026-04-01T14:43:41.506Z" },
-    { url = "https://files.pythonhosted.org/packages/0f/98/f3a6657ecb698c937f6c76ee564882945f29b79bad496abcba0e84659ec5/pillow-12.2.0-cp313-cp313-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:50d8520da2a6ce0af445fa6d648c4273c3eeefbc32d7ce049f22e8b5c3daecc2", size = 4176528, upload-time = "2026-04-01T14:43:43.773Z" },
-    { url = "https://files.pythonhosted.org/packages/69/bc/8986948f05e3ea490b8442ea1c1d4d990b24a7e43d8a51b2c7d8b1dced36/pillow-12.2.0-cp313-cp313-ios_13_0_x86_64_iphonesimulator.whl", hash = "sha256:766cef22385fa1091258ad7e6216792b156dc16d8d3fa607e7545b2b72061f1c", size = 3640401, upload-time = "2026-04-01T14:43:45.87Z" },
-    { url = "https://files.pythonhosted.org/packages/34/46/6c717baadcd62bc8ed51d238d521ab651eaa74838291bda1f86fe1f864c9/pillow-12.2.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:5d2fd0fa6b5d9d1de415060363433f28da8b1526c1c129020435e186794b3795", size = 5308094, upload-time = "2026-04-01T14:43:48.438Z" },
-    { url = "https://files.pythonhosted.org/packages/71/43/905a14a8b17fdb1ccb58d282454490662d2cb89a6bfec26af6d3520da5ec/pillow-12.2.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:56b25336f502b6ed02e889f4ece894a72612fe885889a6e8c4c80239ff6e5f5f", size = 4695402, upload-time = "2026-04-01T14:43:51.292Z" },
-    { url = "https://files.pythonhosted.org/packages/73/dd/42107efcb777b16fa0393317eac58f5b5cf30e8392e266e76e51cff28c3d/pillow-12.2.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f1c943e96e85df3d3478f7b691f229887e143f81fedab9b20205349ab04d73ed", size = 6280005, upload-time = "2026-04-01T14:43:54.242Z" },
-    { url = "https://files.pythonhosted.org/packages/a8/68/b93e09e5e8549019e61acf49f65b1a8530765a7f812c77a7461bca7e4494/pillow-12.2.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:03f6fab9219220f041c74aeaa2939ff0062bd5c364ba9ce037197f4c6d498cd9", size = 8090669, upload-time = "2026-04-01T14:43:57.335Z" },
-    { url = "https://files.pythonhosted.org/packages/4b/6e/3ccb54ce8ec4ddd1accd2d89004308b7b0b21c4ac3d20fa70af4760a4330/pillow-12.2.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5cdfebd752ec52bf5bb4e35d9c64b40826bc5b40a13df7c3cda20a2c03a0f5ed", size = 6395194, upload-time = "2026-04-01T14:43:59.864Z" },
-    { url = "https://files.pythonhosted.org/packages/67/ee/21d4e8536afd1a328f01b359b4d3997b291ffd35a237c877b331c1c3b71c/pillow-12.2.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:eedf4b74eda2b5a4b2b2fb4c006d6295df3bf29e459e198c90ea48e130dc75c3", size = 7082423, upload-time = "2026-04-01T14:44:02.74Z" },
-    { url = "https://files.pythonhosted.org/packages/78/5f/e9f86ab0146464e8c133fe85df987ed9e77e08b29d8d35f9f9f4d6f917ba/pillow-12.2.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:00a2865911330191c0b818c59103b58a5e697cae67042366970a6b6f1b20b7f9", size = 6505667, upload-time = "2026-04-01T14:44:05.381Z" },
-    { url = "https://files.pythonhosted.org/packages/ed/1e/409007f56a2fdce61584fd3acbc2bbc259857d555196cedcadc68c015c82/pillow-12.2.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:1e1757442ed87f4912397c6d35a0db6a7b52592156014706f17658ff58bbf795", size = 7208580, upload-time = "2026-04-01T14:44:08.39Z" },
-    { url = "https://files.pythonhosted.org/packages/23/c4/7349421080b12fb35414607b8871e9534546c128a11965fd4a7002ccfbee/pillow-12.2.0-cp313-cp313-win32.whl", hash = "sha256:144748b3af2d1b358d41286056d0003f47cb339b8c43a9ea42f5fea4d8c66b6e", size = 6375896, upload-time = "2026-04-01T14:44:11.197Z" },
-    { url = "https://files.pythonhosted.org/packages/3f/82/8a3739a5e470b3c6cbb1d21d315800d8e16bff503d1f16b03a4ec3212786/pillow-12.2.0-cp313-cp313-win_amd64.whl", hash = "sha256:390ede346628ccc626e5730107cde16c42d3836b89662a115a921f28440e6a3b", size = 7081266, upload-time = "2026-04-01T14:44:13.947Z" },
-    { url = "https://files.pythonhosted.org/packages/c3/25/f968f618a062574294592f668218f8af564830ccebdd1fa6200f598e65c5/pillow-12.2.0-cp313-cp313-win_arm64.whl", hash = "sha256:8023abc91fba39036dbce14a7d6535632f99c0b857807cbbbf21ecc9f4717f06", size = 2463508, upload-time = "2026-04-01T14:44:16.312Z" },
-    { url = "https://files.pythonhosted.org/packages/4d/a4/b342930964e3cb4dce5038ae34b0eab4653334995336cd486c5a8c25a00c/pillow-12.2.0-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:042db20a421b9bafecc4b84a8b6e444686bd9d836c7fd24542db3e7df7baad9b", size = 5309927, upload-time = "2026-04-01T14:44:18.89Z" },
-    { url = "https://files.pythonhosted.org/packages/9f/de/23198e0a65a9cf06123f5435a5d95cea62a635697f8f03d134d3f3a96151/pillow-12.2.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:dd025009355c926a84a612fecf58bb315a3f6814b17ead51a8e48d3823d9087f", size = 4698624, upload-time = "2026-04-01T14:44:21.115Z" },
-    { url = "https://files.pythonhosted.org/packages/01/a6/1265e977f17d93ea37aa28aa81bad4fa597933879fac2520d24e021c8da3/pillow-12.2.0-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:88ddbc66737e277852913bd1e07c150cc7bb124539f94c4e2df5344494e0a612", size = 6321252, upload-time = "2026-04-01T14:44:23.663Z" },
-    { url = "https://files.pythonhosted.org/packages/3c/83/5982eb4a285967baa70340320be9f88e57665a387e3a53a7f0db8231a0cd/pillow-12.2.0-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:d362d1878f00c142b7e1a16e6e5e780f02be8195123f164edf7eddd911eefe7c", size = 8126550, upload-time = "2026-04-01T14:44:26.772Z" },
-    { url = "https://files.pythonhosted.org/packages/4e/48/6ffc514adce69f6050d0753b1a18fd920fce8cac87620d5a31231b04bfc5/pillow-12.2.0-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2c727a6d53cb0018aadd8018c2b938376af27914a68a492f59dfcaca650d5eea", size = 6433114, upload-time = "2026-04-01T14:44:29.615Z" },
-    { url = "https://files.pythonhosted.org/packages/36/a3/f9a77144231fb8d40ee27107b4463e205fa4677e2ca2548e14da5cf18dce/pillow-12.2.0-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:efd8c21c98c5cc60653bcb311bef2ce0401642b7ce9d09e03a7da87c878289d4", size = 7115667, upload-time = "2026-04-01T14:44:32.773Z" },
-    { url = "https://files.pythonhosted.org/packages/c1/fc/ac4ee3041e7d5a565e1c4fd72a113f03b6394cc72ab7089d27608f8aaccb/pillow-12.2.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:9f08483a632889536b8139663db60f6724bfcb443c96f1b18855860d7d5c0fd4", size = 6538966, upload-time = "2026-04-01T14:44:35.252Z" },
-    { url = "https://files.pythonhosted.org/packages/c0/a8/27fb307055087f3668f6d0a8ccb636e7431d56ed0750e07a60547b1e083e/pillow-12.2.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:dac8d77255a37e81a2efcbd1fc05f1c15ee82200e6c240d7e127e25e365c39ea", size = 7238241, upload-time = "2026-04-01T14:44:37.875Z" },
-    { url = "https://files.pythonhosted.org/packages/ad/4b/926ab182c07fccae9fcb120043464e1ff1564775ec8864f21a0ebce6ac25/pillow-12.2.0-cp313-cp313t-win32.whl", hash = "sha256:ee3120ae9dff32f121610bb08e4313be87e03efeadfc6c0d18f89127e24d0c24", size = 6379592, upload-time = "2026-04-01T14:44:40.336Z" },
-    { url = "https://files.pythonhosted.org/packages/c2/c4/f9e476451a098181b30050cc4c9a3556b64c02cf6497ea421ac047e89e4b/pillow-12.2.0-cp313-cp313t-win_amd64.whl", hash = "sha256:325ca0528c6788d2a6c3d40e3568639398137346c3d6e66bb61db96b96511c98", size = 7085542, upload-time = "2026-04-01T14:44:43.251Z" },
-    { url = "https://files.pythonhosted.org/packages/00/a4/285f12aeacbe2d6dc36c407dfbbe9e96d4a80b0fb710a337f6d2ad978c75/pillow-12.2.0-cp313-cp313t-win_arm64.whl", hash = "sha256:2e5a76d03a6c6dcef67edabda7a52494afa4035021a79c8558e14af25313d453", size = 2465765, upload-time = "2026-04-01T14:44:45.996Z" },
-    { url = "https://files.pythonhosted.org/packages/bf/98/4595daa2365416a86cb0d495248a393dfc84e96d62ad080c8546256cb9c0/pillow-12.2.0-cp314-cp314-ios_13_0_arm64_iphoneos.whl", hash = "sha256:3adc9215e8be0448ed6e814966ecf3d9952f0ea40eb14e89a102b87f450660d8", size = 4100848, upload-time = "2026-04-01T14:44:48.48Z" },
-    { url = "https://files.pythonhosted.org/packages/0b/79/40184d464cf89f6663e18dfcf7ca21aae2491fff1a16127681bf1fa9b8cf/pillow-12.2.0-cp314-cp314-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:6a9adfc6d24b10f89588096364cc726174118c62130c817c2837c60cf08a392b", size = 4176515, upload-time = "2026-04-01T14:44:51.353Z" },
-    { url = "https://files.pythonhosted.org/packages/b0/63/703f86fd4c422a9cf722833670f4f71418fb116b2853ff7da722ea43f184/pillow-12.2.0-cp314-cp314-ios_13_0_x86_64_iphonesimulator.whl", hash = "sha256:6a6e67ea2e6feda684ed370f9a1c52e7a243631c025ba42149a2cc5934dec295", size = 3640159, upload-time = "2026-04-01T14:44:53.588Z" },
-    { url = "https://files.pythonhosted.org/packages/71/e0/fb22f797187d0be2270f83500aab851536101b254bfa1eae10795709d283/pillow-12.2.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:2bb4a8d594eacdfc59d9e5ad972aa8afdd48d584ffd5f13a937a664c3e7db0ed", size = 5312185, upload-time = "2026-04-01T14:44:56.039Z" },
-    { url = "https://files.pythonhosted.org/packages/ba/8c/1a9e46228571de18f8e28f16fabdfc20212a5d019f3e3303452b3f0a580d/pillow-12.2.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:80b2da48193b2f33ed0c32c38140f9d3186583ce7d516526d462645fd98660ae", size = 4695386, upload-time = "2026-04-01T14:44:58.663Z" },
-    { url = "https://files.pythonhosted.org/packages/70/62/98f6b7f0c88b9addd0e87c217ded307b36be024d4ff8869a812b241d1345/pillow-12.2.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:22db17c68434de69d8ecfc2fe821569195c0c373b25cccb9cbdacf2c6e53c601", size = 6280384, upload-time = "2026-04-01T14:45:01.5Z" },
-    { url = "https://files.pythonhosted.org/packages/5e/03/688747d2e91cfbe0e64f316cd2e8005698f76ada3130d0194664174fa5de/pillow-12.2.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7b14cc0106cd9aecda615dd6903840a058b4700fcb817687d0ee4fc8b6e389be", size = 8091599, upload-time = "2026-04-01T14:45:04.5Z" },
-    { url = "https://files.pythonhosted.org/packages/f6/35/577e22b936fcdd66537329b33af0b4ccfefaeabd8aec04b266528cddb33c/pillow-12.2.0-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8cbeb542b2ebc6fcdacabf8aca8c1a97c9b3ad3927d46b8723f9d4f033288a0f", size = 6396021, upload-time = "2026-04-01T14:45:07.117Z" },
-    { url = "https://files.pythonhosted.org/packages/11/8d/d2532ad2a603ca2b93ad9f5135732124e57811d0168155852f37fbce2458/pillow-12.2.0-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4bfd07bc812fbd20395212969e41931001fd59eb55a60658b0e5710872e95286", size = 7083360, upload-time = "2026-04-01T14:45:09.763Z" },
-    { url = "https://files.pythonhosted.org/packages/5e/26/d325f9f56c7e039034897e7380e9cc202b1e368bfd04d4cbe6a441f02885/pillow-12.2.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:9aba9a17b623ef750a4d11b742cbafffeb48a869821252b30ee21b5e91392c50", size = 6507628, upload-time = "2026-04-01T14:45:12.378Z" },
-    { url = "https://files.pythonhosted.org/packages/5f/f7/769d5632ffb0988f1c5e7660b3e731e30f7f8ec4318e94d0a5d674eb65a4/pillow-12.2.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:deede7c263feb25dba4e82ea23058a235dcc2fe1f6021025dc71f2b618e26104", size = 7209321, upload-time = "2026-04-01T14:45:15.122Z" },
-    { url = "https://files.pythonhosted.org/packages/6a/7a/c253e3c645cd47f1aceea6a8bacdba9991bf45bb7dfe927f7c893e89c93c/pillow-12.2.0-cp314-cp314-win32.whl", hash = "sha256:632ff19b2778e43162304d50da0181ce24ac5bb8180122cbe1bf4673428328c7", size = 6479723, upload-time = "2026-04-01T14:45:17.797Z" },
-    { url = "https://files.pythonhosted.org/packages/cd/8b/601e6566b957ca50e28725cb6c355c59c2c8609751efbecd980db44e0349/pillow-12.2.0-cp314-cp314-win_amd64.whl", hash = "sha256:4e6c62e9d237e9b65fac06857d511e90d8461a32adcc1b9065ea0c0fa3a28150", size = 7217400, upload-time = "2026-04-01T14:45:20.529Z" },
-    { url = "https://files.pythonhosted.org/packages/d6/94/220e46c73065c3e2951bb91c11a1fb636c8c9ad427ac3ce7d7f3359b9b2f/pillow-12.2.0-cp314-cp314-win_arm64.whl", hash = "sha256:b1c1fbd8a5a1af3412a0810d060a78b5136ec0836c8a4ef9aa11807f2a22f4e1", size = 2554835, upload-time = "2026-04-01T14:45:23.162Z" },
-    { url = "https://files.pythonhosted.org/packages/b6/ab/1b426a3974cb0e7da5c29ccff4807871d48110933a57207b5a676cccc155/pillow-12.2.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:57850958fe9c751670e49b2cecf6294acc99e562531f4bd317fa5ddee2068463", size = 5314225, upload-time = "2026-04-01T14:45:25.637Z" },
-    { url = "https://files.pythonhosted.org/packages/19/1e/dce46f371be2438eecfee2a1960ee2a243bbe5e961890146d2dee1ff0f12/pillow-12.2.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:d5d38f1411c0ed9f97bcb49b7bd59b6b7c314e0e27420e34d99d844b9ce3b6f3", size = 4698541, upload-time = "2026-04-01T14:45:28.355Z" },
-    { url = "https://files.pythonhosted.org/packages/55/c3/7fbecf70adb3a0c33b77a300dc52e424dc22ad8cdc06557a2e49523b703d/pillow-12.2.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:5c0a9f29ca8e79f09de89293f82fc9b0270bb4af1d58bc98f540cc4aedf03166", size = 6322251, upload-time = "2026-04-01T14:45:30.924Z" },
-    { url = "https://files.pythonhosted.org/packages/1c/3c/7fbc17cfb7e4fe0ef1642e0abc17fc6c94c9f7a16be41498e12e2ba60408/pillow-12.2.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:1610dd6c61621ae1cf811bef44d77e149ce3f7b95afe66a4512f8c59f25d9ebe", size = 8127807, upload-time = "2026-04-01T14:45:33.908Z" },
-    { url = "https://files.pythonhosted.org/packages/ff/c3/a8ae14d6defd2e448493ff512fae903b1e9bd40b72efb6ec55ce0048c8ce/pillow-12.2.0-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0a34329707af4f73cf1782a36cd2289c0368880654a2c11f027bcee9052d35dd", size = 6433935, upload-time = "2026-04-01T14:45:36.623Z" },
-    { url = "https://files.pythonhosted.org/packages/6e/32/2880fb3a074847ac159d8f902cb43278a61e85f681661e7419e6596803ed/pillow-12.2.0-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8e9c4f5b3c546fa3458a29ab22646c1c6c787ea8f5ef51300e5a60300736905e", size = 7116720, upload-time = "2026-04-01T14:45:39.258Z" },
-    { url = "https://files.pythonhosted.org/packages/46/87/495cc9c30e0129501643f24d320076f4cc54f718341df18cc70ec94c44e1/pillow-12.2.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:fb043ee2f06b41473269765c2feae53fc2e2fbf96e5e22ca94fb5ad677856f06", size = 6540498, upload-time = "2026-04-01T14:45:41.879Z" },
-    { url = "https://files.pythonhosted.org/packages/18/53/773f5edca692009d883a72211b60fdaf8871cbef075eaa9d577f0a2f989e/pillow-12.2.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:f278f034eb75b4e8a13a54a876cc4a5ab39173d2cdd93a638e1b467fc545ac43", size = 7239413, upload-time = "2026-04-01T14:45:44.705Z" },
-    { url = "https://files.pythonhosted.org/packages/c9/e4/4b64a97d71b2a83158134abbb2f5bd3f8a2ea691361282f010998f339ec7/pillow-12.2.0-cp314-cp314t-win32.whl", hash = "sha256:6bb77b2dcb06b20f9f4b4a8454caa581cd4dd0643a08bacf821216a16d9c8354", size = 6482084, upload-time = "2026-04-01T14:45:47.568Z" },
-    { url = "https://files.pythonhosted.org/packages/ba/13/306d275efd3a3453f72114b7431c877d10b1154014c1ebbedd067770d629/pillow-12.2.0-cp314-cp314t-win_amd64.whl", hash = "sha256:6562ace0d3fb5f20ed7290f1f929cae41b25ae29528f2af1722966a0a02e2aa1", size = 7225152, upload-time = "2026-04-01T14:45:50.032Z" },
-    { url = "https://files.pythonhosted.org/packages/ff/6e/cf826fae916b8658848d7b9f38d88da6396895c676e8086fc0988073aaf8/pillow-12.2.0-cp314-cp314t-win_arm64.whl", hash = "sha256:aa88ccfe4e32d362816319ed727a004423aab09c5cea43c01a4b435643fa34eb", size = 2556579, upload-time = "2026-04-01T14:45:52.529Z" },
+    { url = "https://files.pythonhosted.org/packages/37/bf/fb3ebff8ddcb76aac5a01389251bbbb9519922a9b520d8247c1ca864a25d/pillow-12.3.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:ba09209fbe443b4acccebe845d8a138b89a8f4fbaeedd44953490b5315d5e965", size = 5345969, upload-time = "2026-07-01T11:54:06.397Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/66/9a386a92561f402389a4fc70c18838bf6d35eb5eb5c6850b4b2dc64f5048/pillow-12.3.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ffd0c5368496f41b0944be820fcb7a838aa6e623d250b01acf2643939c3f99d7", size = 4780323, upload-time = "2026-07-01T11:54:09.351Z" },
+    { url = "https://files.pythonhosted.org/packages/25/27/ac8f99618ffd3dde21db0f4d4b1d2ab00c0880595bfd17df103f7f39fd0c/pillow-12.3.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d9c7f76c0673154f044e9d78c8655fb4213f6ca31a836df48b40fe5d187717b9", size = 6266838, upload-time = "2026-07-01T11:54:11.71Z" },
+    { url = "https://files.pythonhosted.org/packages/84/21/a35af28dcc61f37ed850a2d64c65c701321dfbf25085e469d5559360cbbf/pillow-12.3.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:78cb2c6865a35ab8ff8b75fd122f6033b92a62c82801110e48ddd6c936a45d91", size = 6940830, upload-time = "2026-07-01T11:54:13.732Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/51/8b08617af3ad95e33ce6d7dd2c99ed6c8298f7fb131636303956be022e25/pillow-12.3.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:e491916b378fba47242221bb9ead245211b70d504f495d105d17b14a24b4907c", size = 6344383, upload-time = "2026-07-01T11:54:15.756Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/72/cf78ac9780bb93c28328f408973845a309d4d145041665f734572ced1b52/pillow-12.3.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:0dd2064cbc55aaec028ef5fbb60fa47bb6c3e7918e07ff17935284b227a9d2df", size = 7052934, upload-time = "2026-07-01T11:54:17.721Z" },
+    { url = "https://files.pythonhosted.org/packages/20/20/25e0f4dc178a6bc0696793720055519a0de89e7661dae886992decbd2f81/pillow-12.3.0-cp312-cp312-win32.whl", hash = "sha256:dbce0b29841537a2fa4a214c2bbf14de3587c9680caa9b4e217568472490b28f", size = 6472684, upload-time = "2026-07-01T11:54:19.839Z" },
+    { url = "https://files.pythonhosted.org/packages/45/89/da2f7971a317f83d807fdd4065c0af40208e59e692cc43d315a71a0e96d1/pillow-12.3.0-cp312-cp312-win_amd64.whl", hash = "sha256:a2b55dd6b2a4c4b7d87ffa56bdb33fdc5fdb9a462173861a7bc097f17d91cb09", size = 7227137, upload-time = "2026-07-01T11:54:22.025Z" },
+    { url = "https://files.pythonhosted.org/packages/de/47/4845a0a6c0dbf1db8456bd9fc791f13c5ced7ced20606d08a0aacfd25b49/pillow-12.3.0-cp312-cp312-win_arm64.whl", hash = "sha256:331b624368d4f1d069149002f25f44bc61c8919ce8ddb3c45bdad8f6e2d89510", size = 2568267, upload-time = "2026-07-01T11:54:24.051Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/ac/31fb64e1e7efb5a4b50cd3d92049ba89ac6e4d8d3bb6a74e15048ca3353e/pillow-12.3.0-cp313-cp313-ios_13_0_arm64_iphoneos.whl", hash = "sha256:21900ce7ba264168cd50defae43cd75d25c833ad4ad6e73ffc5596d12e25ac89", size = 4161684, upload-time = "2026-07-01T11:54:25.934Z" },
+    { url = "https://files.pythonhosted.org/packages/87/b4/9805e23d2b4d77842b468513841fda254ee42f0289d25088340e4ff46e2d/pillow-12.3.0-cp313-cp313-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:4e8c2a84d977f50b9daed6eeaf3baef67d00d5d74d932288f02cb94518ee3ace", size = 4255487, upload-time = "2026-07-01T11:54:27.935Z" },
+    { url = "https://files.pythonhosted.org/packages/df/39/ecf519435a200c693fe053a6ee4d835b41cf963a4dfc2551c4e637cb2a71/pillow-12.3.0-cp313-cp313-ios_13_0_x86_64_iphonesimulator.whl", hash = "sha256:ae26d61dfa7a47befdc7572b521024e8745f3d809bd95ca9505a7bba9ef849ec", size = 3696433, upload-time = "2026-07-01T11:54:29.813Z" },
+    { url = "https://files.pythonhosted.org/packages/42/92/2fc3ffad878ae8dd5469ec1bc8eb83b71f48e13efdf68f02709003982a32/pillow-12.3.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:7a743ff716f746fc19a9557f60dab1600d4613255f8a7aeb3cdde4db7eb15a66", size = 5345889, upload-time = "2026-07-01T11:54:31.97Z" },
+    { url = "https://files.pythonhosted.org/packages/10/76/8803c13605b763d33d156c4678fc77f8443389c0c51c8aef707bb02015f4/pillow-12.3.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:d69141514cc30b774ceea5e3ed3a6635c8d8a96edf664689b890f4089111fb35", size = 4780109, upload-time = "2026-07-01T11:54:34.026Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/01/e18aff37cb0b4aac47ac90f016d347a49aca667ef97f190b06ac2aabc928/pillow-12.3.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f7401aebd7f581d7f83a439d87d474999317ee099218e5ad25d125290990ba65", size = 6263736, upload-time = "2026-07-01T11:54:36.131Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/62/de5bdd77d935331f4f802edc11e4d82950f642caad6cb2f949837b8560e2/pillow-12.3.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0847a763afefb695bc912d7c131e7e0632d4edc1d8698f58ddabec8e46b8b6d3", size = 6937129, upload-time = "2026-07-01T11:54:38.216Z" },
+    { url = "https://files.pythonhosted.org/packages/70/4d/105627a13300c5e0df1d174230b32fd1273062c96f7745fd552b945d1e1d/pillow-12.3.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:571b9fcb07b97ef3a492028fb3d2dc0993ca23a06138b0315286566d29ef718a", size = 6339562, upload-time = "2026-07-01T11:54:40.354Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/1d/f13de01a553988ab895ba1c722e06cf3144d4f57656fd5b81b6d881f1179/pillow-12.3.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:756c768d0c9c2955feb7a56c37ea24aea2e369f8d36a88da270b6a9f19e62b5e", size = 7049439, upload-time = "2026-07-01T11:54:42.489Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/f9/066794cca041b969964f779ee5fa66a9498bbf34248ac39c5d7954e4198f/pillow-12.3.0-cp313-cp313-win32.whl", hash = "sha256:a876864214e136f0eb367788dbd7df045f4806801518e2cfe9e13229cfe06d8f", size = 6473287, upload-time = "2026-07-01T11:54:44.9Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/9b/7a58e61d62be561da3a356fe2384d4059a6345fc130e23ef1c36a5b81d24/pillow-12.3.0-cp313-cp313-win_amd64.whl", hash = "sha256:1cca606cd25738df4ed873d5ad46bbdb3d83b5cbca291f6b4ff13a4df6b0bbe8", size = 7239691, upload-time = "2026-07-01T11:54:47.141Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/b0/c4ed4f0ef8f8fa5ee8351537db6650bb8189f7e118842978dd6589065692/pillow-12.3.0-cp313-cp313-win_arm64.whl", hash = "sha256:b629de27fda84b42cde7edef0d85f13b958b47f6e9bbcbba9b673c562a89bd8b", size = 2568185, upload-time = "2026-07-01T11:54:49.137Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/01/001f65b68192f0228cc1dbbc8d2530ab5d58b61037ba0587f946fea607cd/pillow-12.3.0-cp314-cp314-ios_13_0_arm64_iphoneos.whl", hash = "sha256:9cf95fe4d0f84c82d282745d9bb08ad9f926efa00be4697e767b814ce40d4330", size = 4161736, upload-time = "2026-07-01T11:54:51.156Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/d2/0219746d0fd16fc8a84498e79452375be3797d3ce4044596ce565164b84f/pillow-12.3.0-cp314-cp314-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:8728f216dcdb6e6d555cf971cb34076139ad74b31fc2c14da4fafc741c5f6217", size = 4255435, upload-time = "2026-07-01T11:54:53.414Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/02/8d0bc62ef0302318c46ff2a512822d2610e81c7aa46c9b3abe6cbaca5ad0/pillow-12.3.0-cp314-cp314-ios_13_0_x86_64_iphonesimulator.whl", hash = "sha256:a45650e8ce7fafffd731db8550230db6b0d306d181a90b67d3e6bca2f1990930", size = 3696262, upload-time = "2026-07-01T11:54:55.739Z" },
+    { url = "https://files.pythonhosted.org/packages/85/e2/73c77d218410b14f5f2d565e8a998d5317b7b9c75368d29985139f7a46f0/pillow-12.3.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:ba54cfebe86920a559a7c4d6b9050791c20513650a1952ebe3368c7dc70306f8", size = 5350344, upload-time = "2026-07-01T11:54:57.657Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/da/32c752228ae345f489e3a42499d817b6c3996da7e8a3bc7a04fc806b243b/pillow-12.3.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:e158cb00350dc278f3b91551101aa7d12415a66ebf2c91d8d5ac14e56ddd3ad0", size = 4780131, upload-time = "2026-07-01T11:54:59.713Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/9d/8b2c807dbef61a5197c047afe99823787eb66f63daf9fb2432f91d6f0462/pillow-12.3.0-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e9aeb04d6aef139de265b29683e119b638208f88cf73cdd1658aa07221165321", size = 6263757, upload-time = "2026-07-01T11:55:01.778Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/44/c85361f65dbe00eea8576ee467c768d25129989efb76e94f205e9ca9bb46/pillow-12.3.0-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:251bf95b67017e27b13d82f5b326234ca62d70f9cf4c2b9032de2358a3b12c7b", size = 6936962, upload-time = "2026-07-01T11:55:03.93Z" },
+    { url = "https://files.pythonhosted.org/packages/18/7e/e483414b35800b86b6f08dbbc7803fb5cd52c4d6f897f47d53ea2c7e6f65/pillow-12.3.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:fe3cca2e4e8a592be0f269a1ca4835c25199d9f3ce815c8491048f785b0a0198", size = 6339171, upload-time = "2026-07-01T11:55:05.989Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/f4/68c491844841ede6bed70189546b3ee9731cf9f2cbad396faff5e1ccba45/pillow-12.3.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:23aceaa007d6172b02c277f0cd359c79492bbb14f7072b4ede9fbcaf20648130", size = 7048116, upload-time = "2026-07-01T11:55:08.131Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/34/77f3f793fed8efc7d243f21b33c5a3f0d1c97ee70346d3db855587e155ff/pillow-12.3.0-cp314-cp314-win32.whl", hash = "sha256:af8d94b0db561cf68b88a267c5c44b49e134f525d0dc2cb7ed413a66bc23559a", size = 6467209, upload-time = "2026-07-01T11:55:10.408Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/e0/492879f69d94f91f60fc8cd05ba03650e9520afebb2fb7aa12777d7c7f38/pillow-12.3.0-cp314-cp314-win_amd64.whl", hash = "sha256:fdafc9cce40277e0f7a0feabce0ee50dd2fa1800f3b38015e51296b5e814048d", size = 7237707, upload-time = "2026-07-01T11:55:12.745Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/ac/6b11f2875f1c2ac040d84e1bbf9cf22a88038f901ca1037898b280b38365/pillow-12.3.0-cp314-cp314-win_arm64.whl", hash = "sha256:e91206ee562682b51b98ef4b26a6ef48fd84e15fd4c4bc5ec768eb641d206838", size = 2565995, upload-time = "2026-07-01T11:55:14.736Z" },
+    { url = "https://files.pythonhosted.org/packages/52/69/c2208e56af9bfc1913afb24020297a691eb1d4ef688474c8a04913f65e04/pillow-12.3.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:164b31cd1a0490ab6efae01aa5df49da7061be0af1b30e035b6e9a1bfe34ee6e", size = 5352503, upload-time = "2026-07-01T11:55:17.076Z" },
+    { url = "https://files.pythonhosted.org/packages/07/70/e5686d753e898a45d778ff1718dba8516ead6ab6b95d85fc8c4b70650cf2/pillow-12.3.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:5afb51d599ea772b8365ae807ae557f18bccfe46ab261fd1c2a9ed700fc6eb17", size = 4782956, upload-time = "2026-07-01T11:55:19.448Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/37/25c6692f06927ee973ff18c8d9ee98ad0b4d84ee67a09610c2dd1447958e/pillow-12.3.0-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3edce1d53195db527e0191f84b71d02022de0540bf43a16ed734ed7537b07385", size = 6322855, upload-time = "2026-07-01T11:55:21.613Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/91/420637fcb8f1bc11029e403b4538e6694744428d8246118e45719f944556/pillow-12.3.0-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bf16ba1b4d0b6b7c8e534936632270cf70eb00dbe09005bc345b2677b726855c", size = 6989642, upload-time = "2026-07-01T11:55:24.006Z" },
+    { url = "https://files.pythonhosted.org/packages/10/08/b94d7811281ccf0d143a1cf768d1c49e1e54af63e7b708ab2ee3eb87face/pillow-12.3.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:24870b09b224f7ae3c39ed07d10e819d06f8720bc551847b1d623832b5b0e28d", size = 6391281, upload-time = "2026-07-01T11:55:26.252Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/87/24233f785f55474dc02ce3e739c5528a77e3a862e9333d1dd7a25cc31f70/pillow-12.3.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:30f2aa603c41533cc25c05acd0da21636e84a315768feb631c937177db558931", size = 7096716, upload-time = "2026-07-01T11:55:28.318Z" },
+    { url = "https://files.pythonhosted.org/packages/23/26/fcb2f6e37175b04f53570b59937867e2b80ee1685e744023153028fc14f9/pillow-12.3.0-cp314-cp314t-win32.whl", hash = "sha256:4b0a7fe987b14c31ebda6083f74f22b561fd3739bc0ac51e019622e3d72668c7", size = 6474125, upload-time = "2026-07-01T11:55:30.956Z" },
+    { url = "https://files.pythonhosted.org/packages/90/de/3634abee5f1c9e13c56787b7d5517b0ba8d6de51700b95578cf338349c9f/pillow-12.3.0-cp314-cp314t-win_amd64.whl", hash = "sha256:962864dc93511324d51ddbb5b9f8731bf71675b93ca612a07441896f4688fb8c", size = 7242939, upload-time = "2026-07-01T11:55:34.044Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/2a/fd13f8eb24de5714a6eb444a3d67e2842c6c576e159a43793adf23051351/pillow-12.3.0-cp314-cp314t-win_arm64.whl", hash = "sha256:0740a512dc522224c77d9aa5a8d70d8b7d73fb91f2c21125d8d025d3b8990e45", size = 2567506, upload-time = "2026-07-01T11:55:35.988Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/dc/8fdce34ec725a33c81c6ba122b904d6b9024e50ea9ac7bede62fab54506c/pillow-12.3.0-cp315-cp315-ios_13_0_arm64_iphoneos.whl", hash = "sha256:0feb2e9d6ad6c9e3c06effe9d00f3f1e618a6643273576b016f591e9315a7139", size = 4162063, upload-time = "2026-07-01T11:55:37.941Z" },
+    { url = "https://files.pythonhosted.org/packages/76/66/2044b9a63d3b84ff048228dfcb7cd9bf0df983e8470971bf7d4c57b693de/pillow-12.3.0-cp315-cp315-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:9e881fca225083806662a5c43d627d215f258ff43c890f831966c7d7ba9c7402", size = 4255549, upload-time = "2026-07-01T11:55:40.022Z" },
+    { url = "https://files.pythonhosted.org/packages/52/7e/1f67e6f4ece6b582ee4b539decbcc9f848dc245a93ed8cd7338bafef72f1/pillow-12.3.0-cp315-cp315-ios_13_0_x86_64_iphonesimulator.whl", hash = "sha256:4998562bf62a445225f22e07c896bb04b35b1b1f2eb6d760584c9c51d7a5f78c", size = 3696331, upload-time = "2026-07-01T11:55:41.98Z" },
+    { url = "https://files.pythonhosted.org/packages/12/40/d306fc2c8e4d45d7f175c77edca7063be7b86fe7fe6e68f4353bf71d808c/pillow-12.3.0-cp315-cp315-macosx_10_15_x86_64.whl", hash = "sha256:dc624f6bc473dacdf7ef7eb8678d0d08edf15cd94fad6ae5c7d6cc67a4e4902f", size = 5350370, upload-time = "2026-07-01T11:55:44.028Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/44/668fb1437e8ce420f62d6106eb66e44a5971602a4d794615bdf79315d82d/pillow-12.3.0-cp315-cp315-macosx_11_0_arm64.whl", hash = "sha256:71d6097b330eea8fd15097780c8e89cb1a8ce7838669f48c5bacd6f663dd4701", size = 4780147, upload-time = "2026-07-01T11:55:46.073Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/08/93fa2e70e30a2d81547e481b6ee2bb9522117221fb1e0ce4b5df70967677/pillow-12.3.0-cp315-cp315-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:28ce87c5ab450a9dd970b52e5aca5fe63ed432d18a2eaddd1979a00a1ba24ace", size = 6273659, upload-time = "2026-07-01T11:55:48.264Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/6d/043e96ff814fc31a33077e4cba86082167db520c93632afdf2042febbb0c/pillow-12.3.0-cp315-cp315-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6b02afb9b97f65fbca5f31db6a2a3ba21aa93030225f150fa3f249717e938fb4", size = 6947439, upload-time = "2026-07-01T11:55:50.503Z" },
+    { url = "https://files.pythonhosted.org/packages/af/92/ba71d2ee2ac0edf3fa33bd9d5ee9ee080da70b1766f3ca3934f9938ddac9/pillow-12.3.0-cp315-cp315-musllinux_1_2_aarch64.whl", hash = "sha256:1182d52bc2d5e5d7d0949503aa7e36d12f42205dc287e4883f407b1988820d39", size = 6353577, upload-time = "2026-07-01T11:55:52.697Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/ce/e63064e2122923ff687c8ad792d0d736a7b3920a56a46982e81a7fdd25d6/pillow-12.3.0-cp315-cp315-musllinux_1_2_x86_64.whl", hash = "sha256:e795b7eb908249c4e43c7c99fac7c2c75dab0c43566e37db472a355f63693d71", size = 7060394, upload-time = "2026-07-01T11:55:55.149Z" },
+    { url = "https://files.pythonhosted.org/packages/54/76/a09cc3ccc8d773a7283d34c38bec1708f9e3cc932093cbc4c5e71ac4060b/pillow-12.3.0-cp315-cp315-win32.whl", hash = "sha256:57b3d78c95ba9059768b10e28b813002261d3f3dfc55cc48b0c988f625175827", size = 6467375, upload-time = "2026-07-01T11:55:57.769Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/03/1846c49ba3b1d5550392a4bbd06d6fb4578e1cd91a803198b5c90f5f7d53/pillow-12.3.0-cp315-cp315-win_amd64.whl", hash = "sha256:fa4ecea169a355be7a3ade2c783e2ed12f0e40d2c5621cda8b3297faf7fbb9f5", size = 7237048, upload-time = "2026-07-01T11:55:59.975Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/bb/89f35dcc79610423f9f195504d7def7f0d1416a711541b42867e25fe3412/pillow-12.3.0-cp315-cp315-win_arm64.whl", hash = "sha256:877c3f311ff35410f690861c4409e7ccbf0cd2f878e50628a28e5a0bb689e658", size = 2566006, upload-time = "2026-07-01T11:56:02.143Z" },
+    { url = "https://files.pythonhosted.org/packages/30/88/707027ba09942dfa2c28759b5c222d769290a41c6d20ea60ec250801941f/pillow-12.3.0-cp315-cp315t-macosx_10_15_x86_64.whl", hash = "sha256:e9871b1ffbfa9656b60aeee92ed5136a5742696006fa322b29ea3d8da0ecc9cf", size = 5352509, upload-time = "2026-07-01T11:56:04.2Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/6d/00352fa25332c2569cd387851f568cc5a4b75a9adbfb37ac4fbce4c02eec/pillow-12.3.0-cp315-cp315t-macosx_11_0_arm64.whl", hash = "sha256:53aa02d20d10c3d814d536aa4e5ac9b84ca0ff5a88377963b085ad6822f93e64", size = 4783167, upload-time = "2026-07-01T11:56:06.631Z" },
+    { url = "https://files.pythonhosted.org/packages/13/4f/9e049dfa21af7c22427275720e2490267ba8138120add5c4c574deb69782/pillow-12.3.0-cp315-cp315t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:446c34dcc4324b084a53b705127dc15717b22c5e140ae0a3c38349d4efec071e", size = 6329237, upload-time = "2026-07-01T11:56:08.868Z" },
+    { url = "https://files.pythonhosted.org/packages/36/16/cf6eeaae8d0fce8dd390a33437cf68c5d5bd73834a2bc6e2f14efda0ab45/pillow-12.3.0-cp315-cp315t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:cf1845d02ad822a369a49f2bb9345b1614744267682e7a03527dc3bf6eea1777", size = 6997047, upload-time = "2026-07-01T11:56:11.379Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/69/dbf769bdd55f48bf5733cac28edc6364ffaa072ec9ba336266e4fe66be55/pillow-12.3.0-cp315-cp315t-musllinux_1_2_aarch64.whl", hash = "sha256:186941b6aef820ad110fb01fb06eb925374dc3a21b17e37ec9a53b250c6fe2d1", size = 6400440, upload-time = "2026-07-01T11:56:13.908Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/e1/ffc9cfc2eea0d178da8018e18e959301ad9d6bc9f3edb7181e748a474b97/pillow-12.3.0-cp315-cp315t-musllinux_1_2_x86_64.whl", hash = "sha256:f13c32a3abd6079a66d9526e18dad9b6d280384d49d7c54040cd57b6424041d9", size = 7105895, upload-time = "2026-07-01T11:56:16.575Z" },
+    { url = "https://files.pythonhosted.org/packages/18/f0/a5595c1e8c3ae44b9828cb2f0fa8155e5095ef04d6327b8f61cf44a3df85/pillow-12.3.0-cp315-cp315t-win32.whl", hash = "sha256:1657923d2d45afb66526e5b933e5b3052e6bdea196c90d3abb2424e18c77dae8", size = 6474384, upload-time = "2026-07-01T11:56:18.855Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/04/62bcd9f844984c5938d3b05264a61d797a29d3e0812341a8204af70bbdee/pillow-12.3.0-cp315-cp315t-win_amd64.whl", hash = "sha256:8cd2f7bdda092d99c9fc2fb7391354f306d01443d22785d0cbfafa2e2c8bb418", size = 7243537, upload-time = "2026-07-01T11:56:21.214Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/68/1f3066acedf37673694a7141381d8f811ae97f30d34413d236abe7d489f1/pillow-12.3.0-cp315-cp315t-win_arm64.whl", hash = "sha256:06ff022112bc9cbf83b60f8e028d94ad87b60621706487e65f673de61610ab59", size = 2567491, upload-time = "2026-07-01T11:56:23.506Z" },
 ]
 
 [[package]]
@@ -4605,6 +4636,19 @@ wheels = [
 ]
 
 [[package]]
+name = "resource-backed-dask-array"
+version = "0.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "dask", extra = ["array"] },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/62/80/b8952048ae1772d33b95dbf7d7107cf364c037cc229a2690fc8fa9ee8e48/resource_backed_dask_array-0.1.0.tar.gz", hash = "sha256:8fabcccf5c7e29059b5badd6786dd7675a258a203c58babf10077d9c90ada54f", size = 10300, upload-time = "2022-02-18T02:10:06.981Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0d/b5/852f619e53fa7fb70d8915fcae66632df3958cac7e926c4ac38458958674/resource_backed_dask_array-0.1.0-py2.py3-none-any.whl", hash = "sha256:ec457fa72d81f0340a67ea6557a5a5919323a11cccc978a950df29fa69fe5679", size = 8044, upload-time = "2022-02-18T02:10:05.559Z" },
+]
+
+[[package]]
 name = "rfc3986"
 version = "2.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -5243,14 +5287,14 @@ wheels = [
 
 [[package]]
 name = "tifffile"
-version = "2026.4.11"
+version = "2026.7.14"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "numpy" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d7/4a/e687f5957fead200faad58dbf9c9431a2bbb118040e96f5fb8a55f7ebc50/tifffile-2026.4.11.tar.gz", hash = "sha256:17758ff0c0d4db385792a083ad3ca51fcb0f4d942642f4d8f8bc1287fdcf17bc", size = 394956, upload-time = "2026-04-12T01:57:28.793Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/20/2f/e5fe51c8f782241d86fdf7251594b195f0d6c2fcf9d389079de212599246/tifffile-2026.7.14.tar.gz", hash = "sha256:ce2703e5ef22c868f1528d5f5b4ef75eefb019cf628a1c9ec0d17e0afeca8ef5", size = 437660, upload-time = "2026-07-14T23:41:31.737Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3f/9f/74f110b4271ded519c7add4341cbabc824de26817ff1c345b3109df9e99c/tifffile-2026.4.11-py3-none-any.whl", hash = "sha256:9b94ffeddb39e97601af646345e8808f885773de01b299e480ed6d3a41509ec9", size = 248227, upload-time = "2026-04-12T01:57:26.969Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/e8/d381de4a3cc4e3682cba0338f43250893508aad0b310af1d0635f7b04413/tifffile-2026.7.14-py3-none-any.whl", hash = "sha256:4eb20372e76edf2c9fed922b1e3a0a0567be3560bd2008336115763bb1f3c034", size = 270614, upload-time = "2026-07-14T23:41:30.078Z" },
 ]
 
 [[package]]
@@ -5729,7 +5773,7 @@ dependencies = [
 
 [[package]]
 name = "viscy-transforms"
-version = "0.0.0.post215.dev0+4b62365"
+version = "0.1.0a0"
 source = { git = "https://github.com/mehta-lab/VisCy?subdirectory=packages%2Fviscy-transforms&rev=4b62365c0df25929bffc7f01b3bb2d1c11d69cce#4b62365c0df25929bffc7f01b3bb2d1c11d69cce" }
 dependencies = [
     { name = "kornia" },
@@ -6019,6 +6063,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/4b/a6/6fe936a798a3a38a79c7422d1a31afd2e9a14690fcb0ccff96bc01f04bf2/xarray-2026.4.0.tar.gz", hash = "sha256:c4ac9a01a945d90d5b1628e2af045099a9d4943536d4f2ee3ae963c3b222d15b", size = 3132311, upload-time = "2026-04-13T19:45:36.688Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/dc/83/6d810a8a9ebc9c307989b418840c20e46907c74d707beb67ab566773e6fc/xarray-2026.4.0-py3-none-any.whl", hash = "sha256:d43751d9fb4a90f9249c30431684f00c41bc874f1edccd862631a40cbc0edf08", size = 1414326, upload-time = "2026-04-13T19:45:34.659Z" },
+]
+
+[[package]]
+name = "xsdata"
+version = "26.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2f/c9/71e9e8eac669091fd434ed494d806c8cc37614aecb34ce4c62c283f99abf/xsdata-26.2.tar.gz", hash = "sha256:c631af71aaa75734f8ce92a08fcf8389d905dee2aab0b5032c9032e9071009a6", size = 349690, upload-time = "2026-02-15T16:13:31.274Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d3/92/f0edcbc2f895ecea14a68e492b24c157625e251279a94b172a6b263290e7/xsdata-26.2-py3-none-any.whl", hash = "sha256:85a591a4405d903416afbd4a917e8dda8ea44641a3e66d72134bc2a31b3c16b0", size = 235561, upload-time = "2026-02-15T16:13:29.614Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -363,7 +363,7 @@ requires-dist = [
     { name = "dask", extras = ["array"] },
     { name = "humanize" },
     { name = "imageio-ffmpeg" },
-    { name = "iohub", git = "https://github.com/czbiohub-sf/iohub?rev=bf2799bc757f3855170c4047a6a5e7a52a8a0085" },
+    { name = "iohub", git = "https://github.com/czbiohub-sf/iohub?rev=d28c9fbf1fbf22de958af29eab7746c3e6bd80e5" },
     { name = "largestinteriorrectangle" },
     { name = "llvmlite", specifier = ">=0.41.0" },
     { name = "markdown" },
@@ -1786,8 +1786,8 @@ wheels = [
 
 [[package]]
 name = "iohub"
-version = "0.3.11.dev14+bf2799b"
-source = { git = "https://github.com/czbiohub-sf/iohub?rev=bf2799bc757f3855170c4047a6a5e7a52a8a0085#bf2799bc757f3855170c4047a6a5e7a52a8a0085" }
+version = "0.3.11.dev18+d28c9fb"
+source = { git = "https://github.com/czbiohub-sf/iohub?rev=d28c9fbf1fbf22de958af29eab7746c3e6bd80e5#d28c9fbf1fbf22de958af29eab7746c3e6bd80e5" }
 dependencies = [
     { name = "blosc2" },
     { name = "dask", extra = ["array"] },

--- a/uv.lock
+++ b/uv.lock
@@ -363,7 +363,7 @@ requires-dist = [
     { name = "dask", extras = ["array"] },
     { name = "humanize" },
     { name = "imageio-ffmpeg" },
-    { name = "iohub", git = "https://github.com/czbiohub-sf/iohub?rev=fc851fd8a9dafb4a82bda138e4449cfe76eee5e8" },
+    { name = "iohub", git = "https://github.com/czbiohub-sf/iohub?rev=bf2799bc757f3855170c4047a6a5e7a52a8a0085" },
     { name = "largestinteriorrectangle" },
     { name = "llvmlite", specifier = ">=0.41.0" },
     { name = "markdown" },
@@ -1786,8 +1786,8 @@ wheels = [
 
 [[package]]
 name = "iohub"
-version = "0.3.11.dev12+fc851fd"
-source = { git = "https://github.com/czbiohub-sf/iohub?rev=fc851fd8a9dafb4a82bda138e4449cfe76eee5e8#fc851fd8a9dafb4a82bda138e4449cfe76eee5e8" }
+version = "0.3.11.dev14+bf2799b"
+source = { git = "https://github.com/czbiohub-sf/iohub?rev=bf2799bc757f3855170c4047a6a5e7a52a8a0085#bf2799bc757f3855170c4047a6a5e7a52a8a0085" }
 dependencies = [
     { name = "blosc2" },
     { name = "dask", extra = ["array"] },


### PR DESCRIPTION
## Problem

The per-position steps run on the `preempted` partition, so SLURM reclaims tasks mid-write. Two things went wrong when it did:

1. **The retry got stuck.** A killed write left a torn shard, which every later attempt read back and rejected — the position never completed and the run aborted.
2. **The retry threw away good work.** Even once unstuck, a retry recomputed the position from scratch, discarding every (t, c) unit the killed attempt had already finished.

Assemble was the worst case: one job copying the whole plate — 26.5k units and ~16 TiB of I/O against a 6 hour limit — so a kill near the end discarded all of it.

Separately, every `--init` step took minutes and wrote GBs, on a step whose only job is to create an empty plate.

## What this branch does

### Resume instead of restart

`flat-field`, `deskew`, and `concatenate` gain `--resume`, threaded through to `process_single_position`; the Nextflow per-position tasks opt in. A retry now recomputes only the units the killed attempt had not finished.

The completion record is keyed by a fingerprint of the **resolved settings** (`settings_fingerprint`), so re-running a step with a changed config against an existing output store recomputes rather than silently skipping units whose data would now differ. `--resume` is off by default — only the Nextflow tasks turn it on, where "recompute what this position is missing" is always what's wanted.

For concatenate, the three source stores write disjoint channels of each output position, so their units never collide.

Verified by killing an assemble partway (7 completion records dropped, plus one shard torn under a record that still claimed done): the resume recomputed exactly those 8 units, skipped the other 16, and produced output bit-identical to an uninterrupted run.

### Stop copying acquisition metadata into every derived store

`create_empty_plate(metadata_sources=...)` copied **every** non-OME zattrs key from the input plate. The mantis acquisition writer leaves an `ome_writers.frame_metadata` list with one record per raw Z-frame — 214,668 entries, 18.5 MB compact, 39 MB once written back — and that rode from the raw store into every derived plate. iohub then wrote it one key at a time, re-reading the destination for each membership test, making the copy quadratic in the metadata size.

Measured on `2026_07_14_A549_MAP4_ZIKV_rerun` (72 positions):

| init step | wall | written |
|---|---|---|
| flat-field | 3m 09s | 4 GB |
| deskew | 6m 14s | 4 GB |
| reconstruct | 7m 28s | 6 GB |
| concatenate | 14m 38s | 10 GB (16 GB read) |
| virtual-stain — *the one step with no `metadata_sources`* | **37s** | **632 KB** |

Each step now passes an explicit allowlist (`PROVENANCE_METADATA_KEYS = ("biahub-*", "waveorder", "cytoland")`) rather than inheriting whatever an upstream store happens to carry. The blob is stale by then anyway: its frame indices describe the raw 1068-plane Z stack, not the 86-plane deskewed output. `normalization` is dropped alongside it — it describes the reconstruction step's inputs, not its output.

Result: `deskew --init` over 66 positions goes **6m 14s → 49s** (most of the remainder is interpreter startup), the per-position `zarr.json` drops from **39 MB → 2.7 KB**, and the array and OME metadata are byte-identical to the store built by the current code.

## iohub dependency

This needs unreleased iohub, pinned to `czbiohub-sf/iohub#dev/biahub-pipeline` — a short-lived branch combining two features, each reviewable on its own:

- **`feat/interrupt-safe-writes`** — replaces a shard torn by a preempted job instead of reading it back (the recurring "checksum is invalid" abort), and adds the per-unit resume this branch drives via `--resume`.
- **`feat/filter-copied-position-metadata`** ([iohub#454](https://github.com/czbiohub-sf/iohub/pull/454)) — adds `create_empty_plate(metadata_keys=...)`.

Repoint at each feature branch as it merges, then at the PyPI release. **This PR should not merge before those do.**

## Notes for reviewers

- **Reconstruct is not covered by resume.** It drives its own per-timepoint loop in waveorder, so it gets the torn-shard repair from iohub but not per-unit resume.
- **No graceful-shutdown path.** An earlier commit on this branch (`b10b1b0`) described SIGTERM letting the in-flight write finish before stopping. That was measured upstream to never fire under Nextflow — the generated `.command.run` traps TERM, kills the payload, and exits without waiting, and slurmstepd follows with SIGKILL — so it has since been removed from iohub. The protection that actually does the work is repair plus resume, both kept.
- **Resume records now live beside the store**, in a `.iohub-progress/` sibling of the output zarr rather than inside the array directory. Copying or deleting a store therefore no longer carries or clears its progress state, and a `.iohub-progress/` directory will appear next to each output plate.

## Testing

`pytest tests/` — 126 passed, 1 skipped.

Beyond that, this branch produced a full 341-task pipeline run end to end (`2026_07_14_A549_MAP4_ZIKV_rerun`), which absorbed two real preemptions via retry.
