### PR TITLE
fix(skills): keep Nextflow's live display, and record provenance to a file

### DIFF
--- a/.claude/skills/reconstruct-with-nextflow/SKILL.md
+++ b/.claude/skills/reconstruct-with-nextflow/SKILL.md
@@ -161,10 +161,25 @@ do **not** attach yourself:
 ```bash
 SESSION="nf_<DATASET>"
 tmux new-session -d -s "$SESSION" -c "<OUTPUT>"
-tmux send-keys -t "$SESSION" "bash ./run_mantis_v2.sh 2>&1 | tee -a nextflow/run_$(date +%Y%m%dT%H%M%S).log" Enter
+tmux send-keys -t "$SESSION" "bash ./run_mantis_v2.sh" Enter
 ```
 
 Tell the user: `tmux attach -t nf_<DATASET>` to watch, `Ctrl-b d` to detach.
+
+**Do not pipe the launch through `tee`** (or anything else). Nextflow renders its
+live progress table only when stdout is a terminal; a pipe downgrades it to one
+static line per task. Verified on the same Nextflow build: an otherwise identical
+run through `tee` produced plain output, and without it, the dynamic display.
+
+Nothing is lost by dropping it. Two files carry what the console used to:
+
+- `<OUTPUT>/.nextflow.log` — the run record you read to follow progress (step 9).
+- `<OUTPUT>/nextflow/provenance.txt` — written by `run_mantis_v2.sh` at each
+  launch: branch, full commit, input store, host, Nextflow version, and whether
+  the checkout was dirty or off `main`. Appended, so a `-resume` relaunch adds an
+  entry instead of erasing the first one. This is what answers "which commit
+  produced this output?" after the tmux pane is gone — `.nextflow.log` records the
+  launch command line but not the git state.
 
 **Launch from `<OUTPUT>`** (the `-c` above): the cwd controls where
 `.nextflow.log` and the `.nextflow/` resume cache land — relaunching from a

--- a/.claude/skills/reconstruct-with-nextflow/SKILL.md
+++ b/.claude/skills/reconstruct-with-nextflow/SKILL.md
@@ -166,12 +166,26 @@ tmux send-keys -t "$SESSION" "bash ./run_mantis_v2.sh" Enter
 
 Tell the user: `tmux attach -t nf_<DATASET>` to watch, `Ctrl-b d` to detach.
 
-**Do not pipe the launch through `tee`** (or anything else). Nextflow renders its
-live progress table only when stdout is a terminal; a pipe downgrades it to one
-static line per task. Verified on the same Nextflow build: an otherwise identical
-run through `tee` produced plain output, and without it, the dynamic display.
+**Do not pipe the launch through `tee`** (or anything else) — a pipe costs the
+live progress table for nothing, since the two files below already carry the
+console's content.
 
-Nothing is lost by dropping it. Two files carry what the console used to:
+**The live table also needs `CLAUDECODE` unset.** Nextflow 26.04 has an "agent
+mode" that replaces the table with one static `[PROCESS …]` line per task, and it
+turns itself on whenever `CLAUDECODE`, `AGENT`, or `NXF_AGENT_MODE` is truthy. A
+tmux session created from a Claude Code tool call inherits `CLAUDECODE=1`, so the
+run a human then watches for days renders as agent output. `run_mantis_v2.sh`
+does `unset CLAUDECODE` before `nextflow run`; nothing else works, because agent
+mode ORs the three variables (`NXF_AGENT_MODE=false` cannot disable it) and
+`-ansi-log true` is accepted and silently dropped. Reported upstream as
+[nextflow#7478](https://github.com/nextflow-io/nextflow/issues/7478); drop the
+`unset` once it is fixed. Confirm after launching:
+
+```bash
+tmux capture-pane -p -t "$SESSION" | grep -q '^\[PROCESS ' && echo "agent mode — table lost"
+```
+
+Two files carry what the console used to:
 
 - `<OUTPUT>/.nextflow.log` — the run record you read to follow progress (step 9).
 - `<OUTPUT>/nextflow/provenance.txt` — written by `run_mantis_v2.sh` at each

--- a/.claude/skills/reconstruct-with-nextflow/references/caveats.md
+++ b/.claude/skills/reconstruct-with-nextflow/references/caveats.md
@@ -278,11 +278,21 @@ Consequences worth knowing:
   track lengths, and shape/dtype instead.
 - **A rerun is not a reproduction.** If a tracking result matters, keep the
   output; you cannot regenerate the identical one later.
-- **This applies to tracking only.** Every earlier step is deterministic given the
-  same input and config — including `virtual-stain`, despite it also running GPU
-  inference with test-time augmentation. Measured: the same position predicted on
-  two different GPU nodes, one of them with a different CUDA runtime on
-  `LD_LIBRARY_PATH`, produced **bitwise identical** output over three full
-  timepoints (0 differing voxels in 1,024,338,432). So a virtual-stain difference
-  between two runs is a real difference, not noise — worth investigating rather
-  than shrugging at.
+- **Tracking's instability is structural; virtual-stain's is not.** Both run GPU
+  inference, so the distinction matters:
+
+  | | tracking | virtual-stain |
+  |---|---|---|
+  | repeat run, same environment | 1.06% of voxels differ | bitwise identical (0 of 1,024,338,432) |
+  | different GPU node / different CUDA libraries installed | — | 99.87% of voxels differ, but `corr = 1.000000`, median abs diff `5.6e-06`, max abs diff `9.3e-04` on a ~39 range |
+
+  Virtual-stain's differences are float32 last-bit rounding from GPU kernel
+  selection — identical mean, std, min and max to four decimals. Tracking's are
+  *structural*: different label ids and boundaries, from cellpose
+  non-determinism, ultrack's `n_workers=16` watershed with `random_seed='frame'`,
+  and ILP solution ties.
+
+  So **judge virtual-stain on values, not voxel counts.** A bare "99% of voxels
+  differ" means nothing here; `corr` and max abs diff are the measures that do. A
+  real virtual-stain regression moves the distribution, not the last bit. Deskew,
+  reconstruct and assemble are fully deterministic.

--- a/.claude/skills/reconstruct-with-nextflow/references/datasets.md
+++ b/.claude/skills/reconstruct-with-nextflow/references/datasets.md
@@ -82,10 +82,10 @@ layout is defined once in `nextflow/mantis-v2.nf` (`directory_layout()`):
 ├── nextflow/
 │   ├── work/                       # Nextflow work dir (default: <OUTPUT>/nextflow/work)
 │   ├── slurm_output/<step>/%x_%j.{out,err}
-│   ├── report.html  timeline.html  trace.txt  dag.html
-│   └── run_<timestamp>.log         # tee'd console log
-├── .nextflow.log                   # rotates to .1, .2, ...
-└── run_mantis_v2.sh                # provenance: the exact command used
+│   ├── provenance.txt              # branch/commit/input per launch, appended
+│   └── report.html  timeline.html  trace.txt  dag.html
+├── .nextflow.log                   # the run record you read; rotates to .1, .2, ...
+└── run_mantis_v2.sh                # the exact command used
 ```
 
 The dataset stem comes from the *input* store name with `.ome.zarr`/`.zarr`

--- a/.claude/skills/reconstruct-with-nextflow/references/monitoring.md
+++ b/.claude/skills/reconstruct-with-nextflow/references/monitoring.md
@@ -26,19 +26,34 @@ pane so the user sees live Nextflow output on attach:
 SESSION="nf_<DATASET>"
 tmux has-session -t "$SESSION" 2>/dev/null && echo "session exists — attach or kill it first"
 tmux new-session -d -s "$SESSION" -c "<OUTPUT>"
-tmux send-keys -t "$SESSION" \
-  "bash ./run_mantis_v2.sh 2>&1 | tee -a nextflow/run_$(date +%Y%m%dT%H%M%S).log" Enter
+tmux send-keys -t "$SESSION" "bash ./run_mantis_v2.sh" Enter
 ```
 
 Tell the user: `tmux attach -t nf_<DATASET>`, detach with `Ctrl-b d`.
 
+**Send the command bare — no `| tee`, no redirect.** Nextflow renders its live
+progress table only when stdout is a terminal, so any pipe downgrades the user's
+pane to one static line per task. The console is the user's view; yours is
+`.nextflow.log`.
+
 **Do not attach yourself** — attaching from a tool call gives you a terminal you
-cannot read usefully and can steal the user's pane. Read the tee'd log instead:
+cannot read usefully and can steal the user's pane. **Read `.nextflow.log`**,
+which Nextflow writes in the launch directory regardless of what the console
+shows:
 
 ```bash
-tail -n 50 <OUTPUT>/nextflow/run_*.log
-tmux capture-pane -p -t "$SESSION" | tail -40    # if the log is not yet flushed
+tail -n 50 <OUTPUT>/.nextflow.log
 ```
+
+It carries what you need to follow progress: the launch command line, each task's
+submission and completion with its work dir hash, exit statuses, retries, and the
+final `WorkflowStats[succeededCount=...; failedCount=...; retriesCount=...]`
+summary. Rotated per run as `.nextflow.log.1`, `.log.2`, … so the previous run's
+log survives a relaunch.
+
+`tmux capture-pane -p -t "$SESSION" | tail -40` still works as a last resort, but
+prefer the log: the pane holds only what fits on screen, and with the progress
+table redrawing in place it is not a transcript.
 
 To confirm the run is alive:
 

--- a/.claude/skills/reconstruct-with-nextflow/references/monitoring.md
+++ b/.claude/skills/reconstruct-with-nextflow/references/monitoring.md
@@ -31,10 +31,16 @@ tmux send-keys -t "$SESSION" "bash ./run_mantis_v2.sh" Enter
 
 Tell the user: `tmux attach -t nf_<DATASET>`, detach with `Ctrl-b d`.
 
-**Send the command bare — no `| tee`, no redirect.** Nextflow renders its live
-progress table only when stdout is a terminal, so any pipe downgrades the user's
-pane to one static line per task. The console is the user's view; yours is
-`.nextflow.log`.
+**Send the command bare — no `| tee`, no redirect.** A pipe buys nothing that
+`.nextflow.log` and `nextflow/provenance.txt` don't already record. The console is
+the user's view; yours is `.nextflow.log`.
+
+**The pane inherits `CLAUDECODE=1` from the tool call that created the session**,
+which puts Nextflow 26.04 into agent mode: one static `[PROCESS …]` line per task,
+no live table, for a run the user watches for days. `run_mantis_v2.sh` handles it
+with `unset CLAUDECODE`; if you ever launch Nextflow by hand, prefix it with
+`env -u CLAUDECODE`. `NXF_AGENT_MODE=false` and `-ansi-log true` do **not** work —
+see SKILL.md §8 and [nextflow#7478](https://github.com/nextflow-io/nextflow/issues/7478).
 
 **Do not attach yourself** — attaching from a tool call gives you a terminal you
 cannot read usefully and can steal the user's pane. **Read `.nextflow.log`**,

--- a/.claude/skills/reconstruct-with-nextflow/templates/run_mantis_v2.sh
+++ b/.claude/skills/reconstruct-with-nextflow/templates/run_mantis_v2.sh
@@ -66,20 +66,9 @@ uv sync --project "${BIAHUB_PROJECT}"
 set +u; source "${BIAHUB_PROJECT}/.venv/bin/activate"; set -u
 command -v biahub >/dev/null || { echo "biahub not on PATH after activation" >&2; exit 1; }
 
-# Record which code is about to run. This lands in the tee'd run log, so the
-# output directory carries the answer to "which commit produced this?" without
-# depending on the checkout still being in the same state later. Runs should come
-# off `main`; a feature branch is legitimate but should be a deliberate choice, so
-# warn rather than fail.
 BIAHUB_BRANCH="$(git -C "${BIAHUB_PROJECT}" rev-parse --abbrev-ref HEAD 2>/dev/null || echo '?')"
-echo "biahub: ${BIAHUB_PROJECT}"
-echo "  branch ${BIAHUB_BRANCH}  $(git -C "${BIAHUB_PROJECT}" log -1 --format='%h %s' 2>/dev/null)"
-if [[ -n "$(git -C "${BIAHUB_PROJECT}" status --porcelain 2>/dev/null)" ]]; then
-    echo "  WARNING: uncommitted changes — this run is not reproducible from the commit above" >&2
-fi
-if [[ "${BIAHUB_BRANCH}" != "main" ]]; then
-    echo "  WARNING: not on main" >&2
-fi
+BIAHUB_COMMIT="$(git -C "${BIAHUB_PROJECT}" log -1 --format='%H %cI %s' 2>/dev/null || echo '?')"
+BIAHUB_DIRTY="$(git -C "${BIAHUB_PROJECT}" status --porcelain 2>/dev/null || true)"
 
 # Default the converted plate to the conventional location if it exists there.
 if [[ -z "${CONVERTED_ZARR}" && -d "${OUTPUT_DIR}/0-convert/${DATASET}.zarr" ]]; then
@@ -91,6 +80,45 @@ INPUT_ZARR="${CONVERTED_ZARR:-${DATA_DIR}/${DATASET}/${RAW_STORE}}"
 
 [[ -d "${INPUT_ZARR}" ]] || { echo "input not found: ${INPUT_ZARR}" >&2; exit 1; }
 [[ -d "${CONFIGS}"    ]] || { echo "configs not found: ${CONFIGS}"  >&2; exit 1; }
+
+# Record which code and inputs this run used, to a FILE as well as the console.
+#
+# The file is the durable record. The launch is deliberately not piped through
+# `tee` (Nextflow only renders its live progress table when stdout is a terminal),
+# and `.nextflow.log` captures the launch command line but not the git state — so
+# without this, "which commit produced this output?" is unanswerable once the tmux
+# pane is gone. Appends, so a `-resume` relaunch adds an entry rather than erasing
+# the original run's provenance.
+PROVENANCE="${OUTPUT_DIR}/nextflow/provenance.txt"
+mkdir -p "${OUTPUT_DIR}/nextflow"
+{
+    echo "=== $(date -Is) ==="
+    echo "dataset   ${DATASET}"
+    echo "input     ${INPUT_ZARR}"
+    echo "output    ${OUTPUT_DIR}"
+    echo "biahub    ${BIAHUB_PROJECT}"
+    echo "branch    ${BIAHUB_BRANCH}"
+    echo "commit    ${BIAHUB_COMMIT}"
+    echo "host      $(hostname)"
+    echo "nextflow  $(nextflow -version 2>&1 | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)"
+    if [[ -n "${BIAHUB_DIRTY}" ]]; then
+        echo "dirty     YES — not reproducible from the commit above:"
+        echo "${BIAHUB_DIRTY}" | sed 's/^/          /'
+    fi
+    if [[ "${BIAHUB_BRANCH}" != "main" ]]; then
+        echo "warning   not on main"
+    fi
+} >> "${PROVENANCE}"
+
+echo "biahub: ${BIAHUB_PROJECT}"
+echo "  branch ${BIAHUB_BRANCH}  ${BIAHUB_COMMIT%% *}"
+echo "  provenance appended to ${PROVENANCE}"
+if [[ -n "${BIAHUB_DIRTY}" ]]; then
+    echo "  WARNING: uncommitted changes — this run is not reproducible from the commit above" >&2
+fi
+if [[ "${BIAHUB_BRANCH}" != "main" ]]; then
+    echo "  WARNING: not on main" >&2
+fi
 
 nextflow run "${PIPELINE}" \
     -c "${NF_CONFIG}" \

--- a/.claude/skills/reconstruct-with-nextflow/templates/run_mantis_v2.sh
+++ b/.claude/skills/reconstruct-with-nextflow/templates/run_mantis_v2.sh
@@ -84,8 +84,7 @@ INPUT_ZARR="${CONVERTED_ZARR:-${DATA_DIR}/${DATASET}/${RAW_STORE}}"
 # Record which code and inputs this run used, to a FILE as well as the console.
 #
 # The file is the durable record. The launch is deliberately not piped through
-# `tee` (Nextflow only renders its live progress table when stdout is a terminal),
-# and `.nextflow.log` captures the launch command line but not the git state — so
+# `tee`, and `.nextflow.log` captures the launch command line but not the git state — so
 # without this, "which commit produced this output?" is unanswerable once the tmux
 # pane is gone. Appends, so a `-resume` relaunch adds an entry rather than erasing
 # the original run's provenance.
@@ -119,6 +118,18 @@ fi
 if [[ "${BIAHUB_BRANCH}" != "main" ]]; then
     echo "  WARNING: not on main" >&2
 fi
+
+# Nextflow 26.04 switches to "agent mode" — one static `[PROCESS …]` line per task
+# instead of the live progress table — when CLAUDECODE (or AGENT, or
+# NXF_AGENT_MODE) is truthy in the environment. When Claude Code creates the tmux
+# session, the pane inherits CLAUDECODE=1, so a run a HUMAN watches for days
+# renders as agent output. Unsetting the variable is the only way out: agent mode
+# ORs the three variables, so `NXF_AGENT_MODE=false` cannot disable it, and an
+# explicit `-ansi-log true` is silently dropped
+# (CmdRun.groovy: `session.ansiLog = options.ansiLog && !SysEnv.isAgentMode()`).
+# Reported upstream: https://github.com/nextflow-io/nextflow/issues/7478
+# Harmless when unset already, and nothing in the pipeline reads it.
+unset CLAUDECODE
 
 nextflow run "${PIPELINE}" \
     -c "${NF_CONFIG}" \


### PR DESCRIPTION
## What

Follow-ups to #305 on the `reconstruct-with-nextflow` skill:

1. **Restore Nextflow's live progress table** for runs the skill launches — the cause turned out to be Nextflow 26.04's *agent mode*, triggered by the `CLAUDECODE` variable the tmux pane inherits.
2. Stop piping the launch through `tee`.
3. Write `<OUTPUT>/nextflow/provenance.txt`, so dropping `tee` does not lose the branch/commit record.
4. Correct `caveats.md` §14, which overgeneralised a determinism measurement.

## 1. The real cause: Nextflow 26.04 agent mode

Nextflow 26.04 renders one static `[PROCESS …]` line per task instead of the live table when **`CLAUDECODE`**, `AGENT`, or `NXF_AGENT_MODE` is truthy. All three are present in the 26.04.3 launcher (`CLAUDECODE`, `NXF_AGENT_MODE`, and four references to `isAgentMode`).

When Claude Code creates the tmux session, the pane inherits `CLAUDECODE=1`, so a run a **human** watches for days renders as agent output. Two things make it unfixable from the command line:

- agent mode ORs the three variables, so `NXF_AGENT_MODE=false` cannot disable it;
- `-ansi-log true` is silently dropped — `CmdRun.groovy` does
  `session.ansiLog = options.ansiLog && !SysEnv.isAgentMode()`.

So `run_mantis_v2.sh` now does `unset CLAUDECODE` before `nextflow run`, which is the only way out. Harmless when already unset, and nothing in the pipeline reads it. Reported upstream as [nextflow#7478](https://github.com/nextflow-io/nextflow/issues/7478).

`monitoring.md` records the same, plus `env -u CLAUDECODE` for launching Nextflow by hand.

### How I got this wrong first

Worth recording, because the wrong answer was superficially well-evidenced. I concluded Nextflow 26 had *dropped* its ANSI logger, on the strength of: a `script` pty, then a `pty.openpty()` harness with an explicit `TIOCSWINSZ` and a verified `stty size`, neither of which produced the table under `-ansi-log true` (before or after `run`), `NXF_ANSI_LOG=true`, `COLUMNS=200`, `TERM=xterm-256color`, or an interactive `bash -i` — while **24.10.5 did** emit ANSI in the same harness. That looked conclusively like a version regression, and I nearly recommended pinning 24.10.5.

Every one of those tests inherited `CLAUDECODE=1` from the tool environment, so all of them were in agent mode. 24.10.5 predates agent mode entirely, which is why it was unaffected and why the contrast was so misleading. The lesson is that a harness built by an agent inherits the agent's environment, and that is exactly the variable under test here.

## 2. Dropping `tee`

Kept independently of the above: a pipe defeats Nextflow's terminal detection (measured on 24.10.5: 147 → 3 ESC bytes through `tee`), and it buys nothing, since `.nextflow.log` already holds the per-task record `monitoring.md` reads. Verified against the 341-task production run in `2026_07_14_A549_MAP4_ZIKV_rerun_2`: 341 `Submitted process` lines with work-dir hashes, 341 `Task completed` lines with exit status, and the final `WorkflowStats[succeededCount=341; failedCount=0; retriesCount=0; …]`.

`monitoring.md` now points agents at `.nextflow.log` explicitly and demotes `capture-pane` to a last resort — the pane holds only what fits on screen, and a redrawing table is not a transcript.

## 3. `nextflow/provenance.txt`

What `tee` did uniquely carry was the run script's own output, including the branch/commit block; `.nextflow.log` records the launch command line but not the git state. So the script now writes:

```
=== 2026-08-13T12:15:18-07:00 ===
dataset   2026_07_14_A549_MAP4_ZIKV
input     /hpc/instruments/cm.mantis/…/2026_07_14_A549_MAP4_ZIKV_1.ome.zarr
output    /hpc/projects/…/2026_07_14_A549_MAP4_ZIKV_rerun_2
biahub    /hpc/mydata/<user>/biahub
branch    main
commit    5c3baa21aa7a… 2026-08-13T10:58:13-07:00 feat(skills): …
host      gpu-sm02-19
nextflow  26.04.3
dirty     YES — not reproducible from the commit above:
           M .claude/skills/…/SKILL.md
warning   not on main
```

Three details that needed a second pass: it **appends**, so a `-resume` relaunch adds an entry rather than erasing the first; it sits **after** input resolution so it records the real input rather than a placeholder; and the trailing warnings use `if` rather than `[[ … ]] &&`, which under `set -euo pipefail` would have made a *clean* checkout exit non-zero before `nextflow run` — the feature would have broken launches on exactly the well-behaved checkouts it rewards. Exercised end to end under `set -euo pipefail`: exits 0, both warning branches fire.

## 4. Correcting §14

§14 claimed virtual-stain output is bitwise reproducible, and therefore that **any** virtual-stain difference is real and worth investigating. That generalised a single measurement too far.

With `cupy`/`cucim` installed, the same position differs in **99.87% of voxels** — while `corr = 1.000000`, median abs diff `5.6e-06`, max abs diff `9.3e-04` on a ~39 range, and identical mean/std/min/max to four decimals. That is float32 last-bit rounding from GPU kernel selection, not a changed prediction. As written, §14 would have sent someone chasing noise.

It now contrasts tracking's *structural* differences (different label ids; 1.06% between identical runs) with virtual-stain's last-bit ones, and says to judge virtual-stain on `corr` and max abs diff rather than voxel counts.

## Verification

- **Live table confirmed working** by a real launch through the skill.
- `bash -n` clean; provenance block exercised under `set -euo pipefail`.
- No remaining `tee` or `run_*.log` references in the skill.
- `.nextflow.log` content confirmed against a real 341-task run before relying on it.
- Agent-mode variables confirmed present in the 26.04.3 launcher.
- pre-commit clean on the changed files.

One note for anyone reproducing: a fully-cached `-resume` run shows no table either, because there is nothing live to render (`cachedCount=341, submittedCount=0`). Test against a fresh output directory, or `--max_positions 1`.

Docs-only apart from the run-script template; no pipeline or library code touched.
