### PR TITLE
Pin iohub past the gapped-shard-write abort (iohub#460)

### DIFF
--- a/.claude/skills/reconstruct-with-nextflow/references/caveats.md
+++ b/.claude/skills/reconstruct-with-nextflow/references/caveats.md
@@ -180,6 +180,20 @@ sharded — keep C at 1. Auto-sizing is
 [iohub#458](https://github.com/czbiohub-sf/iohub/issues/458); most of this
 section goes away when it lands.
 
+**A T ratio above 1 needs iohub ≥ [#460](https://github.com/czbiohub-sf/iohub/pull/460).**
+Before it, `concatenate` aborted with a message that points nowhere near the
+cause — `numpy ... Unable to allocate 651. TiB for an array with shape
+(1048576, 86, 1664, 1193)`, whose first axis is not T, not a shard, not
+anything. It is **not** evidence that the shard buffer is too large, and
+unsetting `shards_ratio` "fixes" it for the wrong reason. What happens: a
+shard-aligned batch writes a whole shard's worth of timepoints in one call,
+iohub drops the blank ones (`Skipping t=1, c=0 due to all zeros or nans` in the
+step's `.command.out`), and the surviving indices are left with a *gap* — which
+a sharded write cannot express. Confirm it by grepping `.command.err` for
+`DiscontiguousArrayError`; the array it prints is the diff of the surviving
+indices (`[3 1]` for `[0, 3, 4]`, i.e. t=1 and t=2 were blank). If you see this
+signature, check the iohub pin rather than the shard geometry.
+
 ## 8. Preemption is expected, not an error
 
 Per-position work runs on the `preempted` partition; SLURM reclaims jobs

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ classifiers = [
 
 dependencies = [
   "click",
-  "iohub>=0.3.8",
+  "iohub>=0.3.11",
   "matplotlib",
   "natsort",
   "numpy",
@@ -118,23 +118,6 @@ index-strategy = "unsafe-best-match"
 # Pin cytoland to the commit from VisCy PR #465 (non-square TTA and helpers).
 # Revert to the PyPI release once that PR is merged and published.
 cytoland = { git = "https://github.com/mehta-lab/VisCy", subdirectory = "applications/cytoland", rev = "4b62365c0df25929bffc7f01b3bb2d1c11d69cce" }
-# Pin iohub to the three fixes this pipeline needs, none of them in the v0.3.10
-# release. The rev is the tip of the fix/contiguous-shard-writes branch, i.e.
-# main plus the one unmerged fix; repoint it at the main commit once #460 merges.
-#   #460  writes a gapped time selection as separate contiguous runs (UNMERGED).
-#     Without it any `shards_ratio` with a T entry above 1 aborts `concatenate`
-#     as soon as a blank timepoint lands mid-shard — see caveat 7 for the
-#     signature, which does not look like what it is.
-#   #455  replaces a shard torn by a preempted job instead of reading it back
-#     (the recurring "checksum is invalid" abort) and adds the per-unit resume
-#     this branch drives via --resume. Note the resume records sit BESIDE the
-#     store, in a `.iohub-progress/` sibling of the output zarr, so copying or
-#     deleting a store no longer carries or clears its progress state.
-#   #454  adds create_empty_plate's metadata_keys, so a step copies only the
-#     provenance zattrs it wants instead of every non-OME key (see
-#     PROVENANCE_METADATA_KEYS).
-# Drop this source and raise the iohub floor once a release includes all three.
-iohub = { git = "https://github.com/czbiohub-sf/iohub", rev = "719ba12c6932b23d84de86d87168777520c290d9" }
 
 [tool.hatch.metadata]
 allow-direct-references = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -115,8 +115,7 @@ biahub = "biahub.cli.main:cli"
 index-strategy = "unsafe-best-match"
 
 [tool.uv.sources]
-# Pin cytoland to the commit from VisCy PR #465 (non-square TTA and helpers).
-# Revert to the PyPI release once that PR is merged and published.
+# No PyPI release yet
 cytoland = { git = "https://github.com/mehta-lab/VisCy", subdirectory = "applications/cytoland", rev = "4b62365c0df25929bffc7f01b3bb2d1c11d69cce" }
 
 [tool.hatch.metadata]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -118,8 +118,13 @@ index-strategy = "unsafe-best-match"
 # Pin cytoland to the commit from VisCy PR #465 (non-square TTA and helpers).
 # Revert to the PyPI release once that PR is merged and published.
 cytoland = { git = "https://github.com/mehta-lab/VisCy", subdirectory = "applications/cytoland", rev = "4b62365c0df25929bffc7f01b3bb2d1c11d69cce" }
-# Pin iohub to czbiohub-sf/iohub main, which now carries the two features this
-# pipeline needs — both merged, but after the v0.3.10 release:
+# Pin iohub to the three fixes this pipeline needs, none of them in the v0.3.10
+# release. The rev is the tip of the fix/contiguous-shard-writes branch, i.e.
+# main plus the one unmerged fix; repoint it at the main commit once #460 merges.
+#   #460  writes a gapped time selection as separate contiguous runs (UNMERGED).
+#     Without it any `shards_ratio` with a T entry above 1 aborts `concatenate`
+#     as soon as a blank timepoint lands mid-shard — see caveat 7 for the
+#     signature, which does not look like what it is.
 #   #455  replaces a shard torn by a preempted job instead of reading it back
 #     (the recurring "checksum is invalid" abort) and adds the per-unit resume
 #     this branch drives via --resume. Note the resume records sit BESIDE the
@@ -128,8 +133,8 @@ cytoland = { git = "https://github.com/mehta-lab/VisCy", subdirectory = "applica
 #   #454  adds create_empty_plate's metadata_keys, so a step copies only the
 #     provenance zattrs it wants instead of every non-OME key (see
 #     PROVENANCE_METADATA_KEYS).
-# Drop this source and raise the iohub floor once a release includes both.
-iohub = { git = "https://github.com/czbiohub-sf/iohub", rev = "f3c40a4abfda790cf915fd9ccb04ca98fbf15925" }
+# Drop this source and raise the iohub floor once a release includes all three.
+iohub = { git = "https://github.com/czbiohub-sf/iohub", rev = "719ba12c6932b23d84de86d87168777520c290d9" }
 
 [tool.hatch.metadata]
 allow-direct-references = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,35 +52,8 @@ dependencies = [
 [project.optional-dependencies]
 segment = ["cellpose"]
 
-# Deliberately CPU-only: no cupy/cucim here.
-#
-# ultrack has an optional GPU path — it sets its array module to cupy whenever
-# cupy is importable, and sources GPU replacements for skimage/scipy from cucim.
-# ultrack's own pyproject suggests `cupy`/`cucim`/`pytorch-cuda` (a conda-only
-# feature; our torch is already a CUDA build). We measured it and are not
-# adopting it:
-#
-#   no cupy (xp=numpy)   track OK, 13 objects, 48s
-#   cupy + cucim         track OK, 13 objects, 67s / 46s
-#   cupy, no cucim       track FAILS, 0 objects
-#
-# No speedup — tracking is ~1 min per position against virtual-stain's ~46 min,
-# so it is not the bottleneck — identical results, and a new hard failure mode.
-# That last row is the trap: ultrack switches to cupy on cupy alone but needs
-# cucim for the matching skimage, and falls back to CPU skimage silently, so
-# `labels_to_contours` gets a cupy array and raises
-# `TypeError: Implicit conversion to a NumPy array is not allowed`. Installing
-# cupy WITHOUT cucim therefore breaks tracking outright (biahub#309), which is
-# what happened on a checkout carrying an out-of-band cupy.
-#
-# If this is revisited: add BOTH, never one alone, pin the CUDA major to match
-# the torch wheel (torch 2.13.0+cu130 -> cupy-cuda13x + cucim-cu13; ultrack
-# itself still targets CUDA 12), and benchmark on a full plate first.
-# Segmentation (cellpose) and virtual-stain (cytoland) use torch and are
-# unaffected either way.
-# 0.8 drops ultrack's pyarrow<20 cap (which pinned us to a pyarrow flagged by
-# GHSA-rgxp-2hwp-jwgg) and casts its computed chunk sizes to plain ints, so
-# zarr no longer needs capping below 3.3. See royerlab/ultrack#283 and #284.
+# Deliberately CPU-only. ultrack has an optional GPU path when cupy and cucim
+# are installed, but it offers no speedup in tracking in our use cases.
 track = ["ultrack>=0.8"]
 
 # PyQt6>=6.10 does not provide wheels

--- a/uv.lock
+++ b/uv.lock
@@ -357,7 +357,7 @@ requires-dist = [
     { name = "dask", extras = ["array"] },
     { name = "humanize" },
     { name = "imageio-ffmpeg" },
-    { name = "iohub", git = "https://github.com/czbiohub-sf/iohub?rev=f3c40a4abfda790cf915fd9ccb04ca98fbf15925" },
+    { name = "iohub", git = "https://github.com/czbiohub-sf/iohub?rev=719ba12c6932b23d84de86d87168777520c290d9" },
     { name = "largestinteriorrectangle" },
     { name = "llvmlite", specifier = ">=0.41.0" },
     { name = "markdown" },
@@ -1898,8 +1898,8 @@ wheels = [
 
 [[package]]
 name = "iohub"
-version = "0.3.11.dev10+f3c40a4"
-source = { git = "https://github.com/czbiohub-sf/iohub?rev=f3c40a4abfda790cf915fd9ccb04ca98fbf15925#f3c40a4abfda790cf915fd9ccb04ca98fbf15925" }
+version = "0.3.11.dev12+719ba12"
+source = { git = "https://github.com/czbiohub-sf/iohub?rev=719ba12c6932b23d84de86d87168777520c290d9#719ba12c6932b23d84de86d87168777520c290d9" }
 dependencies = [
     { name = "blosc2" },
     { name = "dask", extra = ["array"] },


### PR DESCRIPTION
Depends on [iohub#460](https://github.com/czbiohub-sf/iohub/pull/460). The pin
is that branch's tip — `origin/main` plus its one commit — so it is installable
now; **repoint it at the main commit once #460 merges** before this lands, or
merge this and follow up.

## Why

`shards_ratio` with a T entry above 1 aborted `concatenate` outright. The
`2026_08_11_A549_SEC61B_DENV` assemble step died with:

```
numpy._core._exceptions._ArrayMemoryError: Unable to allocate 651. TiB for an
array with shape (1048576, 86, 1664, 1193) and data type float32
```

which reads as "the shard buffer is too big" — so the run continued with
`shards_ratio` unset. That worked, but for the wrong reason. The geometry was
never the problem:

1. sharding along T makes `process_single_position` batch a whole shard's worth
   of timepoints into one write;
2. `apply_transform_to_tczyx_and_save` drops the timepoints whose input is all
   zeros or NaNs — `t=1` and `t=2` of that plate's channel 0, logged as
   `Skipping t=1, c=0 due to all zeros or nans` — and writes the survivors,
   `[0, 3, 4]`, in a single orthogonal write;
3. a gapped selection is not expressible as a slice and a sharded write needs
   one, so zarrs raises `DiscontiguousArrayError: [3 1]` — exactly
   `np.diff([0, 3, 4])` — and falls back to a zarr-python path that indexes the
   value buffer with coordinates from the *shard's* index space. Hence the
   nonsense shape and the absurd allocation.

Every batch that succeeded in that run was gap-free; `t=[0,1,2,3,4], c=0` is the
one combination missing from the `Finished writing` lines.

iohub#460 splits the write at every gap, so each run of consecutive timepoints
is sliceable. The no-gap case stays a single write and peak memory is unchanged.

## Changes

- `pyproject.toml` / `uv.lock` — iohub `f3c40a4` → `719ba12`. Between those two
  revs: this fix plus one Dependabot GHA bump; no other source change.
- `caveats.md` 7 — records the signature, because nothing in the error names
  sharding or the gap, and `DiscontiguousArrayError` (in `.command.err`, not
  `.command.out`) is the only line that does.

## Testing

- `tests/test_concatenate.py` — 14 passed against the new pin, including the
  `shards_ratio` parametrization.
- The exact failing selection, run against this venv (zarr 3.3.0, zarrs 0.2.3):
  writes cleanly, data round-trips bit-exact. Regression tests live in
  iohub#460.

Not included, and deliberately: nothing re-runs. The existing `5-assemble`
store was written without sharding and is fine; re-running it with a new shard
geometry would invalidate the cached `track` work. The run's local
`configs/concatenate.yml` still has `shards_ratio` commented out with a comment
blaming the shard buffer — worth correcting whenever that dataset is next
touched. The repo templates still carry `shards_ratio: [5, 1, 6, 7, 5]`
unchanged, which now works.