### PR TITLE
perf(flat-field): tile the median so it stays in cache (19x on Zen 2 nodes)

### DIFF
--- a/biahub/flat_field.py
+++ b/biahub/flat_field.py
@@ -33,6 +33,77 @@ from biahub.cli.utils import (
 )
 from biahub.settings import FlatFieldCorrectionSettings
 
+# Byte budget for one median tile. The reduction below runs at DRAM latency when
+# its working set spills out of cache, so the tile is sized to fit in the smallest
+# per-CCX L3 in the cluster (16 MiB on Zen 2), with headroom for the partition's
+# own scratch. See :func:`_median_tiled` for why this matters.
+_MEDIAN_TILE_BYTES = 8 * 1024**2
+
+
+def _median_tile_axis(data: np.ndarray, axis: int) -> int | None:
+    """Return the first axis that is not the reduction axis, or None for 1-D input."""
+    return next((a for a in range(data.ndim) if a != axis), None)
+
+
+def _median_tile_width(data: np.ndarray, axis: int, tile_bytes: int) -> int:
+    """Return how many indices along the tiled axis fit in ``tile_bytes``.
+
+    Never less than 1, never more than the axis length.
+    """
+    tile_axis = _median_tile_axis(data, axis)
+    bytes_per_step = data.itemsize * (data.size // data.shape[tile_axis])
+    width = tile_bytes // max(bytes_per_step, 1)
+    return int(min(max(width, 1), data.shape[tile_axis]))
+
+
+def _median_tiled(
+    data: np.ndarray, axis: int, tile_bytes: int = _MEDIAN_TILE_BYTES
+) -> np.ndarray:
+    """``np.median(data, axis=axis)``, evaluated over cache-resident tiles.
+
+    Output is identical to :func:`numpy.median` -- only the memory access pattern
+    changes. ``np.median`` partitions along ``axis``, whose stride in a ZYX volume
+    is ``Y * X * itemsize`` (852 KB for a mantis-v2 position), so every element
+    touched lands on its own cache line and the reduction runs at DRAM latency.
+    That cost is borne unevenly by the cluster: measured on one position, it is
+    11.5x worse on Zen 2 cores (EPYC 7742, 7302P) than on Zen 3 and newer, which
+    made flat-field spend ~139 CPU-s per (t, c) unit on ``gpu-a``/``gpu-sm`` nodes
+    against ~12 CPU-s on ``cpu-h``.
+
+    Copying a slim tile into a compact buffer first keeps the partition in cache.
+    Per-position medians measured before and after:
+
+    ==================  ===========  =========  ========
+    node                CPU          np.median  tiled
+    ==================  ===========  =========  ========
+    ``gpu-a-3``         EPYC 7742    134.33 s   5.52 s
+    ``gpu-sm02-19``     EPYC 7302P    99.26 s   5.72 s
+    ``cpu-e-1``         EPYC 7763      9.89 s   5.18 s
+    ==================  ===========  =========  ========
+
+    Transposing to make the reduction axis contiguous was also tried and is much
+    worse on the affected nodes (78.25 s on ``gpu-a-3``), because the transpose
+    copy is itself a strided read.
+    """
+    tile_axis = _median_tile_axis(data, axis)
+    if tile_axis is None:
+        return np.median(data, axis=axis)
+
+    tile = _median_tile_width(data, axis, tile_bytes)
+    tiles = []
+    for start in range(0, data.shape[tile_axis], tile):
+        index = [slice(None)] * data.ndim
+        index[tile_axis] = slice(start, start + tile)
+        # ascontiguousarray is what buys the locality: without the copy the tile
+        # is a view carrying the full array's strides, so the partition still
+        # walks the whole buffer.
+        tiles.append(np.median(np.ascontiguousarray(data[tuple(index)]), axis=axis))
+
+    if len(tiles) == 1:
+        return tiles[0]
+    # The reduction drops `axis`, shifting the tiled axis down when it sat after it.
+    return np.concatenate(tiles, axis=tile_axis - (1 if tile_axis > axis else 0))
+
 
 def flat_field_zyx(zyx_data: np.ndarray, axis: int = 0) -> np.ndarray:
     """Apply flat field correction by dividing out the median pattern along an axis.
@@ -50,7 +121,7 @@ def flat_field_zyx(zyx_data: np.ndarray, axis: int = 0) -> np.ndarray:
         Flat-field corrected data, normalised so the mean of the static pattern
         is preserved.
     """
-    static_pattern = np.median(zyx_data, axis=axis)
+    static_pattern = _median_tiled(zyx_data, axis=axis)
     return zyx_data / static_pattern * static_pattern.mean()
 
 

--- a/tests/test_flat_field.py
+++ b/tests/test_flat_field.py
@@ -1,0 +1,115 @@
+import numpy as np
+import pytest
+
+from biahub.flat_field import (
+    _MEDIAN_TILE_BYTES,
+    _flat_field_czyx,
+    _median_tile_width,
+    _median_tiled,
+    flat_field_zyx,
+)
+
+# One mantis-v2 position, as flat-field sees it per (t, c) unit.
+MANTIS_ZYX = (1068, 256, 1664)
+
+
+def _data(shape, dtype, seed=0):
+    rng = np.random.default_rng(seed)
+    # +1 keeps the median pattern away from zero so the division stays finite and
+    # exact-equality comparisons are not comparing NaNs.
+    return (rng.random(shape) * 4095 + 1).astype(dtype)
+
+
+@pytest.mark.parametrize("dtype", [np.uint16, np.float32, np.float64])
+@pytest.mark.parametrize(
+    "shape",
+    [
+        (8, 6, 4),  # even reduction axis -> median averages the two middle values
+        (9, 6, 4),  # odd reduction axis  -> median picks a single element
+        (2, 3, 5),
+        (1, 4, 4),  # degenerate reduction axis
+    ],
+)
+def test_median_tiled_matches_numpy(shape, dtype):
+    data = _data(shape, dtype)
+    expected = np.median(data, axis=0)
+    # A 1-byte budget forces the narrowest possible tile, so the tiling path runs
+    # even for these small arrays.
+    result = _median_tiled(data, axis=0, tile_bytes=1)
+
+    assert result.dtype == expected.dtype
+    assert result.shape == expected.shape
+    np.testing.assert_array_equal(result, expected)
+
+
+@pytest.mark.parametrize("tile_bytes", [1, 64, 4096, _MEDIAN_TILE_BYTES])
+def test_median_tiled_is_invariant_to_tile_size(tile_bytes):
+    """Tile width is a performance knob only; it must not move the result."""
+    data = _data((16, 12, 9), np.uint16)
+    np.testing.assert_array_equal(
+        _median_tiled(data, axis=0, tile_bytes=tile_bytes), np.median(data, axis=0)
+    )
+
+
+@pytest.mark.parametrize("axis", [0, 1, 2])
+def test_median_tiled_matches_numpy_on_every_axis(axis):
+    data = _data((7, 8, 9), np.uint16)
+    np.testing.assert_array_equal(
+        _median_tiled(data, axis=axis, tile_bytes=1), np.median(data, axis=axis)
+    )
+
+
+def test_median_tiled_handles_noncontiguous_input():
+    """Production hands in ``czyx_data[c]``, and callers may pass strided views."""
+    view = _data((8, 6, 10), np.uint16)[:, :, ::2]
+    assert not view.flags["C_CONTIGUOUS"]
+    np.testing.assert_array_equal(
+        _median_tiled(view, axis=0, tile_bytes=1), np.median(view, axis=0)
+    )
+
+
+def test_median_tiled_handles_1d_input():
+    data = _data((32,), np.uint16)
+    assert _median_tiled(data, axis=0) == np.median(data, axis=0)
+
+
+def test_flat_field_zyx_matches_reference_expression():
+    data = _data((16, 12, 9), np.uint16)
+    pattern = np.median(data, axis=0)
+    expected = data / pattern * pattern.mean()
+
+    np.testing.assert_array_equal(flat_field_zyx(data), expected)
+
+
+def test_flat_field_czyx_corrects_only_target_channels():
+    czyx = _data((3, 8, 6, 4), np.uint16)
+    out = _flat_field_czyx(czyx, target_indices=[1])
+
+    assert out.dtype == np.float32
+    np.testing.assert_array_equal(out[0], czyx[0].astype(np.float32))
+    np.testing.assert_array_equal(out[1], flat_field_zyx(czyx[1]).astype(np.float32))
+    np.testing.assert_array_equal(out[2], czyx[2].astype(np.float32))
+
+
+def test_mantis_position_is_tiled_under_the_default_budget():
+    """Guards the optimisation itself: a real position must not become one tile.
+
+    Without this, a change to the budget or the width maths could silently fall
+    back to a single whole-array median -- correct, but 11.5x slower on Zen 2.
+    """
+    # Only shape and itemsize are consulted, so a zero-stride view stands in for
+    # the real 0.9 GB volume.
+    data = np.lib.stride_tricks.as_strided(
+        np.zeros(1, dtype=np.uint16), shape=MANTIS_ZYX, strides=(0, 0, 0)
+    )
+    width = _median_tile_width(data, axis=0, tile_bytes=_MEDIAN_TILE_BYTES)
+
+    assert 1 <= width < MANTIS_ZYX[1]
+    tile_nbytes = width * MANTIS_ZYX[0] * MANTIS_ZYX[2] * data.itemsize
+    assert tile_nbytes <= _MEDIAN_TILE_BYTES
+
+
+def test_median_tile_width_is_clamped_to_the_axis():
+    data = _data((4, 3, 2), np.uint16)
+    assert _median_tile_width(data, axis=0, tile_bytes=1) == 1
+    assert _median_tile_width(data, axis=0, tile_bytes=10**9) == 3


### PR DESCRIPTION
## Problem

`flat_field_zyx` reduces with `np.median(zyx_data, axis=0)`. Axis 0 has a stride of `Y * X * itemsize` — **852 KB** for a mantis-v2 position — so the partition underneath `np.median` touches one cache line per element and runs at DRAM latency.

`np.partition` alone accounts for **134.35 s of the 134.66 s** kernel. The float64 divide is 0.61 s, and casting the median to float32 saves nothing — the partition *is* the kernel.

That cost lands very unevenly across Bruno. Measured on identical synthetic data, single-threaded, zero I/O, across 17 nodes:

| CPU | nodes | strided median | contiguous | streaming |
|---|---|---|---|---|
| EPYC 9354P / 9534 (Zen 4) | `cpu-h`, `cpu-i`, `cpu-g` | 2.05–2.09 s | 0.85–0.88 s | 7.8–9.4 GB/s |
| EPYC 7713 / 7763 / 7773X (Zen 3) | `gpu-b`, `cpu-e`, `gpu-d` | 2.32–2.57 s | 0.86–0.93 s | 8.3–9.4 GB/s |
| EPYC 7313P (Zen 3) | `gpu-e` | 2.30 s | 0.86 s | 9.5 GB/s |
| **EPYC 7742 (Zen 2)** | **`gpu-a-1..4`** | **12.59–12.96 s** | 1.09–1.14 s | 8.3–8.6 GB/s |
| **EPYC 7302P (Zen 2)** | **`gpu-sm01/02`** | **13.04–13.31 s** | 1.15–1.17 s | 7.1–7.7 GB/s |

The affected nodes are within 12% of everything else on streaming bandwidth and within 1.3x on a *contiguous* median — they are only slow at the **strided** reduction. All four `gpu-a` nodes agree within 3%, and a second unrelated Zen 2 model in a different chassis behaves the same, so this is not a degraded node.

In the `2026_08_11_A549_SEC61B_DENV` run this made flat-field spend **~139 CPU-s per (t, c) unit** on `gpu-a`/`gpu-sm` against **~12 CPU-s** on `cpu-h` — a 10x spread over 54 positions × 201 units, and the reason 8 tasks hit the 2h30 wall limit and had to retry.

Ruled out along the way: thread oversubscription (`cpu/wall = 1.00` in every phase; pinning `OMP/MKL/OPENBLAS/NUMEXPR/BLOSC` changed nothing), worker concurrency (+4.7% CPU/unit from 1→16 workers on `gpu-a`), write I/O (4.69 s vs 4.21 s per unit between the two classes), RAM pressure (zero `OUT_OF_MEMORY`; MaxRSS 57–107 GB against a 224 GB request), and dtype promotion.

## Fix

Copy a slim tile into a compact buffer before reducing, sized to fit the smallest per-CCX L3 in the cluster (16 MiB on Zen 2). Per-position median on real data:

| node | CPU | `np.median` | tiled |
|---|---|---|---|
| `gpu-a-3` | EPYC 7742 | 134.33 s | **5.52 s** |
| `gpu-sm02-19` | EPYC 7302P | 99.26 s | **5.72 s** |
| `cpu-e-1` | EPYC 7763 | 9.89 s | **5.18 s** |

The three classes converge to within 10% of each other — the 13.6x hardware spread collapses to 1.1x. End to end through `flat_field_zyx` on one real unit: **131.12 s → 6.79 s (19.3x), output bit-identical.**

Transposing to make the reduction axis contiguous was also tried and is far worse on the affected nodes (78.25 s on `gpu-a-3`) — the transpose copy is itself a strided read. Only tiling works.

## Correctness

Output is unchanged by construction: each 1-D lane is reduced from the same elements by the same algorithm, so tiling only changes the access pattern. Verified bit-identical (`np.array_equal`) against the current implementation on a real mantis position, and `tests/test_flat_field.py` asserts exact equality against `np.median` across dtypes (`uint16`/`float32`/`float64`), all three axes, even *and* odd reduction-axis lengths (the even case averages two middle values), degenerate axes, non-contiguous views, and forced tile widths from 1 byte upward.

One test is a performance guard rather than a correctness check: it asserts a real position does not silently collapse back to a single whole-array tile, which would stay correct but lose the 11.5x.

## Notes

- Wall-clock gains are concentrated where CPU was the binding constraint. On `cpu-h`-class nodes flat-field is already I/O-bound (12.3 CPU-s against ~206 s wall per unit), so those get little faster; the win is the CPU-hours and the `gpu-a` tasks that were timing out.
- `deskew` was checked for the same pattern and does **not** have it — Zen 2 `gpu-sm` nodes are the *fastest* class at deskew (6.5 min mean), so this is specific to flat-field's median.
- Incidental finding, not addressed here: SLURM tags both `gpu-a` and `gpu-b` as `amd_7742`, but `gpu-b` reports an EPYC 7713. `--constraint=amd_7742` does not select what it claims.

🤖 Generated with [Claude Code](https://claude.com/claude-code)