### PR TITLE
perf(concatenate): place chunk files directly when the data is unchanged

### DIFF
--- a/biahub/cli/direct_copy.py
+++ b/biahub/cli/direct_copy.py
@@ -1,0 +1,729 @@
+"""Place Zarr chunk/shard files directly, for copies that do not change the data.
+
+``biahub concatenate`` normally assembles its output by reading each input
+volume, cropping it, and writing it back — a full decompress/recompress of every
+byte. When the output geometry matches the input exactly and no crop is
+requested, that round trip produces stored files that are byte-for-byte what the
+input already holds, so the file can simply be placed at its new key instead.
+For the mantis-v2 assemble step that is ~16 TiB of codec work replaced by a file
+copy, or by nothing at all in ``link`` mode.
+
+Two properties make the decision mechanical rather than a judgement call:
+
+*The array metadata document is the contract.* A stored chunk or shard is
+interpretable only through its array's metadata — data type, chunk grid, codecs,
+fill value, key encoding. If two arrays agree on all of it a file is
+interchangeable between them, and if they disagree anywhere it is not.
+:func:`copy_incompatibilities` therefore compares the whole document instead of
+a hand-picked list of fields, so a codec option introduced by a future Zarr
+release disqualifies the copy by default rather than silently producing an
+output that cannot be decoded.
+
+*The file is the unit.* One file holds one chunk-grid cell — a shard when the
+array is sharded, a chunk when it is not. Remapping ``(t, c)`` is then a rename
+of that cell, but only if a cell holds exactly one channel and one timepoint,
+which is what the pipeline's stores do (``shards_ratio`` defaults to a T ratio
+of 1, and ``process_single_position`` already rejects sharding along C).
+Anything coarser is rejected.
+
+Placement is atomic: each file is written under a temporary name in its final
+directory and then ``os.replace``d into place. An interrupted run therefore
+leaves either the old file or the new one and never a torn one, which is the
+failure mode ``--resume`` exists to recover from on the read-write path.
+
+Two differences from the read-write path are deliberate and worth knowing:
+
+- ``copy_n_paste`` replaces NaN with zero and ``process_single_position`` skips a
+  ``(t, c)`` block that is entirely zero or NaN. A byte copy cannot inspect the
+  data, so **NaNs are carried through unchanged** instead of becoming zeros. An
+  input block that was never written has no file, and the destination is left
+  with no file either, which reads back as the fill value exactly as before.
+- Progress is recorded by the destination files themselves rather than by
+  ``iohub``'s per-unit markers, so ``resume`` here means "the destination file is
+  already the same size as its source". Because placement is atomic that is exact
+  for a run interrupted on this path; a file torn by an interrupted *read-write*
+  run is only caught if its size differs, which in practice it does.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import itertools
+import json
+import math
+import os
+import shutil
+import threading
+
+from collections.abc import Sequence
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Literal
+
+import click
+
+from humanize import naturalsize
+from iohub import open_ome_zarr
+
+#: How a file is materialised at its destination. ``copy`` moves the bytes, so
+#: the output store is independent of its inputs. ``link`` creates a hard link,
+#: so both stores reference one copy of the data: instant and free of disk, but
+#: writing into either store afterwards would corrupt the other.
+PlacementMode = Literal["copy", "link"]
+
+#: Metadata fields left out of the interchangeability comparison. ``shape``
+#: differs by design — the output holds more channels and possibly fewer
+#: timepoints — and is checked per axis instead. ``attributes`` and
+#: ``dimension_names`` are descriptive: neither takes part in encoding a chunk,
+#: so a difference there cannot make a stored file uninterpretable.
+_UNCOMPARED_METADATA_KEYS = frozenset({"shape", "attributes", "dimension_names"})
+
+#: zattrs keys owned by the OME-Zarr spec, which provenance must not overwrite.
+#: Mirrors ``iohub.ngff.utils._OME_KEYS``.
+_OME_KEYS = frozenset({"ome", "multiscales", "omero", "labels", "version"})
+
+#: Longest value rendered inline when reporting a metadata difference. A codec
+#: list runs to hundreds of characters and drowns the message it belongs to.
+_MAX_INLINE_REPR = 60
+
+
+class UnsupportedLayoutError(ValueError):
+    """The array's on-disk layout is not one this module can address by key."""
+
+
+@dataclass(frozen=True)
+class ArrayLayout:
+    """Everything about a Zarr array that decides whether its files can be reused.
+
+    Attributes
+    ----------
+    path : Path
+        Directory holding the array's metadata and chunk/shard files.
+    zarr_format : int
+        2 (OME-Zarr v0.4) or 3 (OME-Zarr v0.5).
+    shape : tuple[int, ...]
+        TCZYX array shape.
+    file_shape : tuple[int, ...]
+        Array extent covered by one file on disk: the shard shape when the array
+        is sharded, the chunk shape when it is not. This is the outer chunk grid
+        in both cases, which is exactly the granularity at which files exist.
+    metadata : dict
+        The parsed metadata document, compared field-by-field against the
+        destination's by :func:`copy_incompatibilities`.
+    key_prefix : str
+        Leading path component of a chunk key (``"c"`` for Zarr v3's default
+        encoding, empty for Zarr v2 and for v3's ``v2`` encoding).
+    key_separator : str
+        Separator between grid indices in a chunk key.
+    """
+
+    path: Path
+    zarr_format: int
+    shape: tuple[int, ...]
+    file_shape: tuple[int, ...]
+    metadata: dict[str, Any]
+    key_prefix: str
+    key_separator: str
+
+    @property
+    def grid_shape(self) -> tuple[int, ...]:
+        """Number of files along each axis, rounding up at the array bound."""
+        return tuple(
+            math.ceil(extent / step)
+            for extent, step in zip(self.shape, self.file_shape, strict=True)
+        )
+
+    def file_path(self, cell: Sequence[int]) -> Path:
+        """Path of the file holding the chunk-grid cell at ``cell``."""
+        key = self.key_separator.join(str(index) for index in cell)
+        if self.key_prefix:
+            key = self.key_separator.join((self.key_prefix, key)) if key else self.key_prefix
+        return self.path / key
+
+
+def read_array_layout(array_path: Path) -> ArrayLayout:
+    """Read the on-disk layout of the Zarr array at ``array_path``.
+
+    Parameters
+    ----------
+    array_path : Path
+        Directory of the array itself, e.g. ``plate.zarr/A/1/0/0``.
+
+    Returns
+    -------
+    ArrayLayout
+
+    Raises
+    ------
+    FileNotFoundError
+        If neither ``zarr.json`` nor ``.zarray`` is present.
+    UnsupportedLayoutError
+        If the metadata uses a chunk grid or key encoding this module cannot
+        turn into a file path.
+    """
+    array_path = Path(array_path)
+
+    v3_metadata_path = array_path / "zarr.json"
+    if v3_metadata_path.exists():
+        metadata = json.loads(v3_metadata_path.read_text())
+        chunk_grid = metadata.get("chunk_grid", {})
+        if chunk_grid.get("name") != "regular":
+            raise UnsupportedLayoutError(f"unsupported chunk grid {chunk_grid.get('name')!r}")
+        # For a sharded array this is the *shard* shape: the sharding codec's
+        # own ``chunk_shape`` describes the chunks nested inside one file, and
+        # is compared as part of ``codecs`` rather than used for addressing.
+        file_shape = tuple(chunk_grid["configuration"]["chunk_shape"])
+        prefix, separator = _v3_key_encoding(metadata)
+        return ArrayLayout(
+            path=array_path,
+            zarr_format=3,
+            shape=tuple(metadata["shape"]),
+            file_shape=file_shape,
+            metadata=metadata,
+            key_prefix=prefix,
+            key_separator=separator,
+        )
+
+    v2_metadata_path = array_path / ".zarray"
+    if v2_metadata_path.exists():
+        metadata = json.loads(v2_metadata_path.read_text())
+        return ArrayLayout(
+            path=array_path,
+            zarr_format=2,
+            shape=tuple(metadata["shape"]),
+            file_shape=tuple(metadata["chunks"]),
+            metadata=metadata,
+            key_prefix="",
+            key_separator=metadata.get("dimension_separator") or ".",
+        )
+
+    raise FileNotFoundError(f"No zarr.json or .zarray under {array_path}")
+
+
+def _v3_key_encoding(metadata: dict[str, Any]) -> tuple[str, str]:
+    """``(key prefix, separator)`` for a Zarr v3 array's chunk keys."""
+    encoding = metadata.get("chunk_key_encoding") or {"name": "default"}
+    configuration = encoding.get("configuration") or {}
+    if encoding["name"] == "default":
+        prefix, default_separator = "c", "/"
+    elif encoding["name"] == "v2":
+        prefix, default_separator = "", "."
+    else:
+        raise UnsupportedLayoutError(f"unsupported chunk key encoding {encoding['name']!r}")
+    return prefix, configuration.get("separator", default_separator)
+
+
+def copy_incompatibilities(
+    source: ArrayLayout,
+    destination: ArrayLayout,
+    zyx_slicing_params: Sequence[slice],
+    input_time_indices: Sequence[int],
+    output_time_indices: Sequence[int],
+) -> list[str]:
+    """Reasons ``source``'s files cannot be reused verbatim in ``destination``.
+
+    An empty list means a file-level copy reproduces exactly what reading,
+    cropping and rewriting would have produced (NaN handling aside, see the
+    module docstring).
+
+    Parameters
+    ----------
+    source, destination : ArrayLayout
+        Layouts of the input and output arrays.
+    zyx_slicing_params : Sequence[slice]
+        The Z, Y and X slices concatenate would apply. Anything other than the
+        full extent of the input is a crop, which no rename can express.
+    input_time_indices, output_time_indices : Sequence[int]
+        The time remapping, paired element-wise.
+
+    Returns
+    -------
+    list[str]
+        Human-readable reasons, empty if the copy is valid.
+    """
+    if source.zarr_format != destination.zarr_format:
+        # Nothing below compares meaningfully across formats, so stop here.
+        return [
+            f"Zarr format differs (input v{source.zarr_format}, "
+            f"output v{destination.zarr_format})"
+        ]
+
+    reasons = []
+
+    differences = [
+        _describe_difference(key, source.metadata.get(key), destination.metadata.get(key))
+        for key in sorted(set(source.metadata) | set(destination.metadata))
+        if key not in _UNCOMPARED_METADATA_KEYS
+        and source.metadata.get(key) != destination.metadata.get(key)
+    ]
+    if differences:
+        reasons.append("array metadata differs: " + ", ".join(differences))
+
+    if source.shape[2:] != destination.shape[2:]:
+        reasons.append(
+            f"ZYX shape differs (input {source.shape[2:]}, output {destination.shape[2:]})"
+        )
+
+    cropped_axes = _cropped_axes(zyx_slicing_params, source.shape[2:])
+    if cropped_axes:
+        reasons.append("ROI crops " + ", ".join(cropped_axes))
+
+    if source.file_shape[1] != 1 or destination.file_shape[1] != 1:
+        reasons.append(
+            "a stored file spans several channels "
+            f"(input {source.file_shape[1]}, output {destination.file_shape[1]}), "
+            "so channels cannot be remapped by key"
+        )
+
+    time_extent = max(source.file_shape[0], destination.file_shape[0])
+    if time_extent != 1 and not _time_mapping_is_identity(
+        source, destination, input_time_indices, output_time_indices
+    ):
+        # A file holding several timepoints carries all of them with it, so it is
+        # only reusable when the copy leaves the time axis alone and the trailing
+        # file clips at the same index on both sides.
+        reasons.append(
+            f"a stored file spans {time_extent} timepoints and the copy is not "
+            "the identity on the time axis"
+        )
+
+    return reasons
+
+
+def _describe_difference(key: str, source_value: Any, destination_value: Any) -> str:
+    """Name a differing metadata field, with values when they are short enough."""
+    source_repr, destination_repr = repr(source_value), repr(destination_value)
+    if max(len(source_repr), len(destination_repr)) <= _MAX_INLINE_REPR:
+        return f"{key} (input {source_repr}, output {destination_repr})"
+    return key
+
+
+def _cropped_axes(zyx_slicing_params: Sequence[slice], zyx_shape: Sequence[int]) -> list[str]:
+    """Axes whose requested slice is not the full extent of the input."""
+    cropped = []
+    for axis, requested, extent in zip("ZYX", zyx_slicing_params, zyx_shape, strict=True):
+        start, stop, step = requested.indices(extent)
+        if (start, stop, step) != (0, extent, 1):
+            cropped.append(f"{axis}[{start}:{stop}]")
+    return cropped
+
+
+def _time_mapping_is_identity(
+    source: ArrayLayout,
+    destination: ArrayLayout,
+    input_time_indices: Sequence[int],
+    output_time_indices: Sequence[int],
+) -> bool:
+    """Whether every timepoint keeps its index and the whole axis is copied."""
+    every_timepoint = list(range(source.shape[0]))
+    return (
+        source.shape[0] == destination.shape[0]
+        and list(input_time_indices) == every_timepoint
+        and list(output_time_indices) == every_timepoint
+    )
+
+
+@dataclass(frozen=True)
+class DirectCopyPlan:
+    """A validated file-level copy of one input position into one output position.
+
+    Holds only the two layouts and the index remapping; the file pairs are
+    enumerated on demand by :meth:`file_pairs` so that a driver planning
+    hundreds of positions does not carry tens of thousands of paths.
+    """
+
+    source: ArrayLayout
+    destination: ArrayLayout
+    input_time_indices: tuple[int, ...]
+    output_time_indices: tuple[int, ...]
+    input_channel_indices: tuple[int, ...]
+    output_channel_indices: tuple[int, ...]
+
+    @property
+    def _time_cells(self) -> list[tuple[int, int]]:
+        """``(input cell, output cell)`` pairs along the time axis, deduplicated."""
+        return list(
+            dict.fromkeys(
+                (
+                    input_index // self.source.file_shape[0],
+                    output_index // self.destination.file_shape[0],
+                )
+                for input_index, output_index in zip(
+                    self.input_time_indices, self.output_time_indices, strict=True
+                )
+            )
+        )
+
+    @property
+    def _channel_cells(self) -> list[tuple[int, int]]:
+        """``(input cell, output cell)`` pairs along the channel axis.
+
+        A file spans exactly one channel here — :func:`copy_incompatibilities`
+        rejects anything else — so a channel index *is* its cell index.
+        """
+        return list(
+            dict.fromkeys(
+                zip(self.input_channel_indices, self.output_channel_indices, strict=True)
+            )
+        )
+
+    @property
+    def num_files(self) -> int:
+        """How many files the copy addresses, present on disk or not."""
+        spatial = math.prod(self.source.grid_shape[2:])
+        return len(self._time_cells) * len(self._channel_cells) * spatial
+
+    def file_pairs(self) -> list[tuple[Path, Path]]:
+        """``(source, destination)`` paths for every file the copy addresses.
+
+        The ZYX grid is shared: ``copy_incompatibilities`` has already required
+        the two arrays to agree on both ZYX shape and file shape, so a spatial
+        cell index means the same thing on each side.
+        """
+        spatial_cells = tuple(
+            itertools.product(*(range(count) for count in self.source.grid_shape[2:]))
+        )
+        return [
+            (
+                self.source.file_path((input_time, input_channel, *cell)),
+                self.destination.file_path((output_time, output_channel, *cell)),
+            )
+            for (input_time, output_time), (
+                input_channel,
+                output_channel,
+            ) in itertools.product(self._time_cells, self._channel_cells)
+            for cell in spatial_cells
+        ]
+
+
+def plan_position_copy(
+    input_position_path: Path,
+    output_position_path: Path,
+    input_channel_indices: Sequence[int],
+    output_channel_indices: Sequence[int],
+    input_time_indices: Sequence[int],
+    output_time_indices: Sequence[int],
+    zyx_slicing_params: Sequence[slice],
+    input_array_name: str = "0",
+    output_array_name: str = "0",
+) -> tuple[DirectCopyPlan | None, list[str]]:
+    """Plan a file-level copy between two positions, or explain why there is none.
+
+    Reads only the two arrays' metadata, so this is cheap enough to call for
+    every position from the submitting process.
+
+    Returns
+    -------
+    tuple[DirectCopyPlan | None, list[str]]
+        The plan and an empty reason list, or None and the reasons the copy is
+        not valid. A metadata document that cannot be read or understood is
+        reported as a reason rather than raised, so one odd store degrades to the
+        read-write path instead of aborting the run.
+    """
+    try:
+        source = read_array_layout(Path(input_position_path) / input_array_name)
+        destination = read_array_layout(Path(output_position_path) / output_array_name)
+    except (OSError, KeyError, ValueError) as error:
+        return None, [f"could not read array metadata: {error}"]
+
+    reasons = copy_incompatibilities(
+        source,
+        destination,
+        zyx_slicing_params,
+        input_time_indices,
+        output_time_indices,
+    )
+    if reasons:
+        return None, reasons
+
+    plan = DirectCopyPlan(
+        source=source,
+        destination=destination,
+        input_time_indices=tuple(input_time_indices),
+        output_time_indices=tuple(output_time_indices),
+        input_channel_indices=tuple(input_channel_indices),
+        output_channel_indices=tuple(output_channel_indices),
+    )
+    return plan, []
+
+
+@dataclass
+class PlacementReport:
+    """Outcome counts for a batch of file placements."""
+
+    placed: int = 0
+    reused: int = 0
+    cleared: int = 0
+    absent: int = 0
+    bytes_placed: int = 0
+    #: Set when ``link`` was requested but the filesystems made it impossible.
+    mode: PlacementMode = "copy"
+
+    def record(self, outcome: str, size: int) -> None:
+        setattr(self, outcome, getattr(self, outcome) + 1)
+        self.bytes_placed += size
+
+    def __str__(self) -> str:
+        verb = "linked" if self.mode == "link" else "copied"
+        parts = [f"{self.placed} {verb} ({naturalsize(self.bytes_placed, binary=True)})"]
+        if self.reused:
+            parts.append(f"{self.reused} already present")
+        if self.cleared:
+            parts.append(f"{self.cleared} removed (no source file)")
+        if self.absent:
+            parts.append(f"{self.absent} absent on both sides")
+        return ", ".join(parts)
+
+
+def resolve_placement_mode(
+    source: Path, destination: Path, mode: PlacementMode
+) -> PlacementMode:
+    """Downgrade ``link`` to ``copy`` when the two paths are on different devices.
+
+    A hard link cannot cross a filesystem boundary. Checking once here turns
+    what would be an ``EXDEV`` failure on the first file into a warning and a
+    byte copy.
+    """
+    if mode != "link":
+        return mode
+    try:
+        same_device = os.stat(source).st_dev == os.stat(destination).st_dev
+    except OSError:
+        same_device = False
+    if same_device:
+        return "link"
+    click.echo(
+        f"Warning: {source} and {destination} are not on the same filesystem, "
+        "so hard links are not possible. Copying bytes instead."
+    )
+    return "copy"
+
+
+def place_files(
+    pairs: Sequence[tuple[Path, Path]],
+    mode: PlacementMode = "copy",
+    num_workers: int = 1,
+    resume: bool = False,
+) -> PlacementReport:
+    """Materialise every ``(source, destination)`` pair, in parallel.
+
+    Parameters
+    ----------
+    pairs : Sequence[tuple[Path, Path]]
+        Files to place. A pair whose source does not exist means the input never
+        wrote that block, so any destination file is *removed* rather than left
+        behind — matching what the read-write path does when it skips an
+        all-zero or all-NaN block, and making a re-run over a stale output store
+        converge on the input's contents.
+    mode : PlacementMode, optional
+        ``copy`` (default) or ``link``; see :data:`PlacementMode`. Pass a value
+        already through :func:`resolve_placement_mode`.
+    num_workers : int, optional
+        Threads to place files with. The work is filesystem calls with the GIL
+        released, so threads are the right tool and a network filesystem
+        benefits from many of them. Defaults to 1.
+    resume : bool, optional
+        Skip a destination that already exists with the same size as its source.
+        Exact for a run interrupted on this path, because placement is atomic.
+        Defaults to False.
+
+    Returns
+    -------
+    PlacementReport
+    """
+    report = PlacementReport(mode=mode)
+    if not pairs:
+        return report
+
+    num_workers = max(1, min(num_workers, len(pairs)))
+    if num_workers == 1:
+        for source, destination in pairs:
+            report.record(*_place_one(source, destination, mode=mode, resume=resume))
+        return report
+
+    with ThreadPoolExecutor(max_workers=num_workers) as pool:
+        futures = [
+            pool.submit(_place_one, source, destination, mode=mode, resume=resume)
+            for source, destination in pairs
+        ]
+        for future in as_completed(futures):
+            report.record(*future.result())
+    return report
+
+
+def _place_one(
+    source: Path,
+    destination: Path,
+    mode: PlacementMode,
+    resume: bool,
+) -> tuple[str, int]:
+    """Place one file atomically. Returns ``(outcome, bytes placed)``.
+
+    The file is created under a temporary name in the destination's own
+    directory and then renamed over the target, which is atomic on a POSIX
+    filesystem. A kill at any point therefore leaves the destination either
+    untouched or complete, never truncated.
+    """
+    try:
+        source_size = os.stat(source).st_size
+    except FileNotFoundError:
+        # The input never wrote this block. Remove a stale destination so the
+        # output reads back as the fill value, as it would after a skipped write.
+        try:
+            destination.unlink()
+        except FileNotFoundError:
+            return "absent", 0
+        return "cleared", 0
+
+    if resume:
+        with contextlib.suppress(OSError):
+            if os.stat(destination).st_size == source_size:
+                return "reused", 0
+
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    # Unique per thread and process so concurrent placements never share a
+    # scratch name, and dot-prefixed so a leftover cannot be mistaken for a
+    # chunk key by a reader globbing the directory.
+    scratch = (
+        destination.parent / f".{destination.name}.{os.getpid()}-{threading.get_ident()}.tmp"
+    )
+    try:
+        if mode == "link":
+            os.link(source, scratch)
+        else:
+            shutil.copyfile(source, scratch)
+        os.replace(scratch, destination)
+    except BaseException:
+        with contextlib.suppress(OSError):
+            scratch.unlink()
+        raise
+    return "placed", source_size
+
+
+def copy_position_files(
+    input_position_path: Path,
+    output_position_path: Path,
+    input_channel_indices: Sequence[int],
+    output_channel_indices: Sequence[int],
+    input_time_indices: Sequence[int],
+    output_time_indices: Sequence[int],
+    zyx_slicing_params: Sequence[slice],
+    input_array_name: str = "0",
+    output_array_name: str = "0",
+    mode: PlacementMode = "copy",
+    num_workers: int = 1,
+    resume: bool = False,
+    extra_metadata: dict[str, Any] | None = None,
+) -> PlacementReport:
+    """Copy one input position into one output position at the file level.
+
+    The read-write counterpart of this function is
+    ``iohub.ngff.utils.process_single_position``, and the arguments mirror it so
+    a caller can choose between them per position.
+
+    Re-validates the copy rather than trusting the caller's plan, and raises if
+    it no longer holds: the caller decided from the same metadata, so a mismatch
+    means the stores changed underneath and silently writing something else
+    would be worse than stopping.
+
+    Raises
+    ------
+    RuntimeError
+        If the two arrays are not file-level compatible.
+    """
+    click.echo(f"Direct chunk copy ({mode}) from:\t{input_position_path}")
+    click.echo(f"Output data path:\t{output_position_path}")
+
+    plan, reasons = plan_position_copy(
+        input_position_path=input_position_path,
+        output_position_path=output_position_path,
+        input_channel_indices=input_channel_indices,
+        output_channel_indices=output_channel_indices,
+        input_time_indices=input_time_indices,
+        output_time_indices=output_time_indices,
+        zyx_slicing_params=zyx_slicing_params,
+        input_array_name=input_array_name,
+        output_array_name=output_array_name,
+    )
+    if plan is None:
+        raise RuntimeError(
+            f"{input_position_path} cannot be copied into {output_position_path} at "
+            f"the file level: {'; '.join(reasons)}"
+        )
+
+    _write_extra_metadata(output_position_path, extra_metadata)
+
+    resolved_mode = resolve_placement_mode(plan.source.path, plan.destination.path, mode)
+    report = place_files(
+        plan.file_pairs(),
+        mode=resolved_mode,
+        num_workers=num_workers,
+        resume=resume,
+    )
+    click.echo(f"Finished {output_position_path}: {report}")
+    return report
+
+
+def _write_extra_metadata(
+    output_position_path: Path, extra_metadata: dict[str, Any] | None
+) -> None:
+    """Record per-step provenance on the output position.
+
+    Each entry becomes its own top-level zattrs key so successive steps
+    accumulate sibling provenance rather than overwriting one shared key, which
+    is what ``process_single_position``'s ``extra_metadata`` does.
+    """
+    if not extra_metadata:
+        return
+    reserved = _OME_KEYS.intersection(extra_metadata)
+    if reserved:
+        raise ValueError(
+            f"extra_metadata keys {sorted(reserved)} are reserved OME-Zarr keys. "
+            "Use a namespaced key (e.g. '<package>-<step>') instead."
+        )
+    with open_ome_zarr(output_position_path, layout="fov", mode="r+") as position:
+        for key, value in extra_metadata.items():
+            position.zattrs[key] = value
+
+
+@dataclass
+class DirectCopySummary:
+    """How much of a multi-position copy can bypass the read-write path."""
+
+    total: int = 0
+    direct: int = 0
+    files: int = 0
+    #: Reason string -> number of position sources it disqualified.
+    fallback_reasons: dict[str, int] = field(default_factory=dict)
+
+    @property
+    def all_direct(self) -> bool:
+        return self.total > 0 and self.direct == self.total
+
+
+def summarize_direct_copy(
+    plans: Sequence[DirectCopyPlan | None], reasons: Sequence[list[str]]
+) -> DirectCopySummary:
+    """Aggregate per-position planning results for reporting."""
+    summary = DirectCopySummary(total=len(plans))
+    for plan, plan_reasons in zip(plans, reasons, strict=True):
+        if plan is not None:
+            summary.direct += 1
+            summary.files += plan.num_files
+            continue
+        for reason in plan_reasons:
+            summary.fallback_reasons[reason] = summary.fallback_reasons.get(reason, 0) + 1
+    return summary
+
+
+def echo_direct_copy_summary(summary: DirectCopySummary) -> None:
+    """Report the copy plan, and why anything fell back, on stdout."""
+    click.echo(
+        f"Direct chunk copy: {summary.direct}/{summary.total} position sources "
+        f"({summary.files} files)"
+    )
+    for reason, count in sorted(
+        summary.fallback_reasons.items(), key=lambda item: (-item[1], item[0])
+    ):
+        click.echo(f"  read-write fallback ({count}): {reason}")

--- a/biahub/concatenate.py
+++ b/biahub/concatenate.py
@@ -11,6 +11,12 @@ from iohub import open_ome_zarr
 from iohub.ngff.utils import create_empty_plate, process_single_position
 from natsort import natsorted
 
+from biahub.cli.direct_copy import (
+    copy_position_files,
+    echo_direct_copy_summary,
+    plan_position_copy,
+    summarize_direct_copy,
+)
 from biahub.cli.monitor import monitor_jobs
 from biahub.cli.parsing import (
     cluster,
@@ -35,6 +41,11 @@ from biahub.cli.utils import (
     yaml_to_model,
 )
 from biahub.settings import ConcatenateSettings
+
+#: Memory to request when every position source is a direct chunk copy. Placing
+#: files streams through the kernel rather than buffering a shard, so the shard-
+#: sized estimate ``estimate_resources`` produces does not apply.
+_DIRECT_COPY_MEM_GB = 8
 
 
 def _unique_source_plates(data_paths: list[Path]) -> list[Path]:
@@ -285,7 +296,11 @@ def _resolve_time_indices(settings: ConcatenateSettings, all_shapes: list[tuple]
     return list(range(T))
 
 
-def _prepare_concatenate(settings: ConcatenateSettings, output_dirpath: Path) -> dict:
+def _prepare_concatenate(
+    settings: ConcatenateSettings,
+    output_dirpath: Path,
+    direct_copy: bool = True,
+) -> dict:
     """Derive metadata and create the output plate.
 
     Runs the channel/slice metadata resolution (the expensive
@@ -293,6 +308,13 @@ def _prepare_concatenate(settings: ConcatenateSettings, output_dirpath: Path) ->
     returns everything the submit loop needs plus the input ``shape`` used by
     ``concatenate`` to estimate SLURM resources. ``create_empty_plate`` is
     idempotent, so calling this from both ``--init`` and the full run is safe.
+
+    Also decides, per input position, whether its stored chunk/shard files can be
+    placed into the output store verbatim instead of being read, cropped and
+    rewritten. That has to happen here rather than in ``concatenate`` because it
+    compares against the *output* array's metadata, which only exists once
+    ``create_empty_plate`` has run. Pass ``direct_copy=False`` to skip the check
+    and take the read-write path everywhere.
     """
     slicing_params = [settings.Z_slice, settings.Y_slice, settings.X_slice]
     (
@@ -314,6 +336,7 @@ def _prepare_concatenate(settings: ConcatenateSettings, output_dirpath: Path) ->
     all_shapes = []
     all_dtypes = []
     all_voxel_sizes = []
+    all_array_names = []
     for path in all_data_paths:
         with open_ome_zarr(path) as dataset:
             if len(dataset.array_keys()) > 1:
@@ -324,6 +347,9 @@ def _prepare_concatenate(settings: ConcatenateSettings, output_dirpath: Path) ->
             all_shapes.append(dataset.data.shape)
             all_dtypes.append(dataset.data.dtype)
             all_voxel_sizes.append(dataset.scale[-3:])
+            # Kept so the direct-copy planner can address the array directory;
+            # the single-array check above makes this unambiguous.
+            all_array_names.append(next(iter(dataset.array_keys())))
 
     # Only check for shape compatibility when using 'all' for slicing
     if (
@@ -389,15 +415,86 @@ def _prepare_concatenate(settings: ConcatenateSettings, output_dirpath: Path) ->
     )
     click.echo(f"Created {output_dirpath} ({len(output_position_paths)} positions)")
 
+    output_time_indices = list(range(len(input_time_indices)))
+    direct_copy_plans, direct_copy_reasons = _plan_direct_copies(
+        all_data_paths=all_data_paths,
+        all_array_names=all_array_names,
+        output_position_paths=output_position_paths,
+        input_channel_idx_list=input_channel_idx_list,
+        output_channel_idx_list=output_channel_idx_list,
+        all_slicing_params=all_slicing_params,
+        input_time_indices=input_time_indices,
+        output_time_indices=output_time_indices,
+        direct_copy=direct_copy,
+    )
+
     return {
         "all_data_paths": all_data_paths,
+        "all_array_names": all_array_names,
         "output_position_paths": output_position_paths,
         "input_channel_idx_list": input_channel_idx_list,
         "output_channel_idx_list": output_channel_idx_list,
         "all_slicing_params": all_slicing_params,
         "input_time_indices": input_time_indices,
+        "output_time_indices": output_time_indices,
+        "direct_copy_plans": direct_copy_plans,
+        "direct_copy_reasons": direct_copy_reasons,
         "shape": (T, C, Z, Y, X),
     }
+
+
+def _plan_direct_copies(
+    all_data_paths: list[Path],
+    all_array_names: list[str],
+    output_position_paths: list[Path],
+    input_channel_idx_list: list[list[int]],
+    output_channel_idx_list: list[list[int]],
+    all_slicing_params: list[list[slice]],
+    input_time_indices: list[int],
+    output_time_indices: list[int],
+    direct_copy: bool,
+) -> tuple[list, list[list[str]]]:
+    """Decide per input position whether its files can be placed verbatim.
+
+    Returns a plan-or-None per position alongside the reasons a plan was not
+    possible, both aligned with ``all_data_paths``. Only array metadata is read,
+    so this stays cheap even for a plate with hundreds of position sources.
+    """
+    if not direct_copy:
+        reason = ["disabled by --no-direct-copy"]
+        return [None] * len(all_data_paths), [reason] * len(all_data_paths)
+
+    plans = []
+    reasons = []
+    for (
+        input_position_path,
+        input_array_name,
+        output_position_path,
+        input_channel_idx,
+        output_channel_idx,
+        zyx_slicing_params,
+    ) in zip(
+        all_data_paths,
+        all_array_names,
+        output_position_paths,
+        input_channel_idx_list,
+        output_channel_idx_list,
+        all_slicing_params,
+        strict=True,
+    ):
+        plan, plan_reasons = plan_position_copy(
+            input_position_path=input_position_path,
+            output_position_path=output_position_path,
+            input_channel_indices=input_channel_idx,
+            output_channel_indices=output_channel_idx,
+            input_time_indices=input_time_indices,
+            output_time_indices=output_time_indices,
+            zyx_slicing_params=zyx_slicing_params,
+            input_array_name=input_array_name,
+        )
+        plans.append(plan)
+        reasons.append(plan_reasons)
+    return plans, reasons
 
 
 def _resolve_concatenate_config(
@@ -430,6 +527,8 @@ def concatenate(
     monitor: bool = True,
     init_only: bool = False,
     resume: bool = False,
+    direct_copy: bool = True,
+    link: bool = False,
 ):
     """Concatenate datasets (with optional cropping).
 
@@ -459,11 +558,30 @@ def concatenate(
         covering every position, so a preemption or walltime kill near the end
         otherwise discards hours of work. See
         ``iohub.ngff.utils.process_single_position``.
+    direct_copy : bool, optional
+        Place a position's stored chunk/shard files into the output store
+        verbatim when the output geometry matches the input and no ROI crop is
+        requested, instead of reading, cropping and rewriting every byte. Decided
+        per input position from the two arrays' metadata; anything that does not
+        match falls back to the read-write path. Note that a byte copy cannot
+        apply ``copy_n_paste``'s ``nan_to_num``, so NaNs are carried through
+        rather than zeroed. By default True.
+    link : bool, optional
+        Hard-link the files the direct copy places instead of copying their
+        bytes. Instant and free of disk, but the output store then shares its
+        data with the inputs, so writing into either would corrupt the other.
+        Only safe for write-once inputs. Ignored where the direct copy does not
+        apply, and downgraded to a byte copy across filesystem boundaries. By
+        default False.
     """
     slurm_out_path = output_dirpath.parent / "slurm_output"
 
-    prep = _prepare_concatenate(settings, output_dirpath)
+    prep = _prepare_concatenate(settings, output_dirpath, direct_copy=direct_copy)
     input_time_indices = prep["input_time_indices"]
+    direct_copy_plans = prep["direct_copy_plans"]
+
+    summary = summarize_direct_copy(direct_copy_plans, prep["direct_copy_reasons"])
+    echo_direct_copy_summary(summary)
 
     T, C, Z, Y, X = prep["shape"]
     batch_size = settings.shards_ratio[0] if settings.shards_ratio else 1
@@ -474,6 +592,19 @@ def concatenate(
     )
     mem_gb = num_cpus * gb_ram_per_cpu
     time_minutes = 360
+    if summary.all_direct:
+        # Nothing decodes a volume, so the estimate above — which sizes a shard
+        # buffer — no longer describes the job. Placing files needs concurrency,
+        # not memory, and a request of hundreds of GB would queue for one of the
+        # few nodes that large for no reason. (For the mantis-v2 assemble step
+        # this is the difference between 96 GB and 8 GB, or 816 GB and 8 GB with
+        # 10-timepoint shards.)
+        # A cap, not a fixed value, so this can only ever lower the request.
+        mem_gb = min(mem_gb, _DIRECT_COPY_MEM_GB)
+        click.echo(
+            "Every position source is a direct chunk copy; "
+            f"requesting {mem_gb} GB instead of {num_cpus * gb_ram_per_cpu} GB."
+        )
     echo_resources(num_cpus, mem_gb, time_minutes=time_minutes)
 
     if init_only:
@@ -503,16 +634,20 @@ def concatenate(
     with submitit.helpers.clean_env(), executor.batch():
         for (
             input_position_path,
+            input_array_name,
             output_position_path,
             input_channel_idx,
             output_channel_idx,
             zyx_slicing_params,
+            direct_copy_plan,
         ) in zip(
             prep["all_data_paths"],
+            prep["all_array_names"],
             prep["output_position_paths"],
             prep["input_channel_idx_list"],
             prep["output_channel_idx_list"],
             prep["all_slicing_params"],
+            direct_copy_plans,
             strict=True,
         ):
             # Preserve extra_metadata written by create_empty_plate's
@@ -526,21 +661,41 @@ def concatenate(
                 "biahub-concatenate": settings.model_dump(),
             }
 
-            job = executor.submit(
-                process_single_position,
-                copy_n_paste,
-                input_position_path=input_position_path,
-                output_position_path=output_position_path,
-                input_channel_indices=input_channel_idx,
-                output_channel_indices=output_channel_idx,
-                input_time_indices=input_time_indices,
-                output_time_indices=list(range(len(input_time_indices))),
-                num_workers=slurm_args["slurm_cpus_per_task"],
-                resume=resume,
-                resume_token=settings_fingerprint(settings),
-                extra_metadata=merged_extra,
-                zyx_slicing_params=zyx_slicing_params,
-            )
+            # A position whose stored files can be reused verbatim skips the
+            # decode/encode round trip entirely; anything else takes the
+            # read-write path, so the two can be mixed within one plate.
+            if direct_copy_plan is not None:
+                job = executor.submit(
+                    copy_position_files,
+                    input_position_path=input_position_path,
+                    output_position_path=output_position_path,
+                    input_channel_indices=input_channel_idx,
+                    output_channel_indices=output_channel_idx,
+                    input_time_indices=input_time_indices,
+                    output_time_indices=prep["output_time_indices"],
+                    zyx_slicing_params=zyx_slicing_params,
+                    input_array_name=input_array_name,
+                    mode="link" if link else "copy",
+                    num_workers=slurm_args["slurm_cpus_per_task"],
+                    resume=resume,
+                    extra_metadata=merged_extra,
+                )
+            else:
+                job = executor.submit(
+                    process_single_position,
+                    copy_n_paste,
+                    input_position_path=input_position_path,
+                    output_position_path=output_position_path,
+                    input_channel_indices=input_channel_idx,
+                    output_channel_indices=output_channel_idx,
+                    input_time_indices=input_time_indices,
+                    output_time_indices=prep["output_time_indices"],
+                    num_workers=slurm_args["slurm_cpus_per_task"],
+                    resume=resume,
+                    resume_token=settings_fingerprint(settings),
+                    extra_metadata=merged_extra,
+                    zyx_slicing_params=zyx_slicing_params,
+                )
             jobs.append(job)
 
     job_ids = [job.job_id for job in jobs]  # Access job IDs after batch submission
@@ -575,6 +730,31 @@ def concatenate(
         "per source store."
     ),
 )
+@click.option(
+    "--direct-copy/--no-direct-copy",
+    "direct_copy",
+    default=True,
+    show_default=True,
+    help=(
+        "Place a position's stored chunk/shard files into the output verbatim "
+        "when the output geometry matches the input and no ROI crop is requested, "
+        "instead of decoding and re-encoding every byte. Decided per position; "
+        "anything that does not match falls back to the read-write path. NaNs are "
+        "carried through rather than zeroed, since a byte copy cannot inspect the "
+        "data."
+    ),
+)
+@click.option(
+    "--link",
+    is_flag=True,
+    default=False,
+    help=(
+        "Hard-link the files a direct copy places instead of copying their bytes: "
+        "instant and free of disk, but the output then shares its data with the "
+        "input stores, so writing into either would corrupt the other. Only pass "
+        "this for write-once inputs."
+    ),
+)
 def concatenate_cli(
     config_filepath: Path,
     output_dirpath: Path,
@@ -584,6 +764,8 @@ def concatenate_cli(
     init_only: bool = False,
     resume: bool = False,
     concat_data_paths: tuple[str, ...] = (),
+    direct_copy: bool = True,
+    link: bool = False,
 ):
     r"""Concatenate datasets (with optional cropping).
 
@@ -607,6 +789,12 @@ def concatenate_cli(
     Single-shot run on a reserved compute node (Nextflow assemble step):
     'debug' iterates every position in-process; the CLI blocks until done.
     >>> biahub concatenate --cluster debug -c resolved.yml -o output.zarr
+
+    \b
+    Same, hard-linking chunks instead of copying them. Near-instant, but the
+    output shares its data with the inputs, so only use it when they are
+    write-once and will not be edited in place:
+    >>> biahub concatenate --cluster debug --link -c resolved.yml -o output.zarr
     """
     config_path = config_filepath
     output_path = output_dirpath
@@ -637,6 +825,8 @@ def concatenate_cli(
         monitor=monitor,
         init_only=init_only,
         resume=resume,
+        direct_copy=direct_copy,
+        link=link,
     )
 
 

--- a/tests/test_concatenate.py
+++ b/tests/test_concatenate.py
@@ -2,6 +2,7 @@ import numpy as np
 import pytest
 
 from iohub import open_ome_zarr
+from iohub.ngff.utils import create_empty_plate
 
 from biahub.concatenate import concatenate
 from biahub.settings import ConcatenateSettings
@@ -516,3 +517,102 @@ def test_concatenate_with_unique_positions(create_custom_plate, tmp_path, sbatch
     for _pos_name, pos in output_plate_unique.positions():
         # Both positions should have all channels
         assert set(pos.channel_names) == {"DAPI", "Cy5", "GFP", "RFP"}
+
+
+def _direct_copy_plate(path, channel_names, time_points=3, seed=0):
+    """A v0.5 plate whose geometry matches what concatenate's output will have.
+
+    ``create_empty_plate`` derives chunks and shards from the shape, so a source
+    built this way is byte-level compatible with the concatenated output as long
+    as concatenate is not asked to change dtype, geometry or ROI.
+    """
+    position_keys = [("A", "1", "0"), ("B", "1", "0")]
+    shape = (time_points, len(channel_names), 4, 16, 16)
+    create_empty_plate(
+        store_path=path,
+        position_keys=position_keys,
+        channel_names=list(channel_names),
+        shape=shape,
+        version="0.5",
+        dtype=np.uint16,
+    )
+    rng = np.random.default_rng(seed)
+    data = {}
+    for position_key in position_keys:
+        volume = rng.integers(1, 1000, size=shape).astype(np.uint16)
+        with open_ome_zarr(path / "/".join(position_key), layout="fov", mode="r+") as pos:
+            pos.data[:] = volume
+        data["/".join(position_key)] = volume
+    return data
+
+
+@pytest.mark.parametrize("link", [False, True])
+def test_concatenate_direct_copy_matches_read_write(tmp_path, sbatch_file, capsys, link):
+    """The direct-copy path must produce the same data as the read-write path."""
+    plate_1_path = tmp_path / "zarr1.zarr"
+    plate_2_path = tmp_path / "zarr2.zarr"
+    data_1 = _direct_copy_plate(plate_1_path, ["DAPI", "Cy3"], seed=0)
+    data_2 = _direct_copy_plate(plate_2_path, ["GFP"], seed=1)
+
+    settings = ConcatenateSettings(
+        concat_data_paths=[str(plate_1_path) + "/*/*/*", str(plate_2_path) + "/*/*/*"],
+        channel_names=["all", "all"],
+        time_indices="all",
+    )
+
+    outputs = {}
+    for label, direct_copy in (("direct", True), ("readwrite", False)):
+        outputs[label] = tmp_path / f"output_{label}.zarr"
+        concatenate(
+            settings=settings,
+            output_dirpath=outputs[label],
+            sbatch_filepath=sbatch_file,
+            cluster="local",
+            block=True,
+            monitor=False,
+            direct_copy=direct_copy,
+            link=link,
+        )
+        # 2 sources x 2 positions, so all four must take the path under test.
+        expected = "4/4" if direct_copy else "0/4"
+        assert f"Direct chunk copy: {expected}" in capsys.readouterr().out
+
+    with (
+        open_ome_zarr(outputs["direct"]) as direct,
+        open_ome_zarr(outputs["readwrite"]) as read_write,
+    ):
+        assert direct.channel_names == read_write.channel_names == ["DAPI", "Cy3", "GFP"]
+        for position_name, position in direct.positions():
+            np.testing.assert_array_equal(position.data[:], read_write[position_name].data[:])
+            # And against the inputs, so a bug shared by both paths still fails.
+            np.testing.assert_array_equal(position.data[:, :2], data_1[position_name])
+            np.testing.assert_array_equal(position.data[:, 2:], data_2[position_name])
+            assert "biahub-concatenate" in position.zattrs
+
+
+def test_concatenate_direct_copy_falls_back_on_a_crop(tmp_path, sbatch_file, capsys):
+    """A Z crop cannot be expressed as a rename, so the read-write path must run."""
+    plate_path = tmp_path / "zarr1.zarr"
+    data = _direct_copy_plate(plate_path, ["DAPI"], seed=0)
+
+    settings = ConcatenateSettings(
+        concat_data_paths=[str(plate_path) + "/*/*/*"],
+        channel_names=["all"],
+        time_indices="all",
+        Z_slice=[1, 3],
+    )
+
+    output_path = tmp_path / "output.zarr"
+    concatenate(
+        settings=settings,
+        output_dirpath=output_path,
+        sbatch_filepath=sbatch_file,
+        cluster="local",
+        block=True,
+        monitor=False,
+    )
+
+    assert "Direct chunk copy: 0/2" in capsys.readouterr().out
+    with open_ome_zarr(output_path) as output:
+        for position_name, position in output.positions():
+            np.testing.assert_array_equal(position.data[:], data[position_name][:, :, 1:3])

--- a/tests/test_direct_copy.py
+++ b/tests/test_direct_copy.py
@@ -1,0 +1,350 @@
+import json
+import os
+
+import numpy as np
+import pytest
+
+from iohub import open_ome_zarr
+from iohub.ngff.utils import create_empty_plate
+
+from biahub.cli.direct_copy import (
+    copy_incompatibilities,
+    copy_position_files,
+    place_files,
+    plan_position_copy,
+    read_array_layout,
+    summarize_direct_copy,
+)
+
+# Geometry small enough to be fast, but with more than one file per (t, c) in
+# every spatial axis so a bug in the ZYX grid mapping shows up.
+SHAPE = (3, 2, 8, 16, 16)
+CHUNKS = (1, 1, 4, 8, 8)
+SHARDS_RATIO = (1, 1, 2, 2, 2)
+POSITION = ("A", "1", "0")
+
+
+def _write_plate(
+    path,
+    channel_names,
+    shape=SHAPE,
+    chunks=CHUNKS,
+    shards_ratio=SHARDS_RATIO,
+    version="0.5",
+    dtype=np.uint16,
+    seed=0,
+):
+    """An HCS plate with one position holding random data, via create_empty_plate."""
+    shape = (shape[0], len(channel_names), *shape[2:])
+    create_empty_plate(
+        store_path=path,
+        position_keys=[POSITION],
+        channel_names=list(channel_names),
+        shape=shape,
+        chunks=chunks,
+        shards_ratio=shards_ratio,
+        version=version,
+        dtype=dtype,
+    )
+    rng = np.random.default_rng(seed)
+    data = rng.integers(1, 1000, size=shape).astype(dtype)
+    with open_ome_zarr(path / "/".join(POSITION), layout="fov", mode="r+") as position:
+        position.data[:] = data
+    return data
+
+
+def _full_slices(shape=SHAPE):
+    return [slice(0, extent) for extent in shape[-3:]]
+
+
+def _plan(input_plate, output_plate, input_channels, output_channels, **kwargs):
+    return plan_position_copy(
+        input_position_path=input_plate / "/".join(POSITION),
+        output_position_path=output_plate / "/".join(POSITION),
+        input_channel_indices=input_channels,
+        output_channel_indices=output_channels,
+        input_time_indices=kwargs.pop("input_time_indices", list(range(SHAPE[0]))),
+        output_time_indices=kwargs.pop("output_time_indices", list(range(SHAPE[0]))),
+        zyx_slicing_params=kwargs.pop("zyx_slicing_params", _full_slices()),
+        **kwargs,
+    )
+
+
+# -- Layout reading --------------------------------------------------------
+
+
+def test_read_array_layout_v05_reports_the_shard_as_the_file(tmp_path):
+    """For a sharded array the on-disk file is the shard, not the inner chunk."""
+    _write_plate(tmp_path / "in.zarr", ["GFP"])
+    layout = read_array_layout(tmp_path / "in.zarr" / "/".join(POSITION) / "0")
+
+    assert layout.zarr_format == 3
+    expected_shard = tuple(c * r for c, r in zip(CHUNKS, SHARDS_RATIO, strict=True))
+    assert layout.file_shape == expected_shard
+    assert layout.grid_shape == (3, 1, 1, 1, 1)
+    assert layout.file_path((2, 0, 0, 0, 0)).name == "0"
+    assert layout.file_path((2, 0, 0, 0, 0)).exists()
+
+
+def test_read_array_layout_v04(tmp_path):
+    _write_plate(tmp_path / "in.zarr", ["GFP"], version="0.4", shards_ratio=None)
+    layout = read_array_layout(tmp_path / "in.zarr" / "/".join(POSITION) / "0")
+
+    assert layout.zarr_format == 2
+    assert layout.file_shape == CHUNKS
+    assert layout.key_prefix == ""
+
+
+def test_read_array_layout_rejects_a_missing_array(tmp_path):
+    with pytest.raises(FileNotFoundError):
+        read_array_layout(tmp_path / "nope")
+
+
+# -- Compatibility --------------------------------------------------------
+
+
+def test_matching_geometry_is_copyable(tmp_path):
+    _write_plate(tmp_path / "in.zarr", ["GFP"])
+    _write_plate(tmp_path / "out.zarr", ["GFP", "RFP"])
+
+    plan, reasons = _plan(tmp_path / "in.zarr", tmp_path / "out.zarr", [0], [1])
+
+    assert reasons == []
+    assert plan is not None
+    # 3 timepoints x 1 channel x 1 spatial shard cell.
+    assert plan.num_files == 3
+
+
+@pytest.mark.parametrize(
+    "kwargs, expected",
+    [
+        ({"dtype": np.float32}, "data_type"),
+        ({"chunks": (1, 1, 2, 8, 8)}, "codecs"),
+        ({"shards_ratio": (1, 1, 4, 2, 2)}, "chunk_grid"),
+        ({"version": "0.4", "shards_ratio": None}, "Zarr format differs"),
+    ],
+)
+def test_geometry_differences_block_the_copy(tmp_path, kwargs, expected):
+    _write_plate(tmp_path / "in.zarr", ["GFP"])
+    _write_plate(tmp_path / "out.zarr", ["GFP", "RFP"], **kwargs)
+
+    plan, reasons = _plan(tmp_path / "in.zarr", tmp_path / "out.zarr", [0], [1])
+
+    assert plan is None
+    assert any(expected in reason for reason in reasons), reasons
+
+
+def test_a_crop_blocks_the_copy(tmp_path):
+    _write_plate(tmp_path / "in.zarr", ["GFP"])
+    _write_plate(tmp_path / "out.zarr", ["GFP"])
+
+    plan, reasons = _plan(
+        tmp_path / "in.zarr",
+        tmp_path / "out.zarr",
+        [0],
+        [0],
+        zyx_slicing_params=[slice(0, 8), slice(2, 10), slice(0, 16)],
+    )
+
+    assert plan is None
+    assert reasons == ["ROI crops Y[2:10]"]
+
+
+def test_a_differing_zyx_shape_blocks_the_copy(tmp_path):
+    _write_plate(tmp_path / "in.zarr", ["GFP"])
+    _write_plate(tmp_path / "out.zarr", ["GFP"], shape=(3, 1, 8, 12, 16))
+
+    plan, reasons = _plan(tmp_path / "in.zarr", tmp_path / "out.zarr", [0], [0])
+
+    assert plan is None
+    assert any("ZYX shape differs" in reason for reason in reasons), reasons
+
+
+def test_a_multi_timepoint_shard_blocks_a_time_subset(tmp_path):
+    """A file holding several timepoints cannot be renamed into a subset."""
+    ratio = (2, 1, 2, 2, 2)
+    _write_plate(tmp_path / "in.zarr", ["GFP"], shards_ratio=ratio)
+    _write_plate(tmp_path / "out.zarr", ["GFP"], shape=(2, 1, 8, 16, 16), shards_ratio=ratio)
+
+    plan, reasons = _plan(
+        tmp_path / "in.zarr",
+        tmp_path / "out.zarr",
+        [0],
+        [0],
+        input_time_indices=[0, 2],
+        output_time_indices=[0, 1],
+    )
+
+    assert plan is None
+    assert any("timepoints" in reason for reason in reasons), reasons
+
+
+def test_a_multi_timepoint_shard_allows_the_identity(tmp_path):
+    ratio = (2, 1, 2, 2, 2)
+    _write_plate(tmp_path / "in.zarr", ["GFP"], shards_ratio=ratio)
+    _write_plate(tmp_path / "out.zarr", ["GFP", "RFP"], shards_ratio=ratio)
+
+    plan, reasons = _plan(tmp_path / "in.zarr", tmp_path / "out.zarr", [0], [1])
+
+    assert reasons == []
+    # 3 timepoints land in 2 shard cells along T.
+    assert plan.num_files == 2
+
+
+def test_an_unrecognised_codec_blocks_the_copy(tmp_path):
+    """A field this module has never heard of must disqualify the copy."""
+    _write_plate(tmp_path / "in.zarr", ["GFP"])
+    _write_plate(tmp_path / "out.zarr", ["GFP"])
+    metadata_path = tmp_path / "out.zarr" / "/".join(POSITION) / "0" / "zarr.json"
+    metadata = json.loads(metadata_path.read_text())
+    metadata["some_future_field"] = {"name": "quantize"}
+    metadata_path.write_text(json.dumps(metadata))
+
+    plan, reasons = _plan(tmp_path / "in.zarr", tmp_path / "out.zarr", [0], [0])
+
+    assert plan is None
+    assert any("some_future_field" in reason for reason in reasons), reasons
+
+
+def test_attributes_do_not_block_the_copy(tmp_path):
+    """Provenance written onto the output array must not disqualify it."""
+    _write_plate(tmp_path / "in.zarr", ["GFP"])
+    _write_plate(tmp_path / "out.zarr", ["GFP"])
+    metadata_path = tmp_path / "out.zarr" / "/".join(POSITION) / "0" / "zarr.json"
+    metadata = json.loads(metadata_path.read_text())
+    metadata["attributes"] = {"biahub-concatenate": {"anything": True}}
+    metadata_path.write_text(json.dumps(metadata))
+
+    plan, reasons = _plan(tmp_path / "in.zarr", tmp_path / "out.zarr", [0], [0])
+
+    assert reasons == []
+    assert plan is not None
+
+
+def test_a_channel_spanning_shard_blocks_the_copy(tmp_path):
+    """Sharding across C means one file holds two channels, so keys cannot remap.
+
+    ``create_empty_plate`` will not produce that geometry, so the metadata is
+    edited directly; only the metadata is read, so the files need not agree.
+    """
+    _write_plate(tmp_path / "in.zarr", ["GFP", "RFP"])
+    metadata_path = tmp_path / "in.zarr" / "/".join(POSITION) / "0" / "zarr.json"
+    metadata = json.loads(metadata_path.read_text())
+    metadata["chunk_grid"]["configuration"]["chunk_shape"][1] = 2
+    metadata_path.write_text(json.dumps(metadata))
+
+    layout = read_array_layout(metadata_path.parent)
+    reasons = copy_incompatibilities(
+        layout, layout, _full_slices(), list(range(SHAPE[0])), list(range(SHAPE[0]))
+    )
+
+    assert any("several channels" in reason for reason in reasons), reasons
+
+
+# -- Placement ------------------------------------------------------------
+
+
+@pytest.mark.parametrize("mode", ["copy", "link"])
+def test_copy_position_files_reproduces_the_read_write_result(tmp_path, mode):
+    """The copied channel must read back exactly as the input channel."""
+    input_data = _write_plate(tmp_path / "in.zarr", ["GFP", "RFP"])
+    _write_plate(tmp_path / "out.zarr", ["DAPI", "GFP", "RFP"], seed=1)
+
+    report = copy_position_files(
+        input_position_path=tmp_path / "in.zarr" / "/".join(POSITION),
+        output_position_path=tmp_path / "out.zarr" / "/".join(POSITION),
+        input_channel_indices=[0, 1],
+        output_channel_indices=[1, 2],
+        input_time_indices=list(range(SHAPE[0])),
+        output_time_indices=list(range(SHAPE[0])),
+        zyx_slicing_params=_full_slices(),
+        mode=mode,
+        num_workers=4,
+        extra_metadata={"biahub-concatenate": {"direct_copy": True}},
+    )
+
+    assert report.placed == 6  # 3 timepoints x 2 channels
+    with open_ome_zarr(tmp_path / "out.zarr" / "/".join(POSITION), layout="fov") as out:
+        np.testing.assert_array_equal(out.data[:, 1:3], input_data)
+        assert out.zattrs["biahub-concatenate"] == {"direct_copy": True}
+
+
+def test_link_mode_shares_inodes(tmp_path):
+    _write_plate(tmp_path / "in.zarr", ["GFP"])
+    _write_plate(tmp_path / "out.zarr", ["GFP"])
+    plan, _ = _plan(tmp_path / "in.zarr", tmp_path / "out.zarr", [0], [0])
+
+    place_files(plan.file_pairs(), mode="link")
+
+    for source, destination in plan.file_pairs():
+        assert os.stat(source).st_ino == os.stat(destination).st_ino
+
+
+def test_a_missing_source_file_clears_a_stale_destination(tmp_path):
+    """An unwritten input block must leave the output at its fill value."""
+    _write_plate(tmp_path / "in.zarr", ["GFP"])
+    _write_plate(tmp_path / "out.zarr", ["GFP"], seed=1)
+    plan, _ = _plan(tmp_path / "in.zarr", tmp_path / "out.zarr", [0], [0])
+    pairs = plan.file_pairs()
+    pairs[0][0].unlink()
+
+    report = place_files(pairs)
+
+    assert (report.cleared, report.placed) == (1, len(pairs) - 1)
+    with open_ome_zarr(tmp_path / "out.zarr" / "/".join(POSITION), layout="fov") as out:
+        assert not out.data[0].any()
+
+
+def test_resume_skips_files_already_placed(tmp_path):
+    _write_plate(tmp_path / "in.zarr", ["GFP"])
+    _write_plate(tmp_path / "out.zarr", ["GFP"])
+    plan, _ = _plan(tmp_path / "in.zarr", tmp_path / "out.zarr", [0], [0])
+    pairs = plan.file_pairs()
+
+    place_files(pairs)
+    report = place_files(pairs, resume=True)
+
+    assert (report.reused, report.placed) == (len(pairs), 0)
+
+
+def test_placement_leaves_no_scratch_files(tmp_path):
+    _write_plate(tmp_path / "in.zarr", ["GFP"])
+    _write_plate(tmp_path / "out.zarr", ["GFP"])
+    plan, _ = _plan(tmp_path / "in.zarr", tmp_path / "out.zarr", [0], [0])
+
+    place_files(plan.file_pairs(), num_workers=4)
+
+    assert not list((tmp_path / "out.zarr").rglob("*.tmp"))
+
+
+def test_copy_position_files_refuses_an_incompatible_pair(tmp_path):
+    _write_plate(tmp_path / "in.zarr", ["GFP"])
+    _write_plate(tmp_path / "out.zarr", ["GFP"], dtype=np.float32)
+
+    with pytest.raises(RuntimeError, match="file level"):
+        copy_position_files(
+            input_position_path=tmp_path / "in.zarr" / "/".join(POSITION),
+            output_position_path=tmp_path / "out.zarr" / "/".join(POSITION),
+            input_channel_indices=[0],
+            output_channel_indices=[0],
+            input_time_indices=list(range(SHAPE[0])),
+            output_time_indices=list(range(SHAPE[0])),
+            zyx_slicing_params=_full_slices(),
+        )
+
+
+# -- Summary --------------------------------------------------------------
+
+
+def test_summarize_direct_copy_counts_reasons(tmp_path):
+    _write_plate(tmp_path / "in.zarr", ["GFP"])
+    _write_plate(tmp_path / "out.zarr", ["GFP"])
+    plan, _ = _plan(tmp_path / "in.zarr", tmp_path / "out.zarr", [0], [0])
+
+    summary = summarize_direct_copy(
+        [plan, None, None], [[], ["dtype differs"], ["dtype differs"]]
+    )
+
+    assert (summary.total, summary.direct, summary.files) == (3, 1, plan.num_files)
+    assert summary.all_direct is False
+    assert summary.fallback_reasons == {"dtype differs": 2}


### PR DESCRIPTION
Stacked on #285's branch (`feat/resume-interrupted-positions`) — review that first; the diff here is the four files below.

## What

`biahub concatenate` assembled its output by reading each input volume, cropping it, and writing it back — a full decompress/recompress of every byte. When the output geometry matches the input and no ROI crop is requested, that round trip produces stored files that are byte-for-byte what the input already holds, so the file can be placed at its new key instead.

Measured on real `5-assemble` shards (4.9 GiB, production overhang geometry, channel remapped), read back and compared element-wise against the read-write path:

| path | time |
|---|---|
| direct copy | **1.7 s** |
| read-write (`process_single_position` + `copy_n_paste`) | 33.3 s |

19.5×, and that is with the bytes crossing Lustre to NFS. With `--link` on one filesystem it is a metadata operation.

## How it decides

A stored chunk is interpretable only through its array's metadata — data type, chunk grid, codecs, fill value, key encoding. `copy_incompatibilities` therefore compares the **whole metadata document** rather than a hand-picked list of fields, so a codec option added by a future Zarr release disqualifies the copy by default instead of silently producing an output that cannot be decoded. On top of that:

- ZYX shape must match and the Z/Y/X slices must be the full extent of the input;
- the `(t, c)` remap must be file-aligned — one channel and one timepoint per file, which is what a default `shards_ratio` gives (T ratio 1, and `process_single_position` already rejects sharding along C). A multi-timepoint shard is allowed only when the copy is the identity on the time axis.

Anything else falls back to the read-write path **per position**, with the reason printed, so a mixed plate still gets the speedup where it applies:

```
Direct chunk copy: 4/4 position sources (18 files)
  read-write fallback (2): array metadata differs: data_type (input 'uint16', output 'float32'), codecs
```

## Two side effects worth knowing

- **Placement is atomic** — written under a temporary name in the final directory, then `os.replace`d. The torn-shard failure the base branch added repair and resume for cannot occur on this path at all.
- **The memory request drops** when every source is copyable: nothing buffers a shard, so `mem_gb` is capped at 8 instead of the shard-sized `estimate_resources` value. For the mantis-v2 assemble step that is 96 GB → 8 GB today, and 816 GB → 8 GB if it moves to the 10-timepoint shards discussed in `HANDOFF_torn_shard_resume.md` §7 — which removes the objection that it would only schedule on the 44 large `preempted` nodes.

## One deliberate behaviour change

A byte copy cannot apply `copy_n_paste`'s `nan_to_num`, so **NaNs are carried through rather than zeroed**. Documented on the CLI flag and in the module docstring. A block the input never wrote still has no file and the destination is left with none, so it reads back as the fill value exactly as before; a stale destination file with no source is *removed*, matching what a skipped write leaves behind.

`resume` on this path means "the destination file is already the same size as its source" rather than iohub's per-unit markers. Exact for a run interrupted here, since placement is atomic; a file torn by an interrupted *read-write* run is only caught if its size differs.

## Flags

- `--direct-copy` / `--no-direct-copy` (default on) — opt out to take the read-write path everywhere.
- `--link` (opt-in) — hard-link instead of copying bytes. Instant and free of disk, but the output then shares data with its inputs, so writing into either would corrupt the other. Only safe for write-once inputs. Downgrades to a byte copy across filesystems rather than failing with `EXDEV`.

## Not in this PR

`nextflow/modules/assembly.nf` needs no change to get the speedup, since `--direct-copy` is on by default. Adding `--link` there would make assemble near-instant and zero-disk, and is arguably safe because the sources are write-once and deleted after assemble is verified — but it means the assembled plate shares inodes with `1-deskew`/`2-reconstruct`/`3-virtual-stain` until those are removed. Left as a separate decision.

## Tests

`tests/test_direct_copy.py` (23) covers layout reading for v0.4 and v0.5, each disqualifying condition, and the placement mechanics (link mode sharing inodes, missing source clearing a stale destination, resume, no leftover scratch files). Three integration tests in `tests/test_concatenate.py` assert the direct and read-write outputs are element-wise equal, in both copy and link mode, and that a Z crop falls back. Full suite: 152 passed, 1 skipped. `pre-commit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
