### PR TITLE
feat(nextflow): notify Slack at run start, each step, and run end

### DIFF
--- a/.claude/skills/reconstruct-with-nextflow/SKILL.md
+++ b/.claude/skills/reconstruct-with-nextflow/SKILL.md
@@ -211,9 +211,15 @@ missing. Before syncing, run the out-of-band-package check in `caveats.md` §11.
 
 Follow `references/monitoring.md`: poll `squeue -u $USER`, the tail of
 `<OUTPUT>/.nextflow.log`, and `<OUTPUT>/nextflow/slurm_output/<step>/*_<jobid>.out`
-at a few minutes' interval — these runs take hours to days. Notify via
-`templates/notify.sh` (Slack webhook, falls back to terminal) on completion, a
-terminating error, or a step retrying past a reasonable threshold.
+at a few minutes' interval — these runs take hours to days.
+
+**The pipeline notifies Slack itself** — run start, each step's completion, and
+run end (`nextflow/modules/notify.nf`), so do not re-send those. What is left for
+you is a terminating error you have diagnosed, a position on attempt 4 of 5, and
+the wrap-up; send those with `templates/notify.sh`. Notifications need
+`$BIAHUB_SLACK_WEBHOOK` and `$BIAHUB_SLACK_ID`; without them messages print
+instead of posting and nothing fails. For a `--max_positions 1` smoke test,
+launch with `env -u BIAHUB_SLACK_WEBHOOK` to keep the channel quiet.
 
 ## 10. Handle errors
 
@@ -240,6 +246,8 @@ Restarts are always `bash ./run_mantis_v2.sh` — the script passes `-resume`.
    `4-track` only as a discarded by-product.
 3. Report per-step task counts, failures, retries, and wall time from
    `<OUTPUT>/nextflow/trace.txt`; point at `report.html` and `timeline.html`.
-4. Send a final Slack message.
+4. Confirm the pipeline's automatic run-end message landed, then send a wrap-up
+   only for what the pipeline cannot know: the channel-rename result, the iohub
+   verification, and size on disk.
 5. Flag anything needing a human eye: positions that passed only after many
    retries, steps far slower than the reference run, unexpected channel counts.

--- a/.claude/skills/reconstruct-with-nextflow/SKILL.md
+++ b/.claude/skills/reconstruct-with-nextflow/SKILL.md
@@ -36,6 +36,26 @@ not on Bruno, stop and tell the user to connect; do not ssh on their behalf.
 The Nextflow head process is lightweight, so a login node is the right place
 for it (see `references/monitoring.md` for the compute-node exception).
 
+### 1a-bis. Slack notifications — optional, offer to set up
+
+```bash
+printenv BIAHUB_SLACK_WEBHOOK >/dev/null && echo "webhook set" || echo "webhook MISSING"
+printenv BIAHUB_SLACK_ID      >/dev/null && echo "slack id set" || echo "slack id MISSING"
+```
+
+**Both are optional and neither gates the run** — without them every message is
+printed instead of posted and nothing else changes. Never block a launch on this.
+
+If either is missing, say so once, explain that they only enable Slack
+notifications, and **offer to append them to `~/.bashrc`**. The webhook is a
+credential the user cannot self-serve: tell them to **ask a biahub developer
+(Ivan, Taylla)** for it. For the ID, point them at Slack profile → **⋮ / More** →
+**Copy member ID**, and give the format explicitly — `U0A2ZH9CS8S`, not
+`@Ivan Ivanov`, which never pings. Write to `~/.bashrc` only if they agree, append
+rather than rewrite, and tell them to `source ~/.bashrc` before launching, since
+the value is read from the launching shell. Full instructions:
+`references/monitoring.md` § Setting it up.
+
 ### 1b. The biahub checkout — run from `main`, up to date
 
 The pipeline, step CLIs, and config templates version together, so runs should
@@ -135,6 +155,9 @@ Do not run anything yet. Show the user:
    deliverable and `4-track` is a discarded by-product** (`caveats.md` §4).
 7. Known caveats that apply to this dataset.
 8. Rough wall-time and that `-resume` is on.
+9. Whether Slack notifications are on, and who will be @-mentioned at run end.
+   If `$BIAHUB_SLACK_WEBHOOK` or `$BIAHUB_SLACK_ID` is missing, note it here as a
+   caveat with the offer from §1a-bis — not as a blocker.
 
 Get explicit approval.
 

--- a/.claude/skills/reconstruct-with-nextflow/SKILL.md
+++ b/.claude/skills/reconstruct-with-nextflow/SKILL.md
@@ -227,8 +227,8 @@ Classify before acting — `references/recovery.md` has the decision table:
 
 - **Exit 130–145** (preemption, timeout, OOM): Nextflow retries up to 5 times.
   Do nothing unless retries are exhausted.
-- **Checksum / Lustre EIO / torn shard**: rerun with `-resume` first — the
-  pinned iohub replaces torn shards and resumes per unit. Only if it fails
+- **Checksum / Lustre EIO / torn shard**: rerun with `-resume` first — iohub
+  replaces torn shards and resumes per unit. Only if it fails
   identically again, write a repair proposal for the user or hand it to the
   **job-io-error-repair** agent. **Never delete zarr data from this skill.**
 - **Exit 1/2 with a Python traceback**: real bug or bad config. Fix, relaunch

--- a/.claude/skills/reconstruct-with-nextflow/references/caveats.md
+++ b/.claude/skills/reconstruct-with-nextflow/references/caveats.md
@@ -11,8 +11,9 @@ A549/cell-line acquisitions already are one (root `zarr.json` has
 `attributes.ome.plate`). Neuromast/zebrafish/dynatrack acquisitions are flat
 `bioformats2raw.layout: 3` stores with positions named `{R}Pos{C}` at the root.
 
-The pinned iohub enumerates flat stores, so `list_positions` alone works — but
-every `init_*` step globs `-i <store>/*/*/*`, track configs use `fov: "*/*/*"`,
+iohub enumerates flat stores (`open_ome_zarr(..., layout="bf2raw")`), so
+`list_positions` alone works — but every `init_*` step globs
+`-i <store>/*/*/*`, track configs use `fov: "*/*/*"`,
 and concatenate builds a plate, so a plate is still required. (New zebrafish
 acquisitions will eventually be written as plates; until then 0-convert stands.)
 
@@ -180,8 +181,11 @@ sharded — keep C at 1. Auto-sizing is
 [iohub#458](https://github.com/czbiohub-sf/iohub/issues/458); most of this
 section goes away when it lands.
 
-**A T ratio above 1 needs iohub ≥ [#460](https://github.com/czbiohub-sf/iohub/pull/460).**
-Before it, `concatenate` aborted with a message that points nowhere near the
+**A T ratio above 1 needs [iohub#460](https://github.com/czbiohub-sf/iohub/pull/460),
+which shipped in iohub 0.3.11** — the floor `pyproject.toml` already requires, so a
+synced checkout has it.
+
+Before that fix, `concatenate` aborted with a message that points nowhere near the
 cause — `numpy ... Unable to allocate 651. TiB for an array with shape
 (1048576, 86, 1664, 1193)`, whose first axis is not T, not a shard, not
 anything. It is **not** evidence that the shard buffer is too large, and
@@ -192,7 +196,15 @@ step's `.command.out`), and the surviving indices are left with a *gap* — whic
 a sharded write cannot express. Confirm it by grepping `.command.err` for
 `DiscontiguousArrayError`; the array it prints is the diff of the surviving
 indices (`[3 1]` for `[0, 3, 4]`, i.e. t=1 and t=2 were blank). If you see this
-signature, check the iohub pin rather than the shard geometry.
+signature, check the installed iohub version rather than the shard geometry:
+
+```bash
+<BIAHUB>/.venv/bin/python -c "import iohub; print(iohub.__version__)"   # need >= 0.3.11
+```
+
+There is no git pin to check: `pyproject.toml` requires `iohub>=0.3.11` and
+`uv.lock` resolves it from PyPI, so `uv sync` is enough. An out-of-band install
+is the only way to end up below the floor — see §11.
 
 ## 8. Preemption is expected, not an error
 

--- a/.claude/skills/reconstruct-with-nextflow/references/caveats.md
+++ b/.claude/skills/reconstruct-with-nextflow/references/caveats.md
@@ -214,7 +214,11 @@ files.
 
 Editing files in `$BIAHUB_PROJECT` changes Nextflow task hashes and
 invalidates `-resume`. Get the branch right before launching, then leave it
-alone. (Editing this skill is fine; it is not part of the pipeline.)
+alone. (Editing this skill is *mostly* fine — but the notification path now runs
+through `biahub/utils/notify.py` and `nextflow/modules/notify.nf`, which ARE part
+of the pipeline, so fixing a notification bug mid-run is a pipeline edit. The
+notify task hashes are the only ones affected, and re-running six sub-second local
+tasks costs nothing.)
 
 ## 11. `uv sync` before launching — but check for out-of-band packages first
 

--- a/.claude/skills/reconstruct-with-nextflow/references/monitoring.md
+++ b/.claude/skills/reconstruct-with-nextflow/references/monitoring.md
@@ -164,7 +164,7 @@ to Slack via `biahub nf notify` (`nextflow/modules/notify.nf`):
 
 | when | message | pings |
 |---|---|---|
-| run start | dataset, **who started it**, input, output, host, `max_positions` if capped | no |
+| run start | dataset, who launched it, pipeline, input, output, host, `max_positions` if capped | no |
 | each step completes | dataset, step name, `[n/6]`, position count, output path | no |
 | run end | succeeded / cached / failed / retries, wall time, assembled path | **yes** |
 | run end, failed | the error message, plus a truncated `errorReport` tail | **yes** |

--- a/.claude/skills/reconstruct-with-nextflow/references/monitoring.md
+++ b/.claude/skills/reconstruct-with-nextflow/references/monitoring.md
@@ -166,7 +166,7 @@ to Slack via `biahub nf notify` (`nextflow/modules/notify.nf`):
 |---|---|---|
 | run start | dataset, operator, pipeline, position count, the 6 step names, input, output, host, `max_positions` if capped | no |
 | each step completes | dataset, step name, `[n/6]`, output path | no |
-| run end | succeeded / cached / preempted / failed, wall time, assembled path | **yes** |
+| run end | succeeded / cached / restarted (with SLURM's cause) / failed, wall time, assembled path | **yes** |
 | run end, failed | the error message, plus a truncated `errorReport` tail | **yes** |
 
 Only the run-end message @-mentions the operator, so a ping always means "this
@@ -287,7 +287,10 @@ bash <SKILL>/templates/notify.sh --level error --ping \
 It takes `--level info|good|warn|error` and `--ping`, and delegates to
 `biahub nf notify`. Also use it for hand-rolled reruns that bypass Nextflow.
 
-Do not notify on individual preemptions; they are routine.
+Do not notify on individual preemptions; they are routine. The run-end message
+already reports them as `restarted: N`, with the cause from `sacct` — a restarted
+attempt was retried and is not a failure, and `sacct` is what distinguishes
+preemption from a wall-time kill, since both exit 143.
 
 Alongside Slack, surface the same information in the conversation, since the user
 may be watching the terminal instead.

--- a/.claude/skills/reconstruct-with-nextflow/references/monitoring.md
+++ b/.claude/skills/reconstruct-with-nextflow/references/monitoring.md
@@ -166,7 +166,7 @@ to Slack via `biahub nf notify` (`nextflow/modules/notify.nf`):
 |---|---|---|
 | run start | dataset, operator, pipeline, position count, the 6 step names, input, output, host, `max_positions` if capped | no |
 | each step completes | dataset, step name, `[n/6]`, output path | no |
-| run end | succeeded / cached / failed / retries, wall time, assembled path | **yes** |
+| run end | succeeded / cached / preempted / failed, wall time, assembled path | **yes** |
 | run end, failed | the error message, plus a truncated `errorReport` tail | **yes** |
 
 Only the run-end message @-mentions the operator, so a ping always means "this

--- a/.claude/skills/reconstruct-with-nextflow/references/monitoring.md
+++ b/.claude/skills/reconstruct-with-nextflow/references/monitoring.md
@@ -170,7 +170,13 @@ to Slack via `biahub nf notify` (`nextflow/modules/notify.nf`):
 | run end, failed | the error message, plus a truncated `errorReport` tail | **yes** |
 
 Only the run-end message @-mentions the operator, so a ping always means "this
-needs you". Step messages are informational and stay quiet.
+needs you". Step messages are informational and stay quiet. The mention sits at
+the END of the title, so every message opens with its emoji and dataset whether or
+not it pings; position within `text` does not affect delivery.
+
+Each kind of message has its own emoji, so the one that needs you is not six
+lookalikes deep in a channel: :rocket: to start, :white_check_mark: per step,
+:checkered_flag: complete, :x: failed, :warning: aborted.
 
 The position count and the step list are reported once, at run start — they are
 the same for every step, so repeating them per message would add nothing. Run

--- a/.claude/skills/reconstruct-with-nextflow/references/monitoring.md
+++ b/.claude/skills/reconstruct-with-nextflow/references/monitoring.md
@@ -80,16 +80,32 @@ tail -n 30 <OUTPUT>/.nextflow.log                                  # head-proces
 column -t <OUTPUT>/nextflow/trace.txt | tail -20                   # per-task record
 ```
 
+**`ProcessFailedException` in the log is not a failure signal.** It is written
+for every *retried* task, immediately before the matching
+`NOTE: ... -- Execution is retried (N)` line — one healthy run's log holds 33 of
+them. Do not report a run as broken on the strength of that string. The terminal
+marker is `Session aborted -- Cause: ...` (which also covers a Ctrl-C).
+
 `trace.txt` is the authoritative per-task record: process name, tag (the
-position), status, exit code, realized time and RSS, and attempt number. Count
-failures and retries from there, not from the console.
+position), status, exit code, realized time and RSS, and — as of the `attempt`
+field added to `trace.fields` in `nextflow.config` — the attempt number, as
+column **15**. Count failures and retries from there, not from the console.
+
+The 14 default columns keep their original positions, so `$4` is still the name,
+`$5` the status and `$6` the exit code. Retried tasks also appear as repeated
+`name` rows (a `FAILED` row and then a `COMPLETED` one), which is how retries had
+to be counted before the column existed.
 
 Per-step task logs (remember `.out` holds the output, `.err` is empty — see
 `caveats.md` §9):
 
+The directory is named for the STEP, not the process: `flat_field`, `deskew`,
+`reconstruct`, `virtual_stain`, `assemble`, `track` (see `slurm_log_dir()` in
+`nextflow/modules/common.nf`). There is no `run_flat_field/` directory.
+
 ```bash
 ls -t <OUTPUT>/nextflow/slurm_output/*/ | head
-tail -n 40 <OUTPUT>/nextflow/slurm_output/run_flat_field/*_<jobid>.out
+tail -n 40 <OUTPUT>/nextflow/slurm_output/flat_field/*_<jobid>.out
 ```
 
 Position count per step. The plate nests `<store>.zarr/<row>/<col>/<fov>`, so glob
@@ -113,9 +129,14 @@ Two traps, both hit for real:
   `trace.txt` is the only authoritative source for completion:
 
 ```bash
-awk -F'\t' 'NR>1{split($4,a,":"); print a[length(a)], $5}' <OUTPUT>/nextflow/trace.txt \
-  | sort | uniq -c | sort -k2
+awk -F'\t' 'NR>1 && $4 !~ /notify_step/ {split($4,a,":"); print a[length(a)], $5}' \
+  <OUTPUT>/nextflow/trace.txt | sort | uniq -c | sort -k2
 ```
+
+The `notify_step` filter matters: the pipeline's Slack notifications are ordinary
+tasks, so six of them appear in `trace.txt` and in `report.html`/`timeline.html`
+alongside the real work. They are local, sub-second, and not part of any step's
+position count.
 
 ## Rough expectations
 
@@ -138,31 +159,70 @@ outside the reference run's time for a comparable dataset, say so.
 
 ## Notifications
 
-Use `templates/notify.sh`. It posts to the Slack webhook in
-`$BIAHUB_SLACK_WEBHOOK` and, when that is unset, prints to the terminal so
-nothing is lost.
+**The pipeline sends these itself — do not duplicate them.** `mantis-v2.nf` posts
+to Slack via `biahub nf notify` (`nextflow/modules/notify.nf`):
+
+| when | message | pings |
+|---|---|---|
+| run start | dataset, input, output, host, `max_positions` if capped | no |
+| each step completes | dataset, step name, `[n/6]`, position count, output path | no |
+| run end | succeeded / cached / failed / retries, wall time, assembled path | **yes** |
+| run end, failed | the error message, plus a truncated `errorReport` tail | **yes** |
+
+Only the run-end message @-mentions the operator, so a ping always means "this
+needs you". Step messages are informational and stay quiet.
+
+Two environment variables, both read from the launching shell and inherited by
+every task. Neither is a pipeline parameter:
 
 ```bash
-export BIAHUB_SLACK_WEBHOOK="https://hooks.slack.com/services/..."   # user sets this
-bash <SKILL>/templates/notify.sh "✅ <DATASET>: mantis-v2 complete — 5-assemble written"
+export BIAHUB_SLACK_WEBHOOK="https://hooks.slack.com/services/..."   # a CREDENTIAL
+export BIAHUB_SLACK_ID="U024BE7LH"    # Slack profile -> Copy member ID
 ```
 
-If the variable is unset, mention it once in the plan so the user can export it
-before launch; do not block on it.
+Put both in `~/.bashrc`, never in the repo, a config file, or a command line. A
+**display name** (`@ivan`) never pings via the API and is rejected with a warning;
+it must be the member ID.
 
-Send a message on:
+If either is unset, say so once in the plan so the user can export it before
+launch, but **do not block on it**: without a webhook every message still prints
+and every exit status is still 0. Note the asymmetry when reporting that — run
+start and run end print to the console, but step messages run as tasks, so their
+text goes only to `nextflow/slurm_output/<step>/*.out`. The pipeline warns about
+this at launch.
 
-- **Completion** — with the summary from the wrap-up step.
-- **A terminating error** — with the step, the position, and the first lines of
-  the traceback. Do not wait to finish diagnosing.
-- **Retries past a threshold** — e.g. a step whose retry count exceeds ~20% of
-  its tasks, or any position on attempt 4 of 5. This is the early warning for a
-  torn shard.
+If a notification itself fails, the reason is in
+`<OUTPUT>/nextflow/.notify/notify.log` — the run-end message is sent during
+session teardown, after Nextflow's console renderer is gone, so that file is the
+only durable record. Silence there means every message was delivered.
+
+### What is left for you to send
+
+`templates/notify.sh` is now only for messages the pipeline cannot know about:
+
+- **A terminating error you have diagnosed** — the step, the position, and the
+  first lines of the traceback. The automatic run-end message reports *that* the
+  run failed; you add *why*. Send it before you finish investigating.
+- **A step retrying past a reasonable threshold** — any position on attempt 4 of
+  `maxRetries = 5`, now readable straight from `trace.txt`'s `attempt` column.
+  This is the early warning for a torn shard. Do **not** use a retry-rate
+  percentage: retries measure preemption pressure on the `preempted` partition,
+  not dataset health, and a busy day crosses any such threshold routinely.
+- **The wrap-up** — channel rename result, iohub verification, shape/channels and
+  size on disk. The pipeline knows none of this.
+
+```bash
+bash <SKILL>/templates/notify.sh --level error --ping \
+  "❌ <DATASET>: run_deskew failed on C/4/001001" "$(tail -20 <OUTPUT>/nextflow/slurm_output/deskew/*_<jobid>.out)"
+```
+
+It takes `--level info|good|warn|error` and `--ping`, and delegates to
+`biahub nf notify`. Also use it for hand-rolled reruns that bypass Nextflow.
 
 Do not notify on individual preemptions; they are routine.
 
-Alongside Slack, surface the same information in the conversation, since the
-user may be watching the terminal instead.
+Alongside Slack, surface the same information in the conversation, since the user
+may be watching the terminal instead.
 
 ## Final summary
 

--- a/.claude/skills/reconstruct-with-nextflow/references/monitoring.md
+++ b/.claude/skills/reconstruct-with-nextflow/references/monitoring.md
@@ -178,17 +178,73 @@ start is therefore sent once `list_positions` has produced the count (about 40s
 in), not at graph-construction time; a config error that kills `list_positions`
 itself yields only the failure message.
 
-Two environment variables, both read from the launching shell and inherited by
-every task. Neither is a pipeline parameter:
+### Setting it up
+
+**Both variables are optional.** They only decide whether messages reach Slack.
+The pipeline runs identically without them: every message is printed instead of
+posted, every exit status is still 0, and no step behaves differently. Never
+block a launch on them, and never treat a missing one as an error.
+
+Two environment variables, read from the launching shell and inherited by every
+task. Neither is a pipeline parameter:
 
 ```bash
-export BIAHUB_SLACK_WEBHOOK="https://hooks.slack.com/services/..."   # a CREDENTIAL
-export BIAHUB_SLACK_ID="U024BE7LH"    # Slack profile -> Copy member ID
+# ~/.bashrc
+export BIAHUB_SLACK_WEBHOOK="https://hooks.slack.com/services/T.../B.../..."
+export BIAHUB_SLACK_ID="U0A2ZH9CS8S"
 ```
 
-Put both in `~/.bashrc`, never in the repo, a config file, or a command line. A
-**display name** (`@ivan`) never pings via the API and is rejected with a warning;
-it must be the member ID.
+`BIAHUB_SLACK_WEBHOOK` — the incoming-webhook URL for the channel the run should
+report to. **This is a credential**: it lets anyone holding it post to that
+channel, so it belongs in `~/.bashrc` only, never in the repo, a config file, a
+command line, or a commit. Users do not create it themselves — **ask a biahub
+developer (Ivan, Taylla) for the webhook URL.**
+
+`BIAHUB_SLACK_ID` — the member ID of the person to @-mention when a run finishes
+or fails. To find it: open Slack, click your avatar (or your name in a message)
+→ **View full profile** → the **⋮ / More** button → **Copy member ID**. In the
+Slack web app it is also the last path segment of your profile URL
+(`.../team/U0A2ZH9CS8S`).
+
+The format matters, and getting it wrong fails silently:
+
+| | |
+|---|---|
+| ✅ `U0A2ZH9CS8S` | a member ID — 9+ characters, starts with `U` (or `W`) |
+| ❌ `@Ivan Ivanov` | a display name; never pings via the API |
+| ❌ `ivan.ivanov` | a username or email local part |
+| ❌ `<@U0A2ZH9CS8S>` | already-wrapped mention — accepted, but write the bare ID |
+
+A display name posts as literal text and notifies nobody, which is why the
+notifier validates the ID against `^[UW][A-Z0-9]{6,}$` and warns rather than
+posting something that silently reaches no one.
+
+**If either variable is unset, offer to add it to the user's `~/.bashrc`** — say
+what each one does, that both are optional, and where to get the webhook. Only
+write the file if the user agrees, append rather than rewrite, and have them
+`source ~/.bashrc` (or open a new shell) before launching, since the pipeline
+reads the value from the launching shell:
+
+```bash
+cat >> ~/.bashrc <<'EOF'
+
+# biahub Nextflow pipeline -> Slack notifications (both optional)
+export BIAHUB_SLACK_WEBHOOK="https://hooks.slack.com/services/..."   # ask Ivan or Taylla
+export BIAHUB_SLACK_ID="U0A2ZH9CS8S"                                # Slack profile -> Copy member ID
+EOF
+```
+
+Check what is already set before offering, so an existing value is never
+clobbered:
+
+```bash
+printenv BIAHUB_SLACK_WEBHOOK >/dev/null && echo "webhook set" || echo "webhook MISSING"
+printenv BIAHUB_SLACK_ID      >/dev/null && echo "slack id set" || echo "slack id MISSING"
+grep -c 'BIAHUB_SLACK' ~/.bashrc
+```
+
+`run_mantis_v2.sh` warns about a missing variable at launch and records the Slack
+ID in `nextflow/provenance.txt`, so which was in effect is part of the run record.
 
 The *name* in the run-start message is separate from the mention: it comes from
 the account database on the cluster (the GECOS field, via `--operator`), not from

--- a/.claude/skills/reconstruct-with-nextflow/references/monitoring.md
+++ b/.claude/skills/reconstruct-with-nextflow/references/monitoring.md
@@ -164,7 +164,7 @@ to Slack via `biahub nf notify` (`nextflow/modules/notify.nf`):
 
 | when | message | pings |
 |---|---|---|
-| run start | dataset, input, output, host, `max_positions` if capped | no |
+| run start | dataset, **who started it**, input, output, host, `max_positions` if capped | no |
 | each step completes | dataset, step name, `[n/6]`, position count, output path | no |
 | run end | succeeded / cached / failed / retries, wall time, assembled path | **yes** |
 | run end, failed | the error message, plus a truncated `errorReport` tail | **yes** |
@@ -183,6 +183,12 @@ export BIAHUB_SLACK_ID="U024BE7LH"    # Slack profile -> Copy member ID
 Put both in `~/.bashrc`, never in the repo, a config file, or a command line. A
 **display name** (`@ivan`) never pings via the API and is rejected with a warning;
 it must be the member ID.
+
+The *name* in the run-start message is separate from the mention: it comes from
+the account database on the cluster (the GECOS field, via `--operator`), not from
+Slack. Turning a member ID into a display name needs a `users.info` call and a bot
+token, which an incoming webhook cannot make — and an `<@U…>` mention would ping,
+while run start is deliberately silent.
 
 If either is unset, say so once in the plan so the user can export it before
 launch, but **do not block on it**: without a webhook every message still prints

--- a/.claude/skills/reconstruct-with-nextflow/references/monitoring.md
+++ b/.claude/skills/reconstruct-with-nextflow/references/monitoring.md
@@ -164,13 +164,19 @@ to Slack via `biahub nf notify` (`nextflow/modules/notify.nf`):
 
 | when | message | pings |
 |---|---|---|
-| run start | dataset, who launched it, pipeline, input, output, host, `max_positions` if capped | no |
-| each step completes | dataset, step name, `[n/6]`, position count, output path | no |
+| run start | dataset, operator, pipeline, position count, the 6 step names, input, output, host, `max_positions` if capped | no |
+| each step completes | dataset, step name, `[n/6]`, output path | no |
 | run end | succeeded / cached / failed / retries, wall time, assembled path | **yes** |
 | run end, failed | the error message, plus a truncated `errorReport` tail | **yes** |
 
 Only the run-end message @-mentions the operator, so a ping always means "this
 needs you". Step messages are informational and stay quiet.
+
+The position count and the step list are reported once, at run start — they are
+the same for every step, so repeating them per message would add nothing. Run
+start is therefore sent once `list_positions` has produced the count (about 40s
+in), not at graph-construction time; a config error that kills `list_positions`
+itself yields only the failure message.
 
 Two environment variables, both read from the launching shell and inherited by
 every task. Neither is a pipeline parameter:

--- a/.claude/skills/reconstruct-with-nextflow/references/recovery.md
+++ b/.claude/skills/reconstruct-with-nextflow/references/recovery.md
@@ -56,8 +56,8 @@ plain retries fail identically, forever.
 ### Step 1 — rerun with `-resume` first
 
 **This is the expected fix, and usually the only one needed.**
-[iohub#455](https://github.com/czbiohub-sf/iohub/pull/455) (in the pinned
-iohub) replaces a torn shard instead of reading it back and records per-unit
+[iohub#455](https://github.com/czbiohub-sf/iohub/pull/455) (in iohub ≥ 0.3.11)
+replaces a torn shard instead of reading it back and records per-unit
 progress in a `.iohub-progress/` *sibling* of the output store, so a retry
 recomputes only the unfinished units.
 

--- a/.claude/skills/reconstruct-with-nextflow/templates/notify.sh
+++ b/.claude/skills/reconstruct-with-nextflow/templates/notify.sh
@@ -1,27 +1,88 @@
 #!/usr/bin/env bash
-# Post a pipeline notification to Slack, falling back to the terminal.
+# Post a notification to Slack, falling back to the terminal.
 #
-#   notify.sh "✅ 2026_07_14_A549_MAP4_ZIKV: mantis-v2 complete"
-#   notify.sh "❌ run_deskew failed on C/4/001001" "$(tail -20 slurm_output/.../x.out)"
+#   notify.sh "✅ 2026_07_14_A549_MAP4_ZIKV: assemble verified"
+#   notify.sh "❌ run_deskew failed on C/4/001001" "$(tail -20 slurm_output/deskew/*.out)"
+#   notify.sh --level error --ping "❌ 2026_07_14: torn shard, needs a human"
 #
-# Set BIAHUB_SLACK_WEBHOOK to an incoming-webhook URL to enable Slack:
-#   export BIAHUB_SLACK_WEBHOOK="https://hooks.slack.com/services/T.../B.../..."
-# Put it in ~/.bashrc (not in the repo) — the URL is a credential.
+# THE PIPELINE DOES NOT USE THIS SCRIPT. mantis-v2.nf posts run start, each
+# step's completion, and run end itself (nextflow/modules/notify.nf). This is for
+# the two cases that have no Nextflow context:
 #
-# Without the variable set this is not an error: the message is printed and the
-# exit status is still 0, so a monitoring loop is never broken by a missing
-# webhook.
+#   1. messages Claude sends while monitoring — a diagnosis mid-run, the wrap-up
+#      summary after verifying the assembled plate;
+#   2. hand-rolled reruns that bypass Nextflow (a bare sbatch of one step).
+#
+# It is a thin wrapper over `biahub nf notify`, which owns the payload shaping,
+# truncation, mention handling, and HTTP retries. The direct-curl branch below is
+# only for a broken venv — which is exactly when you most need to send an alert.
+#
+# Two environment variables, both belonging in ~/.bashrc and never in the repo:
+#   BIAHUB_SLACK_WEBHOOK   incoming-webhook URL — a CREDENTIAL
+#   BIAHUB_SLACK_ID        your Slack member ID, for --ping
+#
+# Without a webhook this is still not an error: the message is printed and the
+# exit status is 0, so a monitoring loop is never broken by a missing webhook.
 
 set -uo pipefail
+
+LEVEL="info"
+PING=""
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --level) LEVEL="$2"; shift 2 ;;
+        --ping)  PING="--ping"; shift ;;
+        --) shift; break ;;
+        -*) echo "notify.sh: unknown option $1" >&2; exit 2 ;;
+        *) break ;;
+    esac
+done
 
 TITLE="${1:-}"
 DETAIL="${2:-}"
 
-[[ -n "${TITLE}" ]] || { echo "usage: notify.sh <title> [detail]" >&2; exit 2; }
+[[ -n "${TITLE}" ]] || {
+    echo "usage: notify.sh [--level info|good|warn|error] [--ping] <title> [detail]" >&2
+    exit 2
+}
+
+# Prefer the CLI. BIAHUB_PROJECT lets a non-activated shell still find it.
+BIAHUB="$(command -v biahub || true)"
+if [[ -z "${BIAHUB}" && -n "${BIAHUB_PROJECT:-}" && -x "${BIAHUB_PROJECT}/.venv/bin/biahub" ]]; then
+    BIAHUB="${BIAHUB_PROJECT}/.venv/bin/biahub"
+fi
+
+if [[ -n "${BIAHUB}" ]]; then
+    # Pass the detail through a file: a traceback contains quotes and backticks,
+    # and argv has a length limit a long log tail can exceed.
+    DETAIL_ARGS=()
+    if [[ -n "${DETAIL}" ]]; then
+        DETAIL_FILE="$(mktemp)"
+        trap 'rm -f "${DETAIL_FILE}"' EXIT
+        printf '%s' "${DETAIL}" > "${DETAIL_FILE}"
+        DETAIL_ARGS=(--detail-file "${DETAIL_FILE}")
+    fi
+    "${BIAHUB}" nf notify --level "${LEVEL}" ${PING} --title "${TITLE}" "${DETAIL_ARGS[@]}"
+    exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# Fallback: biahub is unavailable (venv broken or not synced). Keep this minimal
+# and dependency-free — no severity colors, no mention validation, no retries.
+# ---------------------------------------------------------------------------
+echo "[notify] biahub not found — using the minimal curl fallback" >&2
 
 STAMP="$(date '+%Y-%m-%d %H:%M:%S %Z')"
 TEXT="${TITLE}"
-[[ -n "${DETAIL}" ]] && TEXT="${TEXT}"$'\n'"\`\`\`${DETAIL}\`\`\`"
+if [[ -n "${PING}" && -n "${BIAHUB_SLACK_ID:-}" ]]; then
+    TEXT="<@${BIAHUB_SLACK_ID}> ${TEXT}"
+fi
+if [[ -n "${DETAIL}" ]]; then
+    # Keep the tail: a traceback ends with the exception. Cap it so a huge log
+    # cannot produce a payload Slack rejects.
+    TRIMMED="$(printf '%s' "${DETAIL}" | tail -c 2500 | tr -d '\000')"
+    TEXT="${TEXT}"$'\n'"\`\`\`${TRIMMED}\`\`\`"
+fi
 TEXT="${TEXT}"$'\n'"_${STAMP} · $(hostname)_"
 
 if [[ -z "${BIAHUB_SLACK_WEBHOOK:-}" ]]; then
@@ -32,16 +93,21 @@ fi
 
 PAYLOAD=$(TEXT="${TEXT}" python3 -c 'import json,os; print(json.dumps({"text": os.environ["TEXT"]}))')
 
-HTTP=$(curl -sS -o /tmp/notify_resp.$$ -w '%{http_code}' \
+# mktemp, not /tmp/notify_resp.$$: $TMPDIR is a shared multi-user /tmp on the
+# login nodes, where a predictable name is a collision and symlink hazard.
+RESP="$(mktemp)"
+ERRF="$(mktemp)"
+trap 'rm -f "${RESP}" "${ERRF}" "${DETAIL_FILE:-}"' EXIT
+
+HTTP=$(curl -sS -o "${RESP}" -w '%{http_code}' \
     -X POST -H 'Content-Type: application/json' \
     --data "${PAYLOAD}" --max-time 15 \
-    "${BIAHUB_SLACK_WEBHOOK}" 2>/tmp/notify_err.$$) || true
+    "${BIAHUB_SLACK_WEBHOOK}" 2>"${ERRF}") || true
 
 if [[ "${HTTP}" != "200" ]]; then
-    echo "[notify] Slack post failed (HTTP ${HTTP:-none}): $(cat /tmp/notify_resp.$$ 2>/dev/null)" >&2
-    cat /tmp/notify_err.$$ >&2 2>/dev/null
+    echo "[notify] Slack post failed (HTTP ${HTTP:-none}): $(cat "${RESP}" 2>/dev/null)" >&2
+    cat "${ERRF}" >&2 2>/dev/null
     echo "${TEXT}"
 fi
 
-rm -f /tmp/notify_resp.$$ /tmp/notify_err.$$
 exit 0

--- a/.claude/skills/reconstruct-with-nextflow/templates/run_mantis_v2.sh
+++ b/.claude/skills/reconstruct-with-nextflow/templates/run_mantis_v2.sh
@@ -99,6 +99,7 @@ mkdir -p "${OUTPUT_DIR}/nextflow"
     echo "branch    ${BIAHUB_BRANCH}"
     echo "commit    ${BIAHUB_COMMIT}"
     echo "host      $(hostname)"
+    echo "slack_id  ${BIAHUB_SLACK_ID:-<unset>}"
     echo "nextflow  $(nextflow -version 2>&1 | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)"
     if [[ -n "${BIAHUB_DIRTY}" ]]; then
         echo "dirty     YES — not reproducible from the commit above:"
@@ -117,6 +118,20 @@ if [[ -n "${BIAHUB_DIRTY}" ]]; then
 fi
 if [[ "${BIAHUB_BRANCH}" != "main" ]]; then
     echo "  WARNING: not on main" >&2
+fi
+
+# Slack notifications. The pipeline posts run start, each step's completion, and
+# run end via `biahub nf notify`; both variables are read from this shell's
+# environment (sbatch exports it to every task), so nothing needs passing on the
+# nextflow command line. Missing either one is not an error — messages fall back
+# to printing — so warn and continue.
+#   export BIAHUB_SLACK_WEBHOOK="https://hooks.slack.com/services/..."   # credential
+#   export BIAHUB_SLACK_ID="U024BE7LH"    # Slack profile -> Copy member ID
+# Put both in ~/.bashrc, never in the repo or in a config.
+if [[ -z "${BIAHUB_SLACK_WEBHOOK:-}" ]]; then
+    echo "  WARNING: BIAHUB_SLACK_WEBHOOK unset — no Slack notifications" >&2
+elif [[ -z "${BIAHUB_SLACK_ID:-}" ]]; then
+    echo "  WARNING: BIAHUB_SLACK_ID unset — run-end message will not @-mention you" >&2
 fi
 
 # Nextflow 26.04 switches to "agent mode" — one static `[PROCESS …]` line per task

--- a/.gitignore
+++ b/.gitignore
@@ -129,3 +129,8 @@ ENV/
 # and a killed process leaves the directory behind. Root-anchored so it cannot
 # match anything intentional deeper in the tree.
 /tmp*/
+
+# Nextflow leaves these wherever it is launched from, including the repo root
+# when running `nextflow config` or a compile check.
+.nextflow/
+.nextflow.log*

--- a/biahub/cli/nf.py
+++ b/biahub/cli/nf.py
@@ -1,6 +1,11 @@
+import pathlib
+import tempfile
+
 import click
 
 from iohub.ngff import open_ome_zarr
+
+from biahub.utils import notify as notify_utils
 
 
 @click.group("nf")
@@ -19,3 +24,101 @@ def list_positions(input_zarr: str):
     with open_ome_zarr(input_zarr, mode="r") as plate:
         for name, _ in plate.positions():
             click.echo(name)
+
+
+@nf_cli.command("notify")
+@click.option("--title", required=True, help="One-line summary; should name the dataset.")
+@click.option("--detail", default="", help="Supporting text, shown in a code fence.")
+@click.option(
+    "--detail-file",
+    type=click.Path(exists=True, dir_okay=False, path_type=pathlib.Path),
+    help="Read the detail from a file. Use this for anything containing quotes, "
+    "backticks, or newlines (e.g. a Nextflow error report) instead of --detail.",
+)
+@click.option(
+    "--level",
+    type=click.Choice(["info", "good", "warn", "error"]),
+    default="info",
+    show_default=True,
+    help="Severity, which selects the attachment's color bar.",
+)
+@click.option(
+    "--ping/--no-ping",
+    default=False,
+    help="@-mention $BIAHUB_SLACK_ID. Reserve for messages needing action.",
+)
+@click.option("--slack-id", default=None, help="Member ID override, for testing.")
+@click.option("--key", default=None, help="Rate-limit key, e.g. 'run-start'.")
+@click.option(
+    "--min-interval",
+    type=float,
+    default=0.0,
+    help="Skip if --key was already sent this recently, in seconds.",
+)
+@click.option(
+    "--state-dir",
+    type=click.Path(file_okay=False, path_type=pathlib.Path),
+    default=None,
+    help="Where --key markers live. Defaults to the temp dir.",
+)
+@click.option(
+    "--max-detail",
+    type=int,
+    default=notify_utils.MAX_DETAIL_CHARS,
+    show_default=True,
+    help="Character budget for the detail block; the tail is kept.",
+)
+@click.option("--dry-run", is_flag=True, help="Render the payload without posting.")
+def notify(
+    title: str,
+    detail: str,
+    detail_file: pathlib.Path | None,
+    level: str,
+    ping: bool,
+    slack_id: str | None,
+    key: str | None,
+    min_interval: float,
+    state_dir: pathlib.Path | None,
+    max_detail: int,
+    dry_run: bool,
+):
+    r"""Post a pipeline notification to Slack, falling back to the terminal.
+
+    Reads the webhook from ``$BIAHUB_SLACK_WEBHOOK`` and the operator's member ID
+    from ``$BIAHUB_SLACK_ID``. With no webhook set, the message is printed rather
+    than posted.
+
+    \b
+    This command ALWAYS exits 0. A failed notification must never fail a
+    reconstruction that has been running for days, so delivery problems are
+    reported on stdout and swallowed.
+
+    \b
+    Examples:
+      biahub nf notify --level good --title ":white_check_mark: 2026_07_14 — deskewed"
+      biahub nf notify --level error --ping --title ":x: 2026_07_14 — failed" --detail-file r
+    """
+    if detail_file is not None:
+        detail = detail_file.read_text(errors="replace")
+
+    resolved_state_dir = str(state_dir) if state_dir is not None else tempfile.gettempdir()
+
+    if key and min_interval > 0:
+        if not notify_utils.should_send(resolved_state_dir, key, min_interval):
+            click.echo(f"[notify] {key} sent less than {min_interval:g}s ago — skipping")
+            return
+
+    ok, status = notify_utils.send(
+        title=title,
+        detail=detail,
+        level=level,
+        ping=ping,
+        slack_id=slack_id,
+        max_detail=max_detail,
+        dry_run=dry_run,
+    )
+
+    if ok and key:
+        notify_utils.record_sent(resolved_state_dir, key)
+    if not ok and not dry_run:
+        click.echo(f"[notify] not delivered: {status}")

--- a/biahub/cli/nf.py
+++ b/biahub/cli/nf.py
@@ -118,8 +118,8 @@ def notify(
     if operator:
         # First line of the detail: who to ask about this run. Comes from the
         # account database rather than Slack — see notify_utils.operator_label.
-        started_by = f"launched by: {notify_utils.operator_label()}"
-        detail = f"{started_by}\n{detail}" if detail else started_by
+        who = f"operator: {notify_utils.operator_label()}"
+        detail = f"{who}\n{detail}" if detail else who
 
     resolved_state_dir = str(state_dir) if state_dir is not None else tempfile.gettempdir()
 

--- a/biahub/cli/nf.py
+++ b/biahub/cli/nf.py
@@ -68,6 +68,11 @@ def list_positions(input_zarr: str):
     show_default=True,
     help="Character budget for the detail block; the tail is kept.",
 )
+@click.option(
+    "--operator",
+    is_flag=True,
+    help="Prepend who launched the run, from the account database (not Slack).",
+)
 @click.option("--dry-run", is_flag=True, help="Render the payload without posting.")
 def notify(
     title: str,
@@ -80,6 +85,7 @@ def notify(
     min_interval: float,
     state_dir: pathlib.Path | None,
     max_detail: int,
+    operator: bool,
     dry_run: bool,
 ):
     r"""Post a pipeline notification to Slack, falling back to the terminal.
@@ -100,6 +106,12 @@ def notify(
     """
     if detail_file is not None:
         detail = detail_file.read_text(errors="replace")
+
+    if operator:
+        # First line of the detail: who to ask about this run. Comes from the
+        # account database rather than Slack — see notify_utils.operator_label.
+        started_by = f"started by: {notify_utils.operator_label()}"
+        detail = f"{started_by}\n{detail}" if detail else started_by
 
     resolved_state_dir = str(state_dir) if state_dir is not None else tempfile.gettempdir()
 

--- a/biahub/cli/nf.py
+++ b/biahub/cli/nf.py
@@ -110,7 +110,7 @@ def notify(
     if operator:
         # First line of the detail: who to ask about this run. Comes from the
         # account database rather than Slack — see notify_utils.operator_label.
-        started_by = f"started by: {notify_utils.operator_label()}"
+        started_by = f"launched by: {notify_utils.operator_label()}"
         detail = f"{started_by}\n{detail}" if detail else started_by
 
     resolved_state_dir = str(state_dir) if state_dir is not None else tempfile.gettempdir()

--- a/biahub/cli/nf.py
+++ b/biahub/cli/nf.py
@@ -73,6 +73,13 @@ def list_positions(input_zarr: str):
     is_flag=True,
     help="Prepend who launched the run, from the account database (not Slack).",
 )
+@click.option(
+    "--log-file",
+    type=click.Path(dir_okay=False, path_type=pathlib.Path),
+    default=None,
+    help="Append delivery problems here. Use this when the caller cannot capture "
+    "stdout, e.g. a Nextflow onComplete handler running during JVM shutdown.",
+)
 @click.option("--dry-run", is_flag=True, help="Render the payload without posting.")
 def notify(
     title: str,
@@ -86,6 +93,7 @@ def notify(
     state_dir: pathlib.Path | None,
     max_detail: int,
     operator: bool,
+    log_file: pathlib.Path | None,
     dry_run: bool,
 ):
     r"""Post a pipeline notification to Slack, falling back to the terminal.
@@ -128,6 +136,7 @@ def notify(
         slack_id=slack_id,
         max_detail=max_detail,
         dry_run=dry_run,
+        log_file=str(log_file) if log_file is not None else None,
     )
 
     if ok and key:

--- a/biahub/utils/notify.py
+++ b/biahub/utils/notify.py
@@ -370,6 +370,23 @@ def record_sent(state_dir: str, key: str) -> None:
         pass
 
 
+def append_log(log_file: str, message: str) -> None:
+    """Append a delivery problem to a log file, best-effort.
+
+    The pipeline's run-end message is sent from ``workflow.onComplete``, i.e.
+    during JVM shutdown, where the console is already torn down and the caller
+    may not survive long enough to record anything. So the notifier writes its
+    own record rather than relying on the caller to capture stdout.
+    """
+    try:
+        os.makedirs(os.path.dirname(log_file) or ".", exist_ok=True)
+        stamp = time.strftime("%Y-%m-%d %H:%M:%S")
+        with open(log_file, "a") as handle:
+            handle.write(f"{stamp} {message}\n")
+    except OSError:
+        pass
+
+
 def send(
     title: str,
     detail: str = "",
@@ -378,6 +395,7 @@ def send(
     slack_id: str | None = None,
     max_detail: int = MAX_DETAIL_CHARS,
     dry_run: bool = False,
+    log_file: str | None = None,
 ) -> tuple[bool, str]:
     """Build and post one notification.
 
@@ -399,6 +417,10 @@ def send(
         Character budget for the detail block.
     dry_run : bool, optional
         Render and print without posting.
+    log_file : str or None, optional
+        Append a line here if the message could not be delivered. Written by
+        this process, not the caller, because the caller may be a JVM in
+        shutdown that cannot capture our output.
 
     Returns
     -------
@@ -424,15 +446,21 @@ def send(
         print(json.dumps(payload, indent=2))
         return False, "dry run"
 
+    rendered = render_for_terminal(payload)
+
     webhook = os.environ.get(WEBHOOK_ENV, "")
     if not webhook:
         print(f"[notify] {WEBHOOK_ENV} unset — printing instead of posting")
-        print(render_for_terminal(payload))
+        print(rendered)
+        if log_file:
+            append_log(log_file, f"{WEBHOOK_ENV} unset, not posted:\n{rendered}")
         return False, f"{WEBHOOK_ENV} unset"
 
     ok, status = post_with_retry(webhook, payload)
     if not ok:
-        # Print the message so it is not lost, and say why on stderr.
-        print(render_for_terminal(payload))
+        # Print the message so it is not lost, and say why.
+        print(rendered)
         print(f"[notify] Slack post failed ({status})", flush=True)
+        if log_file:
+            append_log(log_file, f"post failed ({status}), not delivered:\n{rendered}")
     return ok, status

--- a/biahub/utils/notify.py
+++ b/biahub/utils/notify.py
@@ -198,13 +198,19 @@ def build_payload(
     Notes
     -----
     The mention goes in the top-level ``text`` field, not in the attachment:
-    mentions are only reliably delivered as a notification from ``text``.
+    mentions are only reliably delivered as a notification from ``text``. Position
+    within ``text`` does not affect delivery, so it sits at the end for symmetry
+    with the messages that do not ping.
 
     With ``level='info'`` and no detail the payload is byte-identical to the
     plain ``{"text": …}`` this module's shell predecessor sent, so existing
     call sites are unaffected by the richer formatting.
     """
-    text = " ".join(part for part in (mention, _one_line(title)) if part)
+    # Mention LAST, so every message opens with its emoji and dataset and reads
+    # the same whether or not it pings. Appended after _one_line() rather than
+    # inside it: the title is length-capped, and a long error message must not be
+    # able to truncate the mention away and silently drop the notification.
+    text = " ".join(part for part in (_one_line(title), mention) if part)
     payload: dict = {"text": text}
 
     body = clean_and_truncate(detail, max_detail)

--- a/biahub/utils/notify.py
+++ b/biahub/utils/notify.py
@@ -92,6 +92,42 @@ def normalize_slack_id(raw: str | None) -> str | None:
     return f"<@{candidate}>"
 
 
+def operator_label() -> str:
+    """Name the person who launched the run, for the run-start message.
+
+    Returns
+    -------
+    str
+        ``"Ivan Ivanov (ivan.ivanov)"`` when the account has a real name,
+        ``"ivan.ivanov"`` when it does not, ``"unknown"`` if even the login name
+        is unavailable.
+
+    Notes
+    -----
+    Read from the account database (LDAP on the cluster, via ``pwd``), NOT from
+    Slack: resolving a member ID to a display name needs a ``users.info`` call,
+    which requires a bot token with ``users:read``. An incoming webhook cannot do
+    it. Embedding ``<@U…>`` would render as the display name but also pings, and
+    the run-start message is deliberately silent.
+
+    The GECOS field is comma-separated (``full name,room,work phone,home``), so
+    only the first component is a name.
+    """
+    try:
+        import pwd
+
+        entry = pwd.getpwuid(os.getuid())
+        login = entry.pw_name
+        full_name = entry.pw_gecos.split(",")[0].strip()
+    except Exception:
+        login = os.environ.get("USER") or os.environ.get("LOGNAME") or ""
+        full_name = ""
+
+    if full_name and full_name != login:
+        return f"{full_name} ({login})"
+    return login or "unknown"
+
+
 def clean_and_truncate(detail: str, max_chars: int = MAX_DETAIL_CHARS) -> str:
     """Make arbitrary log output safe and small enough for a Slack code fence.
 

--- a/biahub/utils/notify.py
+++ b/biahub/utils/notify.py
@@ -1,0 +1,402 @@
+"""Posting pipeline progress to Slack.
+
+The Nextflow pipeline calls ``biahub nf notify`` at run start, after each step
+completes, and once at run end (see ``nextflow/modules/notify.nf``). Everything
+here is deliberately dependency-free (stdlib ``urllib``) and structured as pure
+functions so the payload shaping, truncation, and retry rules are unit-testable
+without a network.
+
+Two environment variables drive it, both read at call time and never written to
+a file, a config default, or a process script:
+
+``BIAHUB_SLACK_WEBHOOK``
+    Incoming-webhook URL. **A credential.** When unset, messages are printed
+    instead of posted and the exit status is still 0, so a Slack-less user is
+    never blocked and a run is never broken by a missing webhook.
+``BIAHUB_SLACK_ID``
+    The Slack member ID of the person running the reconstruction, used for the
+    ``@``-mention on the messages that need action.
+"""
+
+import json
+import os
+import re
+import time
+import urllib.error
+import urllib.request
+
+WEBHOOK_ENV = "BIAHUB_SLACK_WEBHOOK"
+SLACK_ID_ENV = "BIAHUB_SLACK_ID"
+
+# Slack renders a colored bar down the left edge of an attachment. This is the
+# legacy attachments surface rather than Block Kit, chosen deliberately: a Block
+# Kit section caps its text at 3000 characters, which is the wrong direction for
+# a payload whose worst case is a Python traceback.
+LEVEL_COLORS = {
+    "good": "#2eb886",
+    "warn": "#daa038",
+    "error": "#d40e0d",
+}
+
+# Slack's hard ceiling on a message is 40000 characters, but the binding limit
+# is rendering: clients collapse long text behind a "Show more" link at roughly
+# 3-4k. Staying under that is what keeps an alert readable without a click.
+MAX_DETAIL_CHARS = 2500
+MAX_TITLE_CHARS = 300
+
+# Member IDs start with U (user) or W (Enterprise Grid user).
+_SLACK_ID_RE = re.compile(r"^[UW][A-Z0-9]{6,}$")
+
+# CSI escape sequences. cellpose progress bars and tqdm fill the SLURM task
+# logs with these, and they render as mojibake inside a Slack code fence.
+_ANSI_RE = re.compile(r"\x1b\[[0-9;?]*[a-zA-Z]")
+
+_BLANK_RUN_RE = re.compile(r"\n{3,}")
+
+# Statuses where retrying can plausibly succeed: rate limiting, transient
+# gateway/backend failures, and request timeouts.
+RETRYABLE_STATUSES = frozenset({408, 429, 500, 502, 503, 504})
+
+RETRY_DELAYS = (2.0, 5.0)
+RETRY_AFTER_CAP = 30.0
+REQUEST_TIMEOUT = 10.0
+
+
+def normalize_slack_id(raw: str | None) -> str | None:
+    """Normalize a Slack member ID to the mention form Slack actually delivers.
+
+    Accepts the ID as copied from Slack ("Copy member ID" in a profile), and the
+    ``<@U…>`` and ``@U…`` spellings people tend to paste instead.
+
+    Parameters
+    ----------
+    raw : str or None
+        The candidate ID.
+
+    Returns
+    -------
+    str or None
+        ``"<@U024BE7LH>"`` when the ID is well-formed, otherwise ``None``.
+
+    Notes
+    -----
+    A malformed ID is not an error Slack reports: it renders as literal text and
+    pings nobody. Callers should warn on ``None`` rather than fail silently. A
+    display name (``@ivan``) never pings via the API and is rejected here.
+    """
+    if not raw:
+        return None
+    candidate = raw.strip().strip("<>").lstrip("@").strip()
+    if not _SLACK_ID_RE.match(candidate):
+        return None
+    return f"<@{candidate}>"
+
+
+def clean_and_truncate(detail: str, max_chars: int = MAX_DETAIL_CHARS) -> str:
+    """Make arbitrary log output safe and small enough for a Slack code fence.
+
+    Keeps the **tail**, because every source of detail here puts the diagnosis
+    last: a Python traceback ends with the exception, Nextflow's ``Command
+    error:`` block ends with the raised error, and ``tail -n 40`` of a task log
+    is already a tail.
+
+    Parameters
+    ----------
+    detail : str
+        Raw text, typically captured stderr or a Nextflow error report.
+    max_chars : int, optional
+        Character budget for the result, before the truncation marker.
+
+    Returns
+    -------
+    str
+        Cleaned text, truncated from the front if needed.
+    """
+    if not detail:
+        return ""
+
+    text = _ANSI_RE.sub("", detail)
+    # Progress bars rewrite one line with \r; without this the whole log
+    # collapses into a single enormous line.
+    text = text.replace("\r\n", "\n").replace("\r", "\n")
+    text = _BLANK_RUN_RE.sub("\n\n", text).strip()
+    # A literal fence inside the detail would close our code block early.
+    text = text.replace("```", "'''")
+
+    if len(text) <= max_chars:
+        return text
+
+    kept = text[-max_chars:]
+    dropped = len(text) - max_chars
+    return f"… {dropped} characters truncated …\n{kept}"
+
+
+def build_payload(
+    title: str,
+    detail: str = "",
+    level: str = "info",
+    mention: str | None = None,
+    max_detail: int = MAX_DETAIL_CHARS,
+) -> dict:
+    """Build the Slack incoming-webhook JSON body.
+
+    Parameters
+    ----------
+    title : str
+        One-line summary. Should name the dataset.
+    detail : str, optional
+        Supporting text, rendered in a code fence inside the attachment.
+    level : {'info', 'good', 'warn', 'error'}, optional
+        Severity, which selects the attachment's color bar. ``'info'`` emits no
+        attachment at all.
+    mention : str or None, optional
+        A normalized ``<@U…>`` mention to prepend to the message text.
+    max_detail : int, optional
+        Character budget passed to :func:`clean_and_truncate`.
+
+    Returns
+    -------
+    dict
+        A payload ready for ``json.dumps``.
+
+    Notes
+    -----
+    The mention goes in the top-level ``text`` field, not in the attachment:
+    mentions are only reliably delivered as a notification from ``text``.
+
+    With ``level='info'`` and no detail the payload is byte-identical to the
+    plain ``{"text": …}`` this module's shell predecessor sent, so existing
+    call sites are unaffected by the richer formatting.
+    """
+    text = " ".join(part for part in (mention, _one_line(title)) if part)
+    payload: dict = {"text": text}
+
+    body = clean_and_truncate(detail, max_detail)
+    color = LEVEL_COLORS.get(level)
+    if body or color:
+        attachment: dict = {"mrkdwn_in": ["text"], "fallback": _one_line(title)}
+        if color:
+            attachment["color"] = color
+        if body:
+            attachment["text"] = f"```{body}```"
+        payload["attachments"] = [attachment]
+
+    return payload
+
+
+def _one_line(title: str) -> str:
+    """Collapse a title to a single line within Slack's practical title budget."""
+    collapsed = " ".join(title.split())
+    if len(collapsed) <= MAX_TITLE_CHARS:
+        return collapsed
+    return collapsed[: MAX_TITLE_CHARS - 1] + "…"
+
+
+def post_with_retry(
+    webhook: str,
+    payload: dict,
+    attempts: int = len(RETRY_DELAYS) + 1,
+    sleep=time.sleep,
+) -> tuple[bool, str]:
+    """POST a payload to a Slack incoming webhook, retrying only what can recover.
+
+    Parameters
+    ----------
+    webhook : str
+        The incoming-webhook URL. Never logged.
+    payload : dict
+        Body from :func:`build_payload`.
+    attempts : int, optional
+        Total tries, including the first.
+    sleep : callable, optional
+        Injection point for tests.
+
+    Returns
+    -------
+    tuple of (bool, str)
+        Whether the post succeeded, and a short human-readable status.
+
+    Notes
+    -----
+    A permanent rejection (400 invalid payload, 403 action prohibited, 404
+    revoked webhook, 410 archived channel) is not retried: repeating the request
+    cannot change the outcome and only delays the caller. Slack's plain-text
+    response body names the cause and is returned as the status.
+    """
+    body = json.dumps(payload).encode()
+    status = "not attempted"
+
+    for attempt in range(attempts):
+        try:
+            request = urllib.request.Request(
+                webhook,
+                data=body,
+                headers={"Content-Type": "application/json"},
+                method="POST",
+            )
+            with urllib.request.urlopen(request, timeout=REQUEST_TIMEOUT) as response:
+                return True, f"HTTP {response.status}"
+        except urllib.error.HTTPError as error:
+            detail = _read_error_body(error)
+            status = f"HTTP {error.code}: {detail}"
+            if error.code not in RETRYABLE_STATUSES:
+                return False, status
+            delay = _retry_delay(attempt, error)
+        except (urllib.error.URLError, OSError) as error:
+            status = f"transport error: {_mask(str(error), webhook)}"
+            delay = _retry_delay(attempt, None)
+
+        if attempt == attempts - 1:
+            break
+        sleep(delay)
+
+    return False, status
+
+
+def _retry_delay(attempt: int, error: urllib.error.HTTPError | None) -> float:
+    """Pick the backoff before the next attempt, honouring ``Retry-After``."""
+    if error is not None:
+        raw = error.headers.get("Retry-After") if error.headers else None
+        if raw:
+            try:
+                return min(float(raw), RETRY_AFTER_CAP)
+            except ValueError:
+                pass
+    return RETRY_DELAYS[min(attempt, len(RETRY_DELAYS) - 1)]
+
+
+def _read_error_body(error: urllib.error.HTTPError) -> str:
+    """Read Slack's plain-text rejection reason, which names the actual problem."""
+    try:
+        return error.read().decode(errors="replace").strip()[:200] or error.reason
+    except Exception:
+        return str(error.reason)
+
+
+def _mask(message: str, webhook: str) -> str:
+    """Keep the webhook URL out of any message we print."""
+    return message.replace(webhook, "<webhook>") if webhook else message
+
+
+def render_for_terminal(payload: dict) -> str:
+    """Flatten a payload back to plain text, for the no-webhook fallback."""
+    lines = [payload.get("text", "")]
+    for attachment in payload.get("attachments", []):
+        if attachment.get("text"):
+            lines.append(attachment["text"])
+    return "\n".join(line for line in lines if line)
+
+
+def should_send(state_dir: str, key: str, min_interval: float) -> bool:
+    """Report whether ``key`` was last sent longer ago than ``min_interval``.
+
+    Used only for run start/end, to absorb the relaunch loops that happen while
+    debugging a config (five launches in ten minutes is an observed pattern).
+    Per-step messages need nothing like this: they are deduplicated by
+    Nextflow's own task cache.
+
+    Parameters
+    ----------
+    state_dir : str
+        Directory holding one marker file per key. Created if absent.
+    key : str
+        Marker name, e.g. ``"run-start"``.
+    min_interval : float
+        Seconds that must have passed since the last successful send.
+
+    Returns
+    -------
+    bool
+        True when the message should be sent.
+    """
+    if min_interval <= 0:
+        return True
+    marker = os.path.join(state_dir, f"{key}.sent")
+    try:
+        age = time.time() - os.path.getmtime(marker)
+    except OSError:
+        return True
+    return age >= min_interval
+
+
+def record_sent(state_dir: str, key: str) -> None:
+    """Stamp ``key`` as just sent.
+
+    Called only after a successful post, so a Slack outage does not silently
+    swallow the next message.
+    """
+    try:
+        os.makedirs(state_dir, exist_ok=True)
+        with open(os.path.join(state_dir, f"{key}.sent"), "w") as handle:
+            handle.write(f"{time.time()}\n")
+    except OSError:
+        # State is an optimization, not a correctness requirement.
+        pass
+
+
+def send(
+    title: str,
+    detail: str = "",
+    level: str = "info",
+    ping: bool = False,
+    slack_id: str | None = None,
+    max_detail: int = MAX_DETAIL_CHARS,
+    dry_run: bool = False,
+) -> tuple[bool, str]:
+    """Build and post one notification.
+
+    Parameters
+    ----------
+    title : str
+        One-line summary; should name the dataset.
+    detail : str, optional
+        Supporting text for the code fence.
+    level : {'info', 'good', 'warn', 'error'}, optional
+        Severity driving the attachment color.
+    ping : bool, optional
+        Whether to ``@``-mention the operator. Reserve this for messages that
+        need action — run end and failures — so the mention keeps meaning
+        something.
+    slack_id : str or None, optional
+        Member ID override; defaults to ``$BIAHUB_SLACK_ID``.
+    max_detail : int, optional
+        Character budget for the detail block.
+    dry_run : bool, optional
+        Render and print without posting.
+
+    Returns
+    -------
+    tuple of (bool, str)
+        Whether a post happened, and a human-readable status. Callers should not
+        turn a False into a non-zero exit: a failed notification must never fail
+        a reconstruction.
+    """
+    mention = None
+    if ping:
+        raw = slack_id if slack_id is not None else os.environ.get(SLACK_ID_ENV, "")
+        mention = normalize_slack_id(raw)
+        if raw and mention is None:
+            print(
+                f"[notify] ignoring malformed Slack ID {raw!r} — "
+                f"expected a member ID like U024BE7LH "
+                f"(Slack profile → Copy member ID); display names never ping",
+            )
+
+    payload = build_payload(title, detail, level, mention, max_detail)
+
+    if dry_run:
+        print(json.dumps(payload, indent=2))
+        return False, "dry run"
+
+    webhook = os.environ.get(WEBHOOK_ENV, "")
+    if not webhook:
+        print(f"[notify] {WEBHOOK_ENV} unset — printing instead of posting")
+        print(render_for_terminal(payload))
+        return False, f"{WEBHOOK_ENV} unset"
+
+    ok, status = post_with_retry(webhook, payload)
+    if not ok:
+        # Print the message so it is not lost, and say why on stderr.
+        print(render_for_terminal(payload))
+        print(f"[notify] Slack post failed ({status})", flush=True)
+    return ok, status

--- a/nextflow/mantis-v2.nf
+++ b/nextflow/mantis-v2.nf
@@ -65,6 +65,23 @@ def directory_layout() {
 }
 
 
+// The reconstruction steps, in the order they run, as they are named in Slack.
+// One list so the run-start announcement cannot disagree with the per-step
+// messages. A function rather than a bare assignment for the same reason
+// directory_layout() is one: Nextflow's DSL2 parser allows only declarations at
+// script scope.
+def reconstruction_steps() {
+    return [
+        'flat-field',
+        'deskew',
+        'phase reconstruction',
+        'virtual staining',
+        'assemble',
+        'track',
+    ]
+}
+
+
 workflow {
     if (!params.input)              error "Provide --input"
     if (!params.output)             error "Provide --output"
@@ -81,10 +98,6 @@ workflow {
     def ds     = dataset_name()
     def out    = params.output
     def layout = directory_layout()
-
-    // Announce the run before submitting anything. Also the earliest possible
-    // check that the webhook still works, hours before the completion message.
-    notify_run_start(ds, 'mantis_v2')
 
     collect_positions(params.input)
     all_positions = collect_positions.out
@@ -171,26 +184,40 @@ workflow {
     track_done = track_wf(all_positions, track_input, track_input_images, track_output, params.track_config, track_trigger)
 
     // ----- Notifications ----------------------------------------------------
-    // One Slack message as each step finishes. Step ORDER and labels live here
-    // with the rest of the wiring, not in notify.nf — same reason the layout map
-    // does: this file owns the order steps run in.
+    // One Slack message as each step finishes, plus the run-start announcement.
+    // Step ORDER and labels live here with the rest of the wiring, not in
+    // notify.nf — same reason the layout map does: this file owns the order steps
+    // run in. reconstruction_steps() is the only list of labels, so the announced
+    // list cannot drift from what the per-step messages actually say.
     //
     // The six done channels are MIXED into one and notify_step is invoked ONCE:
     // a process can only be invoked a single time per workflow context, so six
     // separate notify_step(...) calls would not compile.
     //
-    // Note the literal 1 for assemble: unlike the per-position steps, whose
-    // `done` carries the collected position list, assemble_wf emits a single
-    // path String. `('a/b.zarr' as List)` would explode into characters, so this
-    // is deliberately not a polymorphic size helper.
-    notify_events = ff_done.done         .map { ['flat-field',           it.size(), ff_output,            '1/6'] }
-        .mix( deskew_done.done           .map { ['deskew',               it.size(), deskew_output,        '2/6'] } )
-        .mix( reconstruct_done.done      .map { ['phase reconstruction', it.size(), reconstruct_output,   '3/6'] } )
-        .mix( virtual_stain_done.done    .map { ['virtual staining',     it.size(), virtual_stain_output, '4/6'] } )
-        .mix( assemble_done.done         .map { ['assemble',             1,         assemble_output,      '5/6'] } )
-        .mix( track_done.done            .map { ['track',                it.size(), track_output,         '6/6'] } )
+    // Nothing here reads a position count. It is the same for every step, so
+    // saying it six times adds nothing; the run-start message reports it once.
+    // That also removes a trap: assemble_wf's `done` carries a single path
+    // String rather than the collected position list, and `('a/b.zarr' as List)`
+    // explodes into characters.
+    steps = reconstruction_steps()
+    n_steps = steps.size()
+
+    notify_events = ff_done.done      .map { [steps[0], ff_output,            "1/${n_steps}"] }
+        .mix( deskew_done.done        .map { [steps[1], deskew_output,        "2/${n_steps}"] } )
+        .mix( reconstruct_done.done   .map { [steps[2], reconstruct_output,   "3/${n_steps}"] } )
+        .mix( virtual_stain_done.done .map { [steps[3], virtual_stain_output, "4/${n_steps}"] } )
+        .mix( assemble_done.done      .map { [steps[4], assemble_output,      "5/${n_steps}"] } )
+        .mix( track_done.done         .map { [steps[5], track_output,         "6/${n_steps}"] } )
 
     notify_step(notify_events, ds)
+
+    // Announce the run once the position count is known. all_positions carries a
+    // single collected list, so this fires exactly once; registering the
+    // subscribe here rather than earlier is fine because the whole body is graph
+    // construction and nothing executes until it finishes.
+    all_positions.subscribe { positions ->
+        notify_run_start(ds, 'mantis_v2', positions.size(), steps)
+    }
 
     // Report the finished run to Slack, with an @-mention.
     //

--- a/nextflow/mantis-v2.nf
+++ b/nextflow/mantis-v2.nf
@@ -40,6 +40,7 @@ include { reconstruct_wf } from './modules/reconstruct'
 include { virtual_stain_wf } from './modules/virtual_stain'
 include { track_wf } from './modules/tracking'
 include { assemble_wf } from './modules/assembly'
+include { notify_step; notify_run_start; notify_run_end } from './modules/notify'
 
 // Output directory layout for the reconstruction steps — single source of
 // truth. Each entry is a subdirectory under params.output where that step
@@ -80,6 +81,10 @@ workflow {
     def ds     = dataset_name()
     def out    = params.output
     def layout = directory_layout()
+
+    // Announce the run before submitting anything. Also the earliest possible
+    // check that the webhook still works, hours before the completion message.
+    notify_run_start(ds)
 
     collect_positions(params.input)
     all_positions = collect_positions.out
@@ -163,5 +168,49 @@ workflow {
     track_input_images = assemble_output
     track_output       = "${out}/${layout.track}/${ds}.zarr"
 
-    track_wf(all_positions, track_input, track_input_images, track_output, params.track_config, track_trigger)
+    track_done = track_wf(all_positions, track_input, track_input_images, track_output, params.track_config, track_trigger)
+
+    // ----- Notifications ----------------------------------------------------
+    // One Slack message as each step finishes. Step ORDER and labels live here
+    // with the rest of the wiring, not in notify.nf — same reason the layout map
+    // does: this file owns the order steps run in.
+    //
+    // The six done channels are MIXED into one and notify_step is invoked ONCE:
+    // a process can only be invoked a single time per workflow context, so six
+    // separate notify_step(...) calls would not compile.
+    //
+    // Note the literal 1 for assemble: unlike the per-position steps, whose
+    // `done` carries the collected position list, assemble_wf emits a single
+    // path String. `('a/b.zarr' as List)` would explode into characters, so this
+    // is deliberately not a polymorphic size helper.
+    notify_events = ff_done.done         .map { ['flat-field',           it.size(), ff_output,            '1/6'] }
+        .mix( deskew_done.done           .map { ['deskew',               it.size(), deskew_output,        '2/6'] } )
+        .mix( reconstruct_done.done      .map { ['phase reconstruction', it.size(), reconstruct_output,   '3/6'] } )
+        .mix( virtual_stain_done.done    .map { ['virtual staining',     it.size(), virtual_stain_output, '4/6'] } )
+        .mix( assemble_done.done         .map { ['assemble',             1,         assemble_output,      '5/6'] } )
+        .mix( track_done.done            .map { ['track',                it.size(), track_output,         '6/6'] } )
+
+    notify_step(notify_events, ds)
+
+    // Report the finished run to Slack, with an @-mention.
+    //
+    // onComplete ONLY — onError fires in ADDITION to onComplete, so handling
+    // both would double-post every failure. notify_run_end branches on
+    // workflow.success instead.
+    //
+    // Registered inside the workflow body, not at script scope: Nextflow 26's
+    // strict syntax rejects statements outside a declaration, the same
+    // restriction that forces directory_layout() to be a function. The handler
+    // still runs at session teardown, not here.
+    //
+    // `wf` is captured OUT here on purpose. Inside the handler closure the
+    // implicit `workflow` resolves to null, so reading `workflow.stats` there
+    // throws an NPE that Nextflow swallows into a bare "Failed to invoke
+    // workflow.onComplete event handler" — and the run-end message is silently
+    // never sent. The captured reference is the same mutable metadata object, so
+    // the stats read at teardown are still the final ones.
+    def wf = workflow
+    workflow.onComplete {
+        notify_run_end(ds, wf)
+    }
 }

--- a/nextflow/mantis-v2.nf
+++ b/nextflow/mantis-v2.nf
@@ -84,7 +84,7 @@ workflow {
 
     // Announce the run before submitting anything. Also the earliest possible
     // check that the webhook still works, hours before the completion message.
-    notify_run_start(ds)
+    notify_run_start(ds, 'mantis_v2')
 
     collect_positions(params.input)
     all_positions = collect_positions.out

--- a/nextflow/mantis-v2.nf
+++ b/nextflow/mantis-v2.nf
@@ -211,6 +211,6 @@ workflow {
     // the stats read at teardown are still the final ones.
     def wf = workflow
     workflow.onComplete {
-        notify_run_end(ds, wf)
+        notify_run_end(ds, 'mantis_v2', wf)
     }
 }

--- a/nextflow/modules/notify.nf
+++ b/nextflow/modules/notify.nf
@@ -280,7 +280,10 @@ def notify_run_end(dataset, pipeline, wf) {
         notify_send([
             '--level', 'good',
             '--ping',
-            '--title', ":white_check_mark: ${dataset} — reconstruction complete",
+            // :checkered_flag: rather than the :white_check_mark: the six step
+            // messages use — this is the one that pings, so it should not look
+            // identical to six that do not. Reads 🚀 start, ✅ per step, 🏁 done.
+            '--title', ":checkered_flag: ${dataset} — reconstruction complete",
             '--detail', "${summary}\nassembled: ${params.output}/5-assemble/${dataset}.zarr",
         ])
         return

--- a/nextflow/modules/notify.nf
+++ b/nextflow/modules/notify.nf
@@ -130,48 +130,87 @@ def notify_run_start(dataset, pipeline, n_positions, steps) {
     ])
 }
 
-// Classify every failed ATTEMPT recorded in trace.txt as preemption or real failure.
+// Ask SLURM what actually killed each attempt.
 //
-// workflow.stats cannot do this: it reports failedCount and retriesCount with no
-// exit codes, so a position that was preempted once and then succeeded shows up as
-// "failed: 1, retries: 1" — which reads as a broken run when nothing went wrong.
-// The exit code is the only thing that distinguishes them, and trace.txt has it.
+// The exit code alone CANNOT say. 143 is SIGTERM, which SLURM sends both when it
+// reclaims a job on the `preempted` partition and when a job hits its time limit
+// — nextflow.config says as much ("SIGTERM 143 (preempt/timeout)"). Calling every
+// 143 a preemption would send the reader after the wrong cause: preemption needs
+// no action, a time limit needs more --time. sacct knows the difference, and
+// trace.txt hands us the SLURM job id in native_id.
 //
-// Same rule the pipeline itself uses to decide whether to retry (errorStrategy in
-// nextflow.config): 130..145 is "128 + signal", i.e. the job was killed rather
-// than the code failing — SIGTERM 143 for preemption or a time limit, SIGKILL 137
-// for OOM, SIGUSR2 140 for Nextflow's near-limit warning. Anything else is the
-// program itself exiting non-zero.
-//
-// trace.txt is complete and readable by the time onComplete runs (verified). Its
-// path is set by `trace.file` in nextflow.config; returns null if it cannot be
-// read, and the caller then falls back to the raw counts.
-def signal_label(code) {
-    // Name each signal for what it actually is. 143 = SIGTERM, what SLURM sends
-    // when it reclaims a job on the `preempted` partition. 137 = SIGKILL, in
-    // practice an OOM kill. 140 = SIGUSR2, Nextflow's own near-the-time-limit
-    // warning. Anything else in the range is named by its code rather than
-    // guessed at — reporting an OOM as "preempted" would be its own lie.
-    if (code == 143) return 'preempted'
-    if (code == 137) return 'oom-killed'
-    if (code == 140) return 'time-limit'
-    return "killed (exit ${code})".toString()
+// One batched query for every restarted attempt. Returns a label -> count map, or
+// null when sacct cannot answer — no accounting records, not a SLURM run, or the
+// JVM shutting down under us — in which case the caller falls back to exit codes.
+// -X reports the allocation only, without the .batch/.extern sub-steps that would
+// otherwise double-count.
+def restart_causes(job_ids) {
+    if (!job_ids) {
+        return null
+    }
+    try {
+        def proc = ['sacct', '-X', '-n', '-P', '-o', 'JobID,State',
+                    '-j', job_ids.join(',')].execute()
+        def out = new StringBuffer()
+        def err = new StringBuffer()
+        proc.consumeProcessOutput(out, err)
+        proc.waitFor(15, java.util.concurrent.TimeUnit.SECONDS)
+
+        def causes = [:]
+        out.toString().readLines().each { line ->
+            def field = line.split('\\|')
+            if (field.size() > 1) {
+                def label = sacct_label(field[1])
+                causes[label] = (causes[label] ?: 0) + 1
+            }
+        }
+        return causes ?: null
+    }
+    catch (Throwable t) {
+        return null
+    }
 }
 
+def sacct_label(state) {
+    // "CANCELLED by 12345" carries the canceller's uid, so keep the first word.
+    def name = state.trim().split(/\s+/)[0]
+    if (name == 'PREEMPTED')     return 'preempted'
+    if (name == 'TIMEOUT')       return 'timed out'
+    if (name == 'OUT_OF_MEMORY') return 'out of memory'
+    if (name == 'NODE_FAIL')     return 'node failure'
+    return name.toLowerCase().replace('_', ' ')
+}
+
+// Split every failed ATTEMPT in trace.txt into "restarted" and "failed".
+//
+// workflow.stats cannot: it reports failedCount and retriesCount with no exit
+// codes, so a position that was preempted once and then succeeded reads as
+// "failed: 1, retries: 1" — as if the run were broken when nothing went wrong.
+//
+// Same rule the pipeline uses to decide whether to retry (errorStrategy in
+// nextflow.config): 130..145 is "128 + signal", i.e. the job was killed rather
+// than the code failing. Those attempts were restarted, so they are not failures.
+//
+// trace.txt is complete and readable by the time onComplete runs (verified); its
+// path comes from `trace.file` in nextflow.config. Returns null if it cannot be
+// read, and the caller then reports the raw counts instead.
 def failed_attempts() {
     try {
         def trace = new File("${params.output}/nextflow/trace.txt")
         if (!trace.exists()) {
             return null
         }
-        def outcome = [killed: [:], failed: 0]
+        def outcome = [restarted: 0, failed: 0, exits: [:], job_ids: []]
         trace.readLines().drop(1).each { line ->
-            def field = line.split('\t')
+            def field = line.split('\\t')
             if (field.size() > 5 && field[4] == 'FAILED') {
                 def code = field[5].isInteger() ? field[5] as int : -1
                 if (code >= 130 && code <= 145) {
-                    def label = signal_label(code)
-                    outcome.killed[label] = (outcome.killed[label] ?: 0) + 1
+                    outcome.restarted = outcome.restarted + 1
+                    outcome.exits[code] = (outcome.exits[code] ?: 0) + 1
+                    if (field[2] && field[2].isInteger()) {
+                        outcome.job_ids += field[2]
+                    }
                 }
                 else {
                     outcome.failed = outcome.failed + 1
@@ -183,6 +222,16 @@ def failed_attempts() {
     catch (Exception e) {
         return null
     }
+}
+
+// "restarted: 3 (2 preempted, 1 out of memory)", or the exit codes when sacct
+// could not tell us.
+def restarted_line(outcome) {
+    def causes = restart_causes(outcome.job_ids)
+    def detail = causes
+        ? causes.sort { -it.value }.collect { label, n -> "${n} ${label}" }.join(', ')
+        : outcome.exits.sort().collect { code, n -> "exit ${code}×${n}" }.join(', ')
+    return "restarted: ${outcome.restarted} (${detail})".toString()
 }
 
 // Report the finished run, pinging the operator.
@@ -205,17 +254,17 @@ def notify_run_end(dataset, pipeline, wf) {
         lines += ["failed:    ${stats.failedCount}", "retries:   ${stats.retriesCount}"]
     }
     else {
-        // One line per kind of kill, e.g. "preempted: 3". Every one of these was
-        // retried, so they are not failures and must not be counted as any.
-        outcome.killed.sort().each { label, count ->
-            lines += ["${(label + ':').padRight(10)} ${count}".toString()]
+        // Restarted attempts were retried, so they are not failures and must
+        // not be counted as any.
+        if (outcome.restarted) {
+            lines += [restarted_line(outcome)]
         }
         if (outcome.failed) {
             lines += ["failed:    ${outcome.failed}".toString()]
         }
-        // A run that died with nothing but kills burnt through maxRetries. Say so,
-        // or the reader sees a FAILED title with no failures listed under it.
-        if (!wf.success && !outcome.failed && outcome.killed) {
+        // A run that died with nothing but restarts burnt through maxRetries. Say
+        // so, or the reader sees a FAILED title with no failures listed under it.
+        if (!wf.success && !outcome.failed && outcome.restarted) {
             lines += ["note:      retries exhausted, no code-level failure".toString()]
         }
     }

--- a/nextflow/modules/notify.nf
+++ b/nextflow/modules/notify.nf
@@ -100,8 +100,14 @@ def notify_run_start(dataset) {
         ((params.max_positions ?: 0) as int) > 0 ? "max_positions: ${params.max_positions}" : null,
     ].findAll { it }.join('\n')
 
+    // --operator names whoever launched this, resolved from the account database
+    // by the Python. It is NOT taken from Slack: turning a member ID into a
+    // display name needs a users.info call and a bot token, which an incoming
+    // webhook cannot do — and an <@U…> mention would ping, while this message is
+    // deliberately silent.
     notify_send([
         '--level', 'info',
+        '--operator',
         '--title', ":rocket: ${dataset} — mantis-v2 started",
         '--detail', detail,
         '--key', 'run-start',

--- a/nextflow/modules/notify.nf
+++ b/nextflow/modules/notify.nf
@@ -227,6 +227,12 @@ def failed_attempts() {
 // "restarted: 3 (2 preempted, 1 out of memory)", or the exit codes when sacct
 // could not tell us.
 def restarted_line(outcome) {
+    // Always reported, including "restarted: 0", so a clean run says so outright
+    // instead of leaving the reader to infer it from an absent line. Nothing to
+    // ask sacct about in that case.
+    if (!outcome.restarted) {
+        return 'restarted: 0'
+    }
     def causes = restart_causes(outcome.job_ids)
     def detail = causes
         ? causes.sort { -it.value }.collect { label, n -> "${n} ${label}" }.join(', ')
@@ -255,10 +261,8 @@ def notify_run_end(dataset, pipeline, wf) {
     }
     else {
         // Restarted attempts were retried, so they are not failures and must
-        // not be counted as any.
-        if (outcome.restarted) {
-            lines += [restarted_line(outcome)]
-        }
+        // not be counted as any. Reported unconditionally — see restarted_line.
+        lines += [restarted_line(outcome)]
         if (outcome.failed) {
             lines += ["failed:    ${outcome.failed}".toString()]
         }

--- a/nextflow/modules/notify.nf
+++ b/nextflow/modules/notify.nf
@@ -101,7 +101,7 @@ def notify_run_start(dataset, pipeline) {
         ((params.max_positions ?: 0) as int) > 0 ? "max_positions: ${params.max_positions}" : null,
     ].findAll { it }.join('\n')
 
-    // --operator prepends the "launched by:" line, resolved from the account database
+    // --operator prepends the "operator:" line, resolved from the account database
     // by the Python. It is NOT taken from Slack: turning a member ID into a
     // display name needs a users.info call and a bot token, which an incoming
     // webhook cannot do — and an <@U…> mention would ping, while this message is
@@ -207,15 +207,22 @@ def notify_run_end(dataset, pipeline, wf) {
 // orphaned process keeps running. We wait only so a fast post is ordered before
 // shutdown; we do not depend on the wait succeeding.
 //
-// Nothing here reads the child's output. At teardown we may not survive long
-// enough to log it, so `--log-file` makes the notifier record its own delivery
-// problems instead.
+// inheritIO() rather than capturing the child's streams. The notifier is silent
+// on a clean post and only speaks up when something needs attention — no webhook
+// configured, a malformed member ID, a rejected POST — and inheriting sends that
+// straight to the console the user is watching, with no pipe for us to drain (an
+// unread pipe would also block the child once it filled) and nothing for us to
+// re-log at teardown, when the console is already gone. `--log-file` makes the
+// notifier record delivery problems itself, so the durable diagnostic does not
+// depend on this process being alive to write it.
 def notify_send(args) {
     def command = ['biahub', 'nf', 'notify'] +
         ['--log-file', "${params.output}/nextflow/.notify/notify.log".toString()] +
         args.collect { it.toString() }
     try {
-        def proc = command.execute()
+        def builder = new ProcessBuilder(command)
+        builder.inheritIO()
+        def proc = builder.start()
         proc.waitFor(30, java.util.concurrent.TimeUnit.SECONDS)
     }
     catch (Throwable t) {

--- a/nextflow/modules/notify.nf
+++ b/nextflow/modules/notify.nf
@@ -122,9 +122,10 @@ def notify_run_start(dataset, pipeline) {
 // Called from a single `workflow.onComplete`, never from onComplete AND onError:
 // onError fires in ADDITION to onComplete, so implementing both double-posts
 // every failure.
-def notify_run_end(dataset, wf) {
+def notify_run_end(dataset, pipeline, wf) {
     def stats = wf.stats
     def summary = [
+        "pipeline:  ${pipeline}",
         "succeeded: ${stats.succeededCount}",
         "cached:    ${stats.cachedCount}",
         "failed:    ${stats.failedCount}",
@@ -136,7 +137,7 @@ def notify_run_end(dataset, wf) {
         notify_send([
             '--level', 'good',
             '--ping',
-            '--title', ":white_check_mark: ${dataset} — mantis-v2 complete",
+            '--title', ":white_check_mark: ${dataset} — reconstruction complete",
             '--detail', "${summary}\nassembled: ${params.output}/5-assemble/${dataset}.zarr",
         ])
         return
@@ -148,9 +149,18 @@ def notify_run_end(dataset, wf) {
     def aborted = wf.exitStatus == null
     def verb = aborted ? 'aborted' : 'FAILED'
     def icon = aborted ? ':warning:' : ':x:'
-    def title = "${icon} ${dataset} — mantis-v2 ${verb}"
-    if (wf.errorMessage) {
-        title += ": ${wf.errorMessage.readLines()[0]}"
+    def title = "${icon} ${dataset} — reconstruction ${verb}"
+    // LAST non-blank line, not the first. For a task that died in Python,
+    // errorMessage is the captured stderr, so the first line is
+    // "Traceback (most recent call last):" — true of every Python failure and
+    // therefore useless in a title, while the last line is the exception itself
+    // ("ValueError: bad config here"). For a non-Python failure it is a
+    // single-line "Process X terminated with an error exit status (3)", where
+    // first and last are the same. Same reasoning as keeping the tail when
+    // truncating a detail. The Python caps the title length.
+    def message = wf.errorMessage?.readLines()?.findAll { it.trim() }
+    if (message) {
+        title += ": ${message.last().trim()}"
     }
 
     // workflow.errorReport embeds the failing task's `Command executed:` block
@@ -184,51 +194,36 @@ def notify_run_end(dataset, wf) {
 // backticks. `biahub` resolves on PATH because check_environment() already
 // aborted the run at launch if it did not.
 //
-// Bounded and swallowed: a hung POST must not hold up the run's exit, and a
-// notification problem must never surface as a pipeline failure after two days
-// of compute.
-def notify_send(args) {
-    try {
-        def proc = (['biahub', 'nf', 'notify'] + args.collect { it.toString() }).execute()
-        // Drain both streams concurrently. The notifier is silent on a clean
-        // post and only speaks up when something needs attention — no webhook
-        // configured, a malformed member ID, a rejected POST — so anything it
-        // does say belongs on the console, where it is the terminal fallback for
-        // a message that did not reach Slack. Unlike notify_step, whose output
-        // lands in a task's .command.out, these run-level calls have nowhere
-        // else to surface.
-        def out = new StringBuffer()
-        def err = new StringBuffer()
-        proc.consumeProcessOutput(out, err)
-        proc.waitForOrKill(30000)
-
-        def said = [out.toString().trim(), err.toString().trim()].findAll { it }.join('\n')
-        if (said) {
-            log.info said
-            // Also append to a file. The run-end message is sent from
-            // onComplete, i.e. during session teardown, by which point
-            // Nextflow's console renderer has already been torn down and
-            // anything written to it is lost — so without this a failed
-            // run-end post would be invisible after the fact.
-            notify_log(said)
-        }
-    }
-    catch (Exception e) {
-        log.warn "Slack notification failed (continuing): ${e.message}"
-    }
-}
-
-// Append the notifier's own output to <output>/nextflow/.notify/notify.log.
+// NEVER USE waitForOrKill HERE. run-end is sent from onComplete, i.e. during JVM
+// shutdown, and there `waitForOrKill` returns before the child has exited and
+// then DESTROYS it — the notifier was SIGTERMed before it could POST, so the
+// failure message, the one that matters most, was silently never sent. Measured
+// against a local webhook: run start and run end on a successful run delivered,
+// a failed run delivered nothing.
 //
-// This is the only durable record of a notification problem: the run-end message
-// is sent during session teardown, when the console is already gone. Best-effort
-// by design — if it cannot be written there is nothing useful to do about it.
-def notify_log(message) {
+// `waitFor(timeout, unit)` does not kill the child, so it survives and completes
+// its POST even if this thread is interrupted (it is: AnsiLogObserver's own join
+// throws InterruptedException during teardown) or the JVM exits first — an
+// orphaned process keeps running. We wait only so a fast post is ordered before
+// shutdown; we do not depend on the wait succeeding.
+//
+// Nothing here reads the child's output. At teardown we may not survive long
+// enough to log it, so `--log-file` makes the notifier record its own delivery
+// problems instead.
+def notify_send(args) {
+    def command = ['biahub', 'nf', 'notify'] +
+        ['--log-file', "${params.output}/nextflow/.notify/notify.log".toString()] +
+        args.collect { it.toString() }
     try {
-        def file = new File("${params.output}/nextflow/.notify/notify.log")
-        file.parentFile.mkdirs()
-        file << "${new Date().format('yyyy-MM-dd HH:mm:ss')} ${message}\n"
+        def proc = command.execute()
+        proc.waitFor(30, java.util.concurrent.TimeUnit.SECONDS)
     }
-    catch (Exception e) {
+    catch (Throwable t) {
+        // Includes the InterruptedException thrown during shutdown. The child is
+        // already spawned and unaffected, so there is nothing to recover: a
+        // notification problem must never surface as a pipeline failure after two
+        // days of compute.
+        log.debug "notify: ${t.class.simpleName}: ${t.message}"
     }
 }
+

--- a/nextflow/modules/notify.nf
+++ b/nextflow/modules/notify.nf
@@ -1,0 +1,227 @@
+// Slack notifications for a pipeline run.
+//
+// Three kinds of message, all posted by `biahub nf notify` (biahub/utils/notify.py):
+//
+//   run start        notify_run_start()  — once, before any work is submitted
+//   step complete    notify_step         — once per step, as each one finishes
+//   run end          notify_run_end()    — once, from workflow.onComplete
+//
+// WHY notify_step IS A PROCESS AND NOT A `.subscribe { }` ON THE done CHANNEL
+//
+// A `-resume` run replays the entire dataflow graph: cached tasks still emit
+// their outputs, so `collect` still emits and a subscribe closure would fire for
+// every step within seconds of relaunching — six "step complete" messages for
+// work that was merely restored from cache. (Measured: a fully-cached relaunch
+// reaches 341/341 CACHED in about nine seconds.)
+//
+// Making this an ordinary CACHEABLE process solves that with no state of its own:
+// the notify task's inputs are unchanged, so on a resume it is cached too, so it
+// does not execute, so no message is sent. Nextflow's own task cache IS the
+// "already announced" record — it is per-output-directory by construction and it
+// survives `-resume`, which is exactly the semantics wanted here. Only steps that
+// genuinely re-ran announce themselves again.
+//
+// A subscribe closure would also run on a dataflow thread, putting a blocking
+// HTTP POST directly between one step finishing and the next being submitted.
+//
+// CREDENTIALS
+//
+// The webhook URL ($BIAHUB_SLACK_WEBHOOK) and the operator's member ID
+// ($BIAHUB_SLACK_ID) are read from the environment by the Python, never
+// interpolated into a script body. So neither reaches `.command.sh`, the work
+// directory, `.nextflow.log`, or a task hash — and changing either one never
+// invalidates a cached task. The environment reaches every task per the
+// ENVIRONMENT CONTRACT in common.nf (sbatch defaults to --export=ALL).
+
+// One message per completed step. See the header for why this is a process.
+//
+// Resources and error handling are pinned by `withName: 'notify_step'` in
+// nextflow.config rather than by a label: the slurm profile's
+// `withLabel: 'cpu_local'` block would otherwise clobber them, and six 12 GB
+// local tasks would contend with the init steps for the head node.
+process notify_step {
+    tag "${step}"
+
+    input:
+    tuple val(step), val(n_positions), val(output_zarr), val(index)
+    val dataset
+
+    output:
+    val step
+
+    script:
+    // Emoji as a Slack shortcode rather than raw UTF-8: it renders the same and
+    // keeps the payload ASCII.
+    def positions = n_positions > 1 ? " (${n_positions} positions)" : ""
+    // No --ping. Step messages post silently so the @-mention on the run-end
+    // message keeps meaning "this needs you".
+    // `|| true` so nothing the notifier does can fail the task, independent of
+    // the errorStrategy.
+    """
+    biahub nf notify \\
+        --level good \\
+        --title ":white_check_mark: ${dataset} — ${step} complete [${index}]${positions}" \\
+        --detail "output: ${output_zarr}" || true
+    """
+}
+
+// Announce the run before any work is submitted.
+//
+// This doubles as a webhook smoke test: without it the first Slack message is
+// the completion one, hours or days later, so a revoked webhook would be
+// discovered far too late to be useful.
+//
+// Rate-limited by key, because debugging a config produces relaunch storms —
+// five launches inside ten minutes is an observed pattern, which would otherwise
+// be five notifications.
+def notify_run_start(dataset) {
+    // Say once, at launch, that Slack is not configured. Without a webhook every
+    // message still prints and every exit status is still 0, but only the
+    // run-level messages reach the console: notify_step runs as a task, so its
+    // text goes to the task's .command.out and slurm_output/<step>/*.out, which
+    // nobody watching the pane would think to look in.
+    if (!System.getenv('BIAHUB_SLACK_WEBHOOK')) {
+        log.warn "BIAHUB_SLACK_WEBHOOK unset — Slack notifications disabled. " +
+            "Step messages will only appear in nextflow/slurm_output/<step>/*.out."
+    }
+    else if (!System.getenv('BIAHUB_SLACK_ID')) {
+        log.warn "BIAHUB_SLACK_ID unset — the run-end message will not @-mention anyone."
+    }
+
+    def detail = [
+        "input:  ${params.input}",
+        "output: ${params.output}",
+        "host:   ${java.net.InetAddress.localHost.hostName}",
+        // `as int` because a param given on the command line arrives as a
+        // String, and the String "0" is truthy in Groovy (same trap as
+        // queueSize in nextflow.config). `?: 0` because a bare `as int` on an
+        // unset param throws — mantis-v2.nf declares a default, but this module
+        // must not blow up in a pipeline that doesn't.
+        ((params.max_positions ?: 0) as int) > 0 ? "max_positions: ${params.max_positions}" : null,
+    ].findAll { it }.join('\n')
+
+    notify_send([
+        '--level', 'info',
+        '--title', ":rocket: ${dataset} — mantis-v2 started",
+        '--detail', detail,
+        '--key', 'run-start',
+        '--min-interval', '900',
+        '--state-dir', "${params.output}/nextflow/.notify",
+    ])
+}
+
+// Report the finished run, pinging the operator.
+//
+// Called from a single `workflow.onComplete`, never from onComplete AND onError:
+// onError fires in ADDITION to onComplete, so implementing both double-posts
+// every failure.
+def notify_run_end(dataset, wf) {
+    def stats = wf.stats
+    def summary = [
+        "succeeded: ${stats.succeededCount}",
+        "cached:    ${stats.cachedCount}",
+        "failed:    ${stats.failedCount}",
+        "retries:   ${stats.retriesCount}",
+        "duration:  ${wf.duration}",
+    ].join('\n')
+
+    if (wf.success) {
+        notify_send([
+            '--level', 'good',
+            '--ping',
+            '--title', ":white_check_mark: ${dataset} — mantis-v2 complete",
+            '--detail', "${summary}\nassembled: ${params.output}/5-assemble/${dataset}.zarr",
+        ])
+        return
+    }
+
+    // Ctrl-C also lands here. Calling that a failure would make every debug
+    // relaunch read as a catastrophe, so distinguish it: an interrupt records no
+    // process exit status.
+    def aborted = wf.exitStatus == null
+    def verb = aborted ? 'aborted' : 'FAILED'
+    def icon = aborted ? ':warning:' : ':x:'
+    def title = "${icon} ${dataset} — mantis-v2 ${verb}"
+    if (wf.errorMessage) {
+        title += ": ${wf.errorMessage.readLines()[0]}"
+    }
+
+    // workflow.errorReport embeds the failing task's `Command executed:` block
+    // and a full Python traceback — backticks, quotes and newlines. Never build
+    // a shell string out of it; write it to a file and pass the path.
+    def report = [summary, wf.errorReport ?: ''].findAll { it }.join('\n\n')
+    def detail_file = new File("${params.output}/nextflow/.notify/run-end.txt")
+    def args = [
+        '--level', aborted ? 'warn' : 'error',
+        '--ping',
+        '--title', title,
+    ]
+    try {
+        detail_file.parentFile.mkdirs()
+        detail_file.text = report
+        args += ['--detail-file', detail_file.path]
+    }
+    catch (Exception e) {
+        // An unwritable output dir is plausible here (it may be why the run
+        // failed). Fall back to the counts, which need no file.
+        args += ['--detail', summary]
+    }
+
+    notify_send(args)
+}
+
+// Invoke the notifier without a shell.
+//
+// List.execute() execs the command directly, so no argument is ever parsed by a
+// shell — the only safe way to pass an error report containing quotes and
+// backticks. `biahub` resolves on PATH because check_environment() already
+// aborted the run at launch if it did not.
+//
+// Bounded and swallowed: a hung POST must not hold up the run's exit, and a
+// notification problem must never surface as a pipeline failure after two days
+// of compute.
+def notify_send(args) {
+    try {
+        def proc = (['biahub', 'nf', 'notify'] + args.collect { it.toString() }).execute()
+        // Drain both streams concurrently. The notifier is silent on a clean
+        // post and only speaks up when something needs attention — no webhook
+        // configured, a malformed member ID, a rejected POST — so anything it
+        // does say belongs on the console, where it is the terminal fallback for
+        // a message that did not reach Slack. Unlike notify_step, whose output
+        // lands in a task's .command.out, these run-level calls have nowhere
+        // else to surface.
+        def out = new StringBuffer()
+        def err = new StringBuffer()
+        proc.consumeProcessOutput(out, err)
+        proc.waitForOrKill(30000)
+
+        def said = [out.toString().trim(), err.toString().trim()].findAll { it }.join('\n')
+        if (said) {
+            log.info said
+            // Also append to a file. The run-end message is sent from
+            // onComplete, i.e. during session teardown, by which point
+            // Nextflow's console renderer has already been torn down and
+            // anything written to it is lost — so without this a failed
+            // run-end post would be invisible after the fact.
+            notify_log(said)
+        }
+    }
+    catch (Exception e) {
+        log.warn "Slack notification failed (continuing): ${e.message}"
+    }
+}
+
+// Append the notifier's own output to <output>/nextflow/.notify/notify.log.
+//
+// This is the only durable record of a notification problem: the run-end message
+// is sent during session teardown, when the console is already gone. Best-effort
+// by design — if it cannot be written there is nothing useful to do about it.
+def notify_log(message) {
+    try {
+        def file = new File("${params.output}/nextflow/.notify/notify.log")
+        file.parentFile.mkdirs()
+        file << "${new Date().format('yyyy-MM-dd HH:mm:ss')} ${message}\n"
+    }
+    catch (Exception e) {
+    }
+}

--- a/nextflow/modules/notify.nf
+++ b/nextflow/modules/notify.nf
@@ -130,6 +130,61 @@ def notify_run_start(dataset, pipeline, n_positions, steps) {
     ])
 }
 
+// Classify every failed ATTEMPT recorded in trace.txt as preemption or real failure.
+//
+// workflow.stats cannot do this: it reports failedCount and retriesCount with no
+// exit codes, so a position that was preempted once and then succeeded shows up as
+// "failed: 1, retries: 1" — which reads as a broken run when nothing went wrong.
+// The exit code is the only thing that distinguishes them, and trace.txt has it.
+//
+// Same rule the pipeline itself uses to decide whether to retry (errorStrategy in
+// nextflow.config): 130..145 is "128 + signal", i.e. the job was killed rather
+// than the code failing — SIGTERM 143 for preemption or a time limit, SIGKILL 137
+// for OOM, SIGUSR2 140 for Nextflow's near-limit warning. Anything else is the
+// program itself exiting non-zero.
+//
+// trace.txt is complete and readable by the time onComplete runs (verified). Its
+// path is set by `trace.file` in nextflow.config; returns null if it cannot be
+// read, and the caller then falls back to the raw counts.
+def signal_label(code) {
+    // Name each signal for what it actually is. 143 = SIGTERM, what SLURM sends
+    // when it reclaims a job on the `preempted` partition. 137 = SIGKILL, in
+    // practice an OOM kill. 140 = SIGUSR2, Nextflow's own near-the-time-limit
+    // warning. Anything else in the range is named by its code rather than
+    // guessed at — reporting an OOM as "preempted" would be its own lie.
+    if (code == 143) return 'preempted'
+    if (code == 137) return 'oom-killed'
+    if (code == 140) return 'time-limit'
+    return "killed (exit ${code})".toString()
+}
+
+def failed_attempts() {
+    try {
+        def trace = new File("${params.output}/nextflow/trace.txt")
+        if (!trace.exists()) {
+            return null
+        }
+        def outcome = [killed: [:], failed: 0]
+        trace.readLines().drop(1).each { line ->
+            def field = line.split('\t')
+            if (field.size() > 5 && field[4] == 'FAILED') {
+                def code = field[5].isInteger() ? field[5] as int : -1
+                if (code >= 130 && code <= 145) {
+                    def label = signal_label(code)
+                    outcome.killed[label] = (outcome.killed[label] ?: 0) + 1
+                }
+                else {
+                    outcome.failed = outcome.failed + 1
+                }
+            }
+        }
+        return outcome
+    }
+    catch (Exception e) {
+        return null
+    }
+}
+
 // Report the finished run, pinging the operator.
 //
 // Called from a single `workflow.onComplete`, never from onComplete AND onError:
@@ -137,14 +192,36 @@ def notify_run_start(dataset, pipeline, n_positions, steps) {
 // every failure.
 def notify_run_end(dataset, pipeline, wf) {
     def stats = wf.stats
-    def summary = [
+    def lines = [
         "pipeline:  ${pipeline}",
         "succeeded: ${stats.succeededCount}",
         "cached:    ${stats.cachedCount}",
-        "failed:    ${stats.failedCount}",
-        "retries:   ${stats.retriesCount}",
-        "duration:  ${wf.duration}",
-    ].join('\n')
+    ]
+
+    def outcome = failed_attempts()
+    if (outcome == null) {
+        // No trace.txt to classify against; report the raw counts rather than
+        // claim something we cannot substantiate.
+        lines += ["failed:    ${stats.failedCount}", "retries:   ${stats.retriesCount}"]
+    }
+    else {
+        // One line per kind of kill, e.g. "preempted: 3". Every one of these was
+        // retried, so they are not failures and must not be counted as any.
+        outcome.killed.sort().each { label, count ->
+            lines += ["${(label + ':').padRight(10)} ${count}".toString()]
+        }
+        if (outcome.failed) {
+            lines += ["failed:    ${outcome.failed}".toString()]
+        }
+        // A run that died with nothing but kills burnt through maxRetries. Say so,
+        // or the reader sees a FAILED title with no failures listed under it.
+        if (!wf.success && !outcome.failed && outcome.killed) {
+            lines += ["note:      retries exhausted, no code-level failure".toString()]
+        }
+    }
+
+    lines += ["duration:  ${wf.duration}"]
+    def summary = lines.join('\n')
 
     if (wf.success) {
         notify_send([

--- a/nextflow/modules/notify.nf
+++ b/nextflow/modules/notify.nf
@@ -74,7 +74,7 @@ process notify_step {
 // Rate-limited by key, because debugging a config produces relaunch storms —
 // five launches inside ten minutes is an observed pattern, which would otherwise
 // be five notifications.
-def notify_run_start(dataset) {
+def notify_run_start(dataset, pipeline) {
     // Say once, at launch, that Slack is not configured. Without a webhook every
     // message still prints and every exit status is still 0, but only the
     // run-level messages reach the console: notify_step runs as a task, so its
@@ -89,6 +89,7 @@ def notify_run_start(dataset) {
     }
 
     def detail = [
+        "pipeline: ${pipeline}",
         "input:  ${params.input}",
         "output: ${params.output}",
         "host:   ${java.net.InetAddress.localHost.hostName}",
@@ -100,7 +101,7 @@ def notify_run_start(dataset) {
         ((params.max_positions ?: 0) as int) > 0 ? "max_positions: ${params.max_positions}" : null,
     ].findAll { it }.join('\n')
 
-    // --operator names whoever launched this, resolved from the account database
+    // --operator prepends the "launched by:" line, resolved from the account database
     // by the Python. It is NOT taken from Slack: turning a member ID into a
     // display name needs a users.info call and a bot token, which an incoming
     // webhook cannot do — and an <@U…> mention would ping, while this message is
@@ -108,7 +109,7 @@ def notify_run_start(dataset) {
     notify_send([
         '--level', 'info',
         '--operator',
-        '--title', ":rocket: ${dataset} — mantis-v2 started",
+        '--title', ":rocket: ${dataset} — reconstruction started",
         '--detail', detail,
         '--key', 'run-start',
         '--min-interval', '900',

--- a/nextflow/modules/notify.nf
+++ b/nextflow/modules/notify.nf
@@ -43,7 +43,7 @@ process notify_step {
     tag "${step}"
 
     input:
-    tuple val(step), val(n_positions), val(output_zarr), val(index)
+    tuple val(step), val(output_zarr), val(index)
     val dataset
 
     output:
@@ -52,29 +52,40 @@ process notify_step {
     script:
     // Emoji as a Slack shortcode rather than raw UTF-8: it renders the same and
     // keeps the payload ASCII.
-    def positions = n_positions > 1 ? " (${n_positions} positions)" : ""
-    // No --ping. Step messages post silently so the @-mention on the run-end
-    // message keeps meaning "this needs you".
+    //
+    // No position count here. The plate has the same number of positions for
+    // every step, so repeating it six times says nothing new — it is reported
+    // once, in the run-start message.
+    //
+    // No --ping either. Step messages post silently so the @-mention on the
+    // run-end message keeps meaning "this needs you".
+    //
     // `|| true` so nothing the notifier does can fail the task, independent of
     // the errorStrategy.
     """
     biahub nf notify \\
         --level good \\
-        --title ":white_check_mark: ${dataset} — ${step} complete [${index}]${positions}" \\
+        --title ":white_check_mark: ${dataset} — ${step} complete [${index}]" \\
         --detail "output: ${output_zarr}" || true
     """
 }
 
-// Announce the run before any work is submitted.
+// Announce the run.
 //
 // This doubles as a webhook smoke test: without it the first Slack message is
 // the completion one, hours or days later, so a revoked webhook would be
 // discovered far too late to be useful.
 //
+// Sent once the position count is known rather than at graph-construction time,
+// because the count comes from the list_positions task (about 40s) and the
+// message reports it. The consequence to know: a config error that kills
+// list_positions itself produces no start message — only the failure message
+// from onComplete.
+//
 // Rate-limited by key, because debugging a config produces relaunch storms —
 // five launches inside ten minutes is an observed pattern, which would otherwise
 // be five notifications.
-def notify_run_start(dataset, pipeline) {
+def notify_run_start(dataset, pipeline, n_positions, steps) {
     // Say once, at launch, that Slack is not configured. Without a webhook every
     // message still prints and every exit status is still 0, but only the
     // run-level messages reach the console: notify_step runs as a task, so its
@@ -89,10 +100,12 @@ def notify_run_start(dataset, pipeline) {
     }
 
     def detail = [
-        "pipeline: ${pipeline}",
-        "input:  ${params.input}",
-        "output: ${params.output}",
-        "host:   ${java.net.InetAddress.localHost.hostName}",
+        "pipeline:  ${pipeline}",
+        "positions: ${n_positions}",
+        "steps:     ${steps.size()} — ${steps.join(', ')}",
+        "input:     ${params.input}",
+        "output:    ${params.output}",
+        "host:      ${java.net.InetAddress.localHost.hostName}",
         // `as int` because a param given on the command line arrives as a
         // String, and the String "0" is truthy in Groovy (same trap as
         // queueSize in nextflow.config). `?: 0` because a bare `as int` on an

--- a/nextflow/nextflow.config
+++ b/nextflow/nextflow.config
@@ -56,6 +56,22 @@ process {
         memory = '8 GB'
     }
 
+    // Slack notifications (modules/notify.nf). Pinned by name rather than by a
+    // label because the slurm profile's `withLabel: 'cpu_local'` block would
+    // otherwise apply, and six 12 GB local tasks would contend with the init
+    // steps for the head node.
+    //
+    // `errorStrategy = 'ignore'` is load-bearing, not defensive: the closure in
+    // this block's `errorStrategy` above terminates the whole run on any
+    // non-signal exit, and a selector beats a process-body directive. Without
+    // this, a Slack outage could kill a two-day reconstruction.
+    withName: 'notify_step' {
+        executor      = 'local'
+        cpus          = 1
+        memory        = '256 MB'
+        errorStrategy = 'ignore'
+    }
+
     // NOTE: labels 'cpu' and 'gpu' intentionally have NO withLabel body here.
     // Each module sets cpus/memory/time in its own process body (dynamically from
     // the init step's RESOURCES payload). A withLabel selector in config overrides
@@ -144,6 +160,18 @@ trace {
     enabled   = true
     overwrite = true
     file      = "${params.output}/nextflow/trace.txt"
+
+    // The 14 default fields plus `attempt`, so a retried position is visible in
+    // trace.txt itself rather than having to be inferred from duplicate `name`
+    // rows or grepped out of `.nextflow.log`.
+    //
+    // `fields` REPLACES the default list, so the defaults are respelled here in
+    // their original order and `attempt` is APPENDED. Keeping columns 1-14 where
+    // they were means the field positions everything else relies on ($4 name,
+    // $5 status, $6 exit) do not move.
+    //
+    // Hash-neutral: trace is an observer and takes no part in task hashing.
+    fields = 'task_id,hash,native_id,name,status,exit,submit,duration,realtime,%cpu,peak_rss,peak_vmem,rchar,wchar,attempt'
 }
 
 timeline {

--- a/tests/test_cli/test_nf_cli.py
+++ b/tests/test_cli/test_nf_cli.py
@@ -125,9 +125,9 @@ def test_notify_operator_flag_names_who_launched_the_run(monkeypatch):
     )
 
     assert result.exit_code == 0, result.output
-    assert "launched by: Ivan Ivanov (ivan.ivanov)" in result.output
+    assert "operator: Ivan Ivanov (ivan.ivanov)" in result.output
     # The operator line goes first, before the rest of the detail.
-    assert result.output.index("launched by:") < result.output.index("input: /x")
+    assert result.output.index("operator:") < result.output.index("input: /x")
 
 
 def test_notify_without_operator_flag_omits_it(monkeypatch):
@@ -137,4 +137,4 @@ def test_notify_without_operator_flag_omits_it(monkeypatch):
     result = runner.invoke(cli, ["nf", "notify", "--title", "started"])
 
     assert result.exit_code == 0, result.output
-    assert "launched by" not in result.output
+    assert "operator:" not in result.output

--- a/tests/test_cli/test_nf_cli.py
+++ b/tests/test_cli/test_nf_cli.py
@@ -125,9 +125,9 @@ def test_notify_operator_flag_names_who_launched_the_run(monkeypatch):
     )
 
     assert result.exit_code == 0, result.output
-    assert "started by: Ivan Ivanov (ivan.ivanov)" in result.output
+    assert "launched by: Ivan Ivanov (ivan.ivanov)" in result.output
     # The operator line goes first, before the rest of the detail.
-    assert result.output.index("started by:") < result.output.index("input: /x")
+    assert result.output.index("launched by:") < result.output.index("input: /x")
 
 
 def test_notify_without_operator_flag_omits_it(monkeypatch):
@@ -137,4 +137,4 @@ def test_notify_without_operator_flag_omits_it(monkeypatch):
     result = runner.invoke(cli, ["nf", "notify", "--title", "started"])
 
     assert result.exit_code == 0, result.output
-    assert "started by" not in result.output
+    assert "launched by" not in result.output

--- a/tests/test_cli/test_nf_cli.py
+++ b/tests/test_cli/test_nf_cli.py
@@ -1,6 +1,9 @@
+import json
+
 from click.testing import CliRunner
 
 from biahub.cli.main import cli
+from biahub.utils import notify as notify_utils
 
 
 def test_list_positions(example_plate):
@@ -16,3 +19,96 @@ def test_list_positions(example_plate):
     assert "A/1/0" in lines
     assert "B/1/0" in lines
     assert "B/2/0" in lines
+
+
+def test_notify_dry_run_renders_payload_without_posting(monkeypatch):
+    monkeypatch.setenv("BIAHUB_SLACK_ID", "U024BE7LH")
+    monkeypatch.delenv("BIAHUB_SLACK_WEBHOOK", raising=False)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        [
+            "nf",
+            "notify",
+            "--title",
+            "2026_07_14_A549 — deskew complete (2/6)",
+            "--detail",
+            "output: /hpc/x.zarr",
+            "--level",
+            "good",
+            "--ping",
+            "--dry-run",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+
+    payload = json.loads(result.output)
+    assert payload["text"] == "<@U024BE7LH> 2026_07_14_A549 — deskew complete (2/6)"
+    assert payload["attachments"][0]["color"] == "#2eb886"
+
+
+def test_notify_exits_zero_without_a_webhook(monkeypatch):
+    # The pipeline calls this on every step; a Slack-less environment must never
+    # fail a task.
+    monkeypatch.delenv("BIAHUB_SLACK_WEBHOOK", raising=False)
+
+    runner = CliRunner()
+    result = runner.invoke(cli, ["nf", "notify", "--title", "hello"])
+
+    assert result.exit_code == 0, result.output
+    assert "hello" in result.output
+
+
+def test_notify_reads_detail_from_a_file(tmp_path, monkeypatch):
+    # An error report contains backticks, quotes and newlines, so the pipeline
+    # passes it by path rather than on the command line.
+    monkeypatch.delenv("BIAHUB_SLACK_WEBHOOK", raising=False)
+    report = tmp_path / "report.txt"
+    report.write_text('Command error:\n  raise ValueError("bad `config`")\n')
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        [
+            "nf",
+            "notify",
+            "--title",
+            "failed",
+            "--detail-file",
+            str(report),
+            "--level",
+            "error",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "bad `config`" in result.output
+
+
+def test_notify_min_interval_suppresses_a_repeat(tmp_path, monkeypatch):
+    # Debugging a config produces relaunch storms; run-start must not ping twice.
+    monkeypatch.delenv("BIAHUB_SLACK_WEBHOOK", raising=False)
+    state = tmp_path / "state"
+    notify_utils.record_sent(str(state), "run-start")
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        [
+            "nf",
+            "notify",
+            "--title",
+            "launched",
+            "--key",
+            "run-start",
+            "--min-interval",
+            "900",
+            "--state-dir",
+            str(state),
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "skipping" in result.output
+    assert "launched" not in result.output

--- a/tests/test_cli/test_nf_cli.py
+++ b/tests/test_cli/test_nf_cli.py
@@ -112,3 +112,29 @@ def test_notify_min_interval_suppresses_a_repeat(tmp_path, monkeypatch):
     assert result.exit_code == 0, result.output
     assert "skipping" in result.output
     assert "launched" not in result.output
+
+
+def test_notify_operator_flag_names_who_launched_the_run(monkeypatch):
+    monkeypatch.delenv("BIAHUB_SLACK_WEBHOOK", raising=False)
+    monkeypatch.setattr(notify_utils, "operator_label", lambda: "Ivan Ivanov (ivan.ivanov)")
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        ["nf", "notify", "--title", "started", "--detail", "input: /x", "--operator"],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "started by: Ivan Ivanov (ivan.ivanov)" in result.output
+    # The operator line goes first, before the rest of the detail.
+    assert result.output.index("started by:") < result.output.index("input: /x")
+
+
+def test_notify_without_operator_flag_omits_it(monkeypatch):
+    monkeypatch.delenv("BIAHUB_SLACK_WEBHOOK", raising=False)
+
+    runner = CliRunner()
+    result = runner.invoke(cli, ["nf", "notify", "--title", "started"])
+
+    assert result.exit_code == 0, result.output
+    assert "started by" not in result.output

--- a/tests/test_cli/test_nf_cli.py
+++ b/tests/test_cli/test_nf_cli.py
@@ -44,7 +44,7 @@ def test_notify_dry_run_renders_payload_without_posting(monkeypatch):
     assert result.exit_code == 0, result.output
 
     payload = json.loads(result.output)
-    assert payload["text"] == "<@U024BE7LH> 2026_07_14_A549 — deskew complete (2/6)"
+    assert payload["text"] == "2026_07_14_A549 — deskew complete (2/6) <@U024BE7LH>"
     assert payload["attachments"][0]["color"] == "#2eb886"
 
 

--- a/tests/test_utils/test_notify.py
+++ b/tests/test_utils/test_notify.py
@@ -365,3 +365,56 @@ def test_operator_label_survives_an_unresolvable_account(monkeypatch):
     monkeypatch.delenv("USER", raising=False)
     monkeypatch.delenv("LOGNAME", raising=False)
     assert notify.operator_label() == "unknown"
+
+
+def test_append_log_records_a_delivery_problem(tmp_path):
+    log_file = tmp_path / "nested" / "notify.log"
+
+    notify.append_log(str(log_file), "post failed (HTTP 404)")
+
+    assert "post failed (HTTP 404)" in log_file.read_text()
+
+
+def test_append_log_survives_an_unwritable_path(tmp_path):
+    blocker = tmp_path / "blocked"
+    blocker.write_text("not a directory")
+
+    notify.append_log(str(blocker / "notify.log"), "anything")
+
+
+def test_send_records_a_failed_post_to_the_log_file(monkeypatch, tmp_path, capsys):
+    # The run-end message is sent during JVM shutdown, where the caller cannot
+    # capture our stdout, so the notifier must write its own record.
+    monkeypatch.setenv(notify.WEBHOOK_ENV, "http://hook")
+    monkeypatch.setattr(
+        notify.urllib.request,
+        "urlopen",
+        lambda *a, **k: (_ for _ in ()).throw(_http_error(404, b"no_service")),
+    )
+    log_file = tmp_path / "notify.log"
+
+    notify.send("2026_07_14 — failed", level="error", log_file=str(log_file))
+
+    recorded = log_file.read_text()
+    assert "no_service" in recorded
+    assert "2026_07_14 — failed" in recorded
+
+
+def test_send_records_a_missing_webhook_to_the_log_file(monkeypatch, tmp_path):
+    monkeypatch.delenv(notify.WEBHOOK_ENV, raising=False)
+    log_file = tmp_path / "notify.log"
+
+    notify.send("2026_07_14 — done", log_file=str(log_file))
+
+    assert notify.WEBHOOK_ENV in log_file.read_text()
+
+
+def test_send_stays_quiet_in_the_log_on_success(monkeypatch, tmp_path):
+    monkeypatch.setenv(notify.WEBHOOK_ENV, "http://hook")
+    monkeypatch.setattr(notify.urllib.request, "urlopen", lambda *a, **k: _FakeResponse())
+    log_file = tmp_path / "notify.log"
+
+    ok, _ = notify.send("fine", log_file=str(log_file))
+
+    assert ok
+    assert not log_file.exists()

--- a/tests/test_utils/test_notify.py
+++ b/tests/test_utils/test_notify.py
@@ -70,7 +70,8 @@ def test_build_payload_puts_mention_in_text_not_attachment():
         "2026_07_14 — done", detail="stats", level="good", mention="<@U024BE7LH>"
     )
 
-    assert payload["text"].startswith("<@U024BE7LH> ")
+    # Mention last, so the message opens with its emoji and dataset.
+    assert payload["text"] == "2026_07_14 — done <@U024BE7LH>"
     assert "U024BE7LH" not in json.dumps(payload["attachments"])
 
 

--- a/tests/test_utils/test_notify.py
+++ b/tests/test_utils/test_notify.py
@@ -319,3 +319,49 @@ def test_record_sent_survives_an_unwritable_state_dir(tmp_path):
     blocker.write_text("not a directory")
 
     notify.record_sent(str(blocker / "nested"), "run-start")
+
+
+def test_operator_label_uses_the_account_full_name(monkeypatch):
+    import pwd
+
+    entry = pwd.struct_passwd(
+        ("ivan.ivanov", "*", 5011, 5011, "Ivan Ivanov", "/home/ivan.ivanov", "/bin/bash")
+    )
+    monkeypatch.setattr(pwd, "getpwuid", lambda _uid: entry)
+
+    assert notify.operator_label() == "Ivan Ivanov (ivan.ivanov)"
+
+
+def test_operator_label_takes_only_the_name_from_gecos(monkeypatch):
+    # GECOS is comma-separated: full name, room, work phone, home phone.
+    import pwd
+
+    entry = pwd.struct_passwd(
+        ("jdoe", "*", 1, 1, "Jane Doe,Bldg 4,x1234,", "/home/jdoe", "/bin/bash")
+    )
+    monkeypatch.setattr(pwd, "getpwuid", lambda _uid: entry)
+
+    assert notify.operator_label() == "Jane Doe (jdoe)"
+
+
+def test_operator_label_falls_back_to_the_login_name(monkeypatch):
+    import pwd
+
+    entry = pwd.struct_passwd(("svc-runner", "*", 1, 1, "", "/home/svc", "/bin/bash"))
+    monkeypatch.setattr(pwd, "getpwuid", lambda _uid: entry)
+
+    assert notify.operator_label() == "svc-runner"
+
+
+def test_operator_label_survives_an_unresolvable_account(monkeypatch):
+    # A container or a UID with no passwd entry must not break the notification.
+    import pwd
+
+    monkeypatch.setattr(pwd, "getpwuid", lambda _uid: (_ for _ in ()).throw(KeyError("uid")))
+    monkeypatch.setenv("USER", "fallback.user")
+
+    assert notify.operator_label() == "fallback.user"
+
+    monkeypatch.delenv("USER", raising=False)
+    monkeypatch.delenv("LOGNAME", raising=False)
+    assert notify.operator_label() == "unknown"

--- a/tests/test_utils/test_notify.py
+++ b/tests/test_utils/test_notify.py
@@ -1,0 +1,321 @@
+import json
+import urllib.error
+
+import pytest
+
+from biahub.utils import notify
+
+
+@pytest.mark.parametrize(
+    "raw, expected",
+    [
+        ("U024BE7LH", "<@U024BE7LH>"),
+        ("<@U024BE7LH>", "<@U024BE7LH>"),
+        ("@U024BE7LH", "<@U024BE7LH>"),
+        ("  U024BE7LH  ", "<@U024BE7LH>"),
+        ("W012ABC345", "<@W012ABC345>"),
+        # A display name never pings via the API, so it must be rejected rather
+        # than posted as literal text that silently notifies nobody.
+        ("@ivan.ivanov", None),
+        ("ivan", None),
+        ("U024", None),
+        ("u024be7lh", None),
+        ("", None),
+        (None, None),
+    ],
+)
+def test_normalize_slack_id(raw, expected):
+    assert notify.normalize_slack_id(raw) == expected
+
+
+def test_clean_and_truncate_keeps_the_tail():
+    text = "\n".join(f"line {i}" for i in range(1000))
+    result = notify.clean_and_truncate(text, max_chars=100)
+
+    assert result.endswith("line 999")
+    assert "truncated" in result
+    assert len(result) <= 100 + 60
+
+
+def test_clean_and_truncate_short_text_is_untouched():
+    assert notify.clean_and_truncate("boom", max_chars=100) == "boom"
+    assert notify.clean_and_truncate("") == ""
+
+
+def test_clean_and_truncate_strips_ansi_and_carriage_returns():
+    # tqdm/cellpose progress output rewrites one line with \r and colors it.
+    noisy = "\x1b[32m10%\x1b[0m\r\x1b[32m50%\x1b[0m\rdone"
+    assert notify.clean_and_truncate(noisy) == "10%\n50%\ndone"
+
+
+def test_clean_and_truncate_neutralizes_code_fence():
+    # A literal fence in the detail would close our code block early.
+    assert "```" not in notify.clean_and_truncate("before ``` after")
+
+
+def test_clean_and_truncate_does_not_split_multibyte_characters():
+    result = notify.clean_and_truncate("µ" * 500, max_chars=100)
+    assert "�" not in result
+    result.encode("utf-8")
+
+
+def test_build_payload_info_level_is_plain_text():
+    # Byte-identical to what the shell predecessor sent, so existing agent-driven
+    # call sites are unaffected by the richer formatting.
+    assert notify.build_payload("hello") == {"text": "hello"}
+
+
+def test_build_payload_puts_mention_in_text_not_attachment():
+    payload = notify.build_payload(
+        "2026_07_14 — done", detail="stats", level="good", mention="<@U024BE7LH>"
+    )
+
+    assert payload["text"].startswith("<@U024BE7LH> ")
+    assert "U024BE7LH" not in json.dumps(payload["attachments"])
+
+
+@pytest.mark.parametrize(
+    "level, color",
+    [("good", "#2eb886"), ("warn", "#daa038"), ("error", "#d40e0d")],
+)
+def test_build_payload_colors_by_level(level, color):
+    payload = notify.build_payload("t", detail="d", level=level)
+    assert payload["attachments"][0]["color"] == color
+    assert payload["attachments"][0]["text"] == "```d```"
+
+
+def test_build_payload_collapses_multiline_title():
+    payload = notify.build_payload("a\nb   c")
+    assert payload["text"] == "a b c"
+
+
+def test_build_payload_truncates_long_title():
+    payload = notify.build_payload("x" * 500)
+    assert len(payload["text"]) == notify.MAX_TITLE_CHARS
+
+
+class _FakeResponse:
+    status = 200
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+
+def _http_error(code, body=b"invalid_payload", headers=None):
+    return urllib.error.HTTPError(
+        "http://example", code, "err", headers or {}, _BytesBody(body)
+    )
+
+
+class _BytesBody:
+    def __init__(self, body):
+        self._body = body
+
+    def read(self):
+        return self._body
+
+    def close(self):
+        # HTTPError treats its fp as a file object and closes it on teardown.
+        pass
+
+
+def test_post_with_retry_succeeds_first_try(monkeypatch):
+    calls = []
+    monkeypatch.setattr(
+        notify.urllib.request, "urlopen", lambda *a, **k: calls.append(1) or _FakeResponse()
+    )
+
+    ok, status = notify.post_with_retry("http://hook", {"text": "x"}, sleep=lambda _: None)
+
+    assert ok
+    assert status == "HTTP 200"
+    assert len(calls) == 1
+
+
+@pytest.mark.parametrize("code", sorted(notify.RETRYABLE_STATUSES))
+def test_post_with_retry_retries_transient_statuses(monkeypatch, code):
+    calls = []
+
+    def fail(*a, **k):
+        calls.append(1)
+        raise _http_error(code)
+
+    monkeypatch.setattr(notify.urllib.request, "urlopen", fail)
+
+    ok, _ = notify.post_with_retry("http://hook", {"text": "x"}, sleep=lambda _: None)
+
+    assert not ok
+    assert len(calls) == 3
+
+
+@pytest.mark.parametrize("code", [400, 403, 404, 410])
+def test_post_with_retry_does_not_retry_permanent_rejections(monkeypatch, code):
+    # A revoked webhook or malformed payload cannot be fixed by repeating the
+    # request; retrying only delays the caller.
+    calls = []
+
+    def fail(*a, **k):
+        calls.append(1)
+        raise _http_error(code, b"no_service")
+
+    monkeypatch.setattr(notify.urllib.request, "urlopen", fail)
+
+    ok, status = notify.post_with_retry("http://hook", {"text": "x"}, sleep=lambda _: None)
+
+    assert not ok
+    assert len(calls) == 1
+    assert "no_service" in status
+
+
+def test_post_with_retry_recovers_after_transient_failure(monkeypatch):
+    attempts = []
+
+    def flaky(*a, **k):
+        attempts.append(1)
+        if len(attempts) == 1:
+            raise _http_error(503, b"service_unavailable")
+        return _FakeResponse()
+
+    monkeypatch.setattr(notify.urllib.request, "urlopen", flaky)
+
+    ok, _ = notify.post_with_retry("http://hook", {"text": "x"}, sleep=lambda _: None)
+
+    assert ok
+    assert len(attempts) == 2
+
+
+def test_post_with_retry_honours_retry_after(monkeypatch):
+    slept = []
+    monkeypatch.setattr(
+        notify.urllib.request,
+        "urlopen",
+        lambda *a, **k: (_ for _ in ()).throw(_http_error(429, b"rate", {"Retry-After": "7"})),
+    )
+
+    notify.post_with_retry("http://hook", {"text": "x"}, sleep=slept.append)
+
+    assert slept and slept[0] == 7.0
+
+
+def test_post_with_retry_caps_retry_after(monkeypatch):
+    slept = []
+    monkeypatch.setattr(
+        notify.urllib.request,
+        "urlopen",
+        lambda *a, **k: (_ for _ in ()).throw(
+            _http_error(429, b"rate", {"Retry-After": "99999"})
+        ),
+    )
+
+    notify.post_with_retry("http://hook", {"text": "x"}, sleep=slept.append)
+
+    assert slept[0] == notify.RETRY_AFTER_CAP
+
+
+def test_post_with_retry_masks_the_webhook_in_transport_errors(monkeypatch):
+    secret = "https://hooks.slack.com/services/T0/B0/supersecret"
+
+    def fail(*a, **k):
+        raise urllib.error.URLError(f"cannot reach {secret}")
+
+    monkeypatch.setattr(notify.urllib.request, "urlopen", fail)
+
+    _, status = notify.post_with_retry(secret, {"text": "x"}, sleep=lambda _: None)
+
+    assert "supersecret" not in status
+    assert "<webhook>" in status
+
+
+def test_send_without_webhook_prints_and_reports_unset(monkeypatch, capsys):
+    monkeypatch.delenv(notify.WEBHOOK_ENV, raising=False)
+
+    ok, status = notify.send("2026_07_14 — done", detail="stats", level="good")
+
+    assert not ok
+    assert notify.WEBHOOK_ENV in status
+    output = capsys.readouterr().out
+    assert "2026_07_14 — done" in output
+    assert "stats" in output
+
+
+def test_send_reads_slack_id_from_environment(monkeypatch, capsys):
+    monkeypatch.setenv(notify.SLACK_ID_ENV, "U024BE7LH")
+    monkeypatch.delenv(notify.WEBHOOK_ENV, raising=False)
+
+    notify.send("t", ping=True)
+
+    assert "<@U024BE7LH>" in capsys.readouterr().out
+
+
+def test_send_without_ping_does_not_mention(monkeypatch, capsys):
+    monkeypatch.setenv(notify.SLACK_ID_ENV, "U024BE7LH")
+    monkeypatch.delenv(notify.WEBHOOK_ENV, raising=False)
+
+    notify.send("t", ping=False)
+
+    assert "U024BE7LH" not in capsys.readouterr().out
+
+
+def test_send_warns_on_malformed_slack_id(monkeypatch, capsys):
+    monkeypatch.setenv(notify.SLACK_ID_ENV, "@ivan")
+    monkeypatch.delenv(notify.WEBHOOK_ENV, raising=False)
+
+    notify.send("t", ping=True)
+
+    assert "malformed Slack ID" in capsys.readouterr().out
+
+
+def test_send_dry_run_does_not_post(monkeypatch, capsys):
+    monkeypatch.setenv(notify.WEBHOOK_ENV, "http://hook")
+    monkeypatch.setattr(
+        notify.urllib.request,
+        "urlopen",
+        lambda *a, **k: pytest.fail("dry run must not post"),
+    )
+
+    ok, status = notify.send("t", dry_run=True)
+
+    assert not ok
+    assert status == "dry run"
+    assert json.loads(capsys.readouterr().out)["text"] == "t"
+
+
+def test_send_prints_the_message_when_delivery_fails(monkeypatch, capsys):
+    monkeypatch.setenv(notify.WEBHOOK_ENV, "http://hook")
+    monkeypatch.setattr(
+        notify.urllib.request,
+        "urlopen",
+        lambda *a, **k: (_ for _ in ()).throw(_http_error(404, b"no_service")),
+    )
+
+    ok, _ = notify.send("2026_07_14 — failed", level="error")
+
+    assert not ok
+    output = capsys.readouterr().out
+    assert "2026_07_14 — failed" in output
+    assert "Slack post failed" in output
+
+
+def test_should_send_and_record_sent(tmp_path):
+    state = str(tmp_path / "state")
+
+    assert notify.should_send(state, "run-start", 900)
+
+    notify.record_sent(state, "run-start")
+    assert not notify.should_send(state, "run-start", 900)
+
+    # A zero interval disables rate limiting entirely.
+    assert notify.should_send(state, "run-start", 0)
+    # An unrelated key is unaffected.
+    assert notify.should_send(state, "run-end", 900)
+
+
+def test_record_sent_survives_an_unwritable_state_dir(tmp_path):
+    # State is an optimization; losing it must not raise into the pipeline.
+    blocker = tmp_path / "blocked"
+    blocker.write_text("not a directory")
+
+    notify.record_sent(str(blocker / "nested"), "run-start")

--- a/uv.lock
+++ b/uv.lock
@@ -357,7 +357,7 @@ requires-dist = [
     { name = "dask", extras = ["array"] },
     { name = "humanize" },
     { name = "imageio-ffmpeg" },
-    { name = "iohub", git = "https://github.com/czbiohub-sf/iohub?rev=719ba12c6932b23d84de86d87168777520c290d9" },
+    { name = "iohub", specifier = ">=0.3.11" },
     { name = "largestinteriorrectangle" },
     { name = "llvmlite", specifier = ">=0.41.0" },
     { name = "markdown" },
@@ -865,34 +865,40 @@ name = "cryptography"
 version = "50.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
+    { name = "cffi", marker = "platform_python_implementation != 'PyPy' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/de/41/6cbdcf9142d00fe82836fbb51e503e58088575cf7a0fe1dbff6695bf0840/cryptography-50.0.0.tar.gz", hash = "sha256:eeac2acb5a20ed25e0ad6d1df9891a520b78b404266b6d11778f25d5d691a6c9", size = 880201, upload-time = "2026-07-31T14:25:10.11Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/57/ef/8f2df13c7216bcad3e1c74e07f6e193d93e998e114f524a53877c9af27ad/cryptography-50.0.0-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:fd9192b7b70c573d7f214eb1ae35e00d359f6f5e4b27c7e21e30de1fc6204645", size = 4719554, upload-time = "2026-07-31T14:23:35.611Z" },
     { url = "https://files.pythonhosted.org/packages/d9/41/029086c34d91052fc3b88bcc8056f709a7c915c7a23b235a54eb800b1c97/cryptography-50.0.0-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:06a32a980526a6ab9a4b9bf8f7385800791e2bb960903cb6b530e4817509a3b7", size = 4702130, upload-time = "2026-07-31T14:23:37.635Z" },
     { url = "https://files.pythonhosted.org/packages/7d/ff/b6ce0954962e7f7b969f850a883744197bb3910bdfd7b6da162eab7d9f68/cryptography-50.0.0-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:a1b30560f2acc95aa8b2e06e716a13dbfc97314747b80d9707e307f77b40d6b3", size = 4725244, upload-time = "2026-07-31T14:23:39.471Z" },
+    { url = "https://files.pythonhosted.org/packages/06/1e/63a1027cb7fec360a182208e1b7767d5aa1fe57be3d6aa856e69a321edc0/cryptography-50.0.0-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:8d89f3976b10b4ce31118de72329025f70d2c6ead14a8217c5514dd2c6d5a78f", size = 5342265, upload-time = "2026-07-31T14:23:41.286Z" },
     { url = "https://files.pythonhosted.org/packages/6b/72/a1116d683a6d7ece94590013882515de087edf9ef0e6292aae615a44df73/cryptography-50.0.0-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:b42a28c1844fd9de8f3f7d540e36b66f3a9c83fceac7170ebc7a6a19edd9dcae", size = 4734609, upload-time = "2026-07-31T14:23:43.139Z" },
     { url = "https://files.pythonhosted.org/packages/15/37/36a9c479bbe49acea2636c7fd3360d20f7b7e079c300352011c44850b181/cryptography-50.0.0-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:900131fafd8aead39ac7dd3a7e833be754c17a95cfd91221636949fe4eb0aa8a", size = 4356517, upload-time = "2026-07-31T14:23:44.939Z" },
     { url = "https://files.pythonhosted.org/packages/32/98/8a151d64367204cbc63ec65d37502f1d9c53cf4bfc6ec3c532614dbec60d/cryptography-50.0.0-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:07949c449a1abcf60d1ee6e88956d89404c7df3c8258f46589e912988e551987", size = 4724529, upload-time = "2026-07-31T14:23:46.93Z" },
+    { url = "https://files.pythonhosted.org/packages/22/f6/ec13b470172126464a86bf54d2294a46d29837fc51ba3e45d4047946fb5e/cryptography-50.0.0-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:f89831ef99dd7dd169ab06d63a831adb9e20a87aac6d380266bbda5823349169", size = 5299852, upload-time = "2026-07-31T14:23:48.851Z" },
     { url = "https://files.pythonhosted.org/packages/da/3a/f05e32c99d440c9bb891ea0e36c9091891e36be5a9a87ab2ee6ea20729f6/cryptography-50.0.0-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:82148ec5bddac30b51a5b3c1945075f896fa022cb93f8e4a01e9f6ee95292c5f", size = 4734462, upload-time = "2026-07-31T14:23:50.861Z" },
     { url = "https://files.pythonhosted.org/packages/ca/dc/bd72b26be8953f80625f63151efd38eee71c76ca6cf591c08ff34615a79e/cryptography-50.0.0-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:1489e263a8048bb8b6a8bac662eb2d402ea5d2b7b4699b72f385f1e2772db105", size = 4852708, upload-time = "2026-07-31T14:23:52.715Z" },
     { url = "https://files.pythonhosted.org/packages/27/20/c930314a2ab476d15dec966ec87e2e9637bb02b06106b12c0396c57bb603/cryptography-50.0.0-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:7cec5b856506da6defb290f30c9ee687d5f5e8cb0bd3f6459dde43b0b4fa40ef", size = 5004179, upload-time = "2026-07-31T14:23:54.887Z" },
     { url = "https://files.pythonhosted.org/packages/d4/67/91eb047e69c5e845f2f14b8a2e4a1aab0f283cb885531e9e22c8adb176bc/cryptography-50.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:19736989797678c6af1e55cd49055cdbcb55d8f6b5583ac5335f933aba9101dc", size = 4700648, upload-time = "2026-07-31T14:24:00.702Z" },
     { url = "https://files.pythonhosted.org/packages/30/82/85f0f7425c856b9f96459411eb12e74ef72df9caf6f8f15bf23a33ff131f/cryptography-50.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:80b63928fa35083b33966ce1efb70e5b9607181e49dcd1c22c8c005e319f667f", size = 4682442, upload-time = "2026-07-31T14:24:02.538Z" },
     { url = "https://files.pythonhosted.org/packages/1a/28/b555a365adff1cca2fbe7b9e487d68a40de6bc67ff2cb587473eb43de0e7/cryptography-50.0.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:d58c3db7cd6eed54e6c06744db55456b65ebd7492ddeae9c1e93cfca7aa857d3", size = 4707596, upload-time = "2026-07-31T14:24:04.394Z" },
+    { url = "https://files.pythonhosted.org/packages/72/d8/f52538140cc719df62a01cf87d1c7142318d235817109d6f4054d7c352d6/cryptography-50.0.0-cp314-cp314t-manylinux_2_28_ppc64le.whl", hash = "sha256:df2a58a472f332225671c35b0a830208b86d004f82baa8530fa3782c85646533", size = 5314552, upload-time = "2026-07-31T14:24:06.31Z" },
     { url = "https://files.pythonhosted.org/packages/38/14/6120e5bd7c5aa022ad15424ba4d5c5269d0d9448ed4d55e492ea91e3c1c4/cryptography-50.0.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:11b74db56cdbe3cdee6e3f6982ecb70334fa10dce99ed58bf7894aaaa3b2a037", size = 4717113, upload-time = "2026-07-31T14:24:08.349Z" },
     { url = "https://files.pythonhosted.org/packages/fa/71/190bf38c3ee2e0f8efc9860ae100c9df4169742eef274b91e7aa1cb133b9/cryptography-50.0.0-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:f59e38625469987d7ef6d495323c55e7db6c212eaf6112267e0d3b565a2e9c9f", size = 4338580, upload-time = "2026-07-31T14:24:10.227Z" },
     { url = "https://files.pythonhosted.org/packages/3a/63/504ccfbbe61fd8aa983f7f146399cdf034c72c2fc55f5b2dfdcdcdb20c99/cryptography-50.0.0-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:ecfed7367f965a0328cfbdd70da860f15441f002f613185668c6e6ebf5a0ac11", size = 4707038, upload-time = "2026-07-31T14:24:12.169Z" },
+    { url = "https://files.pythonhosted.org/packages/01/77/2cf79bbfc4d12ca106437a6e170d6aaa01a373e93093118aaaef0e801bd4/cryptography-50.0.0-cp314-cp314t-manylinux_2_34_ppc64le.whl", hash = "sha256:9aa87839c383bdbab6ef865787a1fb877af8dd03464c4400322726feaaadfc6d", size = 5273110, upload-time = "2026-07-31T14:24:14.38Z" },
     { url = "https://files.pythonhosted.org/packages/e5/45/8aae2972c520145377ea3559a605a899bebe227bf070b33cdb445929a9b9/cryptography-50.0.0-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:6ba6a53445bd3cfa809ef3ef5f1589aa6ba08784a1d962bf47d0940e871dab1c", size = 4716439, upload-time = "2026-07-31T14:24:16.415Z" },
     { url = "https://files.pythonhosted.org/packages/7b/20/4fe50b619a48c2525cc46e2dbc1ac490708d704be5d467bdaac6dc955682/cryptography-50.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:3f5735ffe4996d28b809371756219f5354864902a3b9e7c0b9ee87041209fc9c", size = 4837383, upload-time = "2026-07-31T14:24:18.553Z" },
     { url = "https://files.pythonhosted.org/packages/92/91/3a31366e183343d3703f8995c095f5734676bd6938118047e50fcf279eb4/cryptography-50.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:1b4a266766514614f8aa60416e71f2fc6e575d36e7bdc90f644fadb2f4b75b95", size = 4985772, upload-time = "2026-07-31T14:24:20.385Z" },
     { url = "https://files.pythonhosted.org/packages/ff/c6/7a6202a534e32103a285b7834a120869557fe198d51d7cfe59754c8bda9c/cryptography-50.0.0-cp39-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:910e1d2668e7de9648f2bcee30e180db2a6b15c30f887d7c4c93ddf96e3992e3", size = 4745252, upload-time = "2026-07-31T14:24:26.118Z" },
     { url = "https://files.pythonhosted.org/packages/85/4f/0fa8c2f4428198f15d9ff8d63400e27afbf94ce833f6108da1eb3753f945/cryptography-50.0.0-cp39-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:a91296cb61e8df6f86d0c19cc4068228da256bf59bf86049fbd821084565327f", size = 4728939, upload-time = "2026-07-31T14:24:27.994Z" },
     { url = "https://files.pythonhosted.org/packages/d1/63/54dd723490ba2dc09b299682c10b38db38f159728bcaae8c591b8af2f22d/cryptography-50.0.0-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:e722f16708d854fe924790e051061f6704a472c3bac347b6fd88033ea8dd0dc5", size = 4748483, upload-time = "2026-07-31T14:24:30.254Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/dd/7c77d26285cc7f6991efce64a0f5b4f9383bfa5dd8c5033003eaf7db4cdb/cryptography-50.0.0-cp39-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:d764dcf130c428ef66786f866dd750f53182bc608813489915e9fc106bb0c82f", size = 5367599, upload-time = "2026-07-31T14:24:32.457Z" },
     { url = "https://files.pythonhosted.org/packages/46/c9/f60aed34c013f317f92817b6c171c2d22a78270fa41109bd4b08af26b194/cryptography-50.0.0-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:105110f43a471dbd0060b9c9516cb8a6a79233631a04cc2ba16f28323ac6e025", size = 4762647, upload-time = "2026-07-31T14:24:34.599Z" },
     { url = "https://files.pythonhosted.org/packages/be/f3/f9a0173b139372c3a48ed98154b45cc6b9de17c789d5ab552e621c293609/cryptography-50.0.0-cp39-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:828743d939e9629bc267b8e2d08d8bb67cd4319c771a33d4b18b22dd8fb7440a", size = 4385197, upload-time = "2026-07-31T14:24:36.647Z" },
     { url = "https://files.pythonhosted.org/packages/d8/36/83bb81f6e569bc38e1e4a7bc80f29b46bb9601920bc455fc8e888f5d5742/cryptography-50.0.0-cp39-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:2a8183b489dc1f7f80f135780fadc1108f14b31b8a40411c7a5b17425f65f28b", size = 4748095, upload-time = "2026-07-31T14:24:39.493Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/16/d3008eff98c764979865834c3d386d4fd041b5f52e7f34fc29ac1a5eb515/cryptography-50.0.0-cp39-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:6e7d61120573a7f2cd94cc095f9e81f6967c61ccdf194285aa143ecec8e0b708", size = 5325948, upload-time = "2026-07-31T14:24:41.556Z" },
     { url = "https://files.pythonhosted.org/packages/9c/f8/d97f9603efda3888187bfdb893f26c41be4735c10631d05d284ee6b047c4/cryptography-50.0.0-cp39-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:37fdb0d0111f1e2ff07139dfb79f1b49531f8e213c46f1163dd7642979b58c47", size = 4762400, upload-time = "2026-07-31T14:24:43.636Z" },
     { url = "https://files.pythonhosted.org/packages/64/a2/4615c8f7d81a00b1d6e6afe19f694e1543582349fb5f4076f6cb5dc36485/cryptography-50.0.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:c87f62a3d3b9888ed0fdde100ec06aa61ca9cd44bad9057d1dff9a516b5f5bb9", size = 4878208, upload-time = "2026-07-31T14:24:45.522Z" },
     { url = "https://files.pythonhosted.org/packages/d2/1a/efcfb02f91407149a0dacffffab791f7e19bf6385f63b3666dc8b5e5c9c8/cryptography-50.0.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:65c2c3add92b45fd0709db8594536aea39c2a67af0e27ffcf049c498501140b7", size = 5037050, upload-time = "2026-07-31T14:24:47.697Z" },
@@ -903,7 +909,7 @@ name = "cuda-bindings"
 version = "13.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cuda-pathfinder" },
+    { name = "cuda-pathfinder", marker = "sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ce/67/5e7dba1ba576dd73da5dee894ca076ca5e959450dfff66d6d510a255d1f7/cuda_bindings-13.3.1-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c7855c4868aabc0cfae28abbe83d56734bdfbd08f08fc234ac1912a12858bf49", size = 6025351, upload-time = "2026-05-29T23:11:49.685Z" },
@@ -934,43 +940,43 @@ wheels = [
 
 [package.optional-dependencies]
 cublas = [
-    { name = "nvidia-cublas", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
-    { name = "nvidia-cuda-nvrtc", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cublas", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-cuda-nvrtc", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 cudart = [
-    { name = "nvidia-cuda-runtime", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cuda-runtime", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 cufft = [
-    { name = "nvidia-cufft", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
-    { name = "nvidia-nvjitlink", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cufft", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-nvjitlink", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 cufile = [
-    { name = "nvidia-cufile", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cufile", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 cupti = [
-    { name = "nvidia-cuda-cupti", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cuda-cupti", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 curand = [
-    { name = "nvidia-curand", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-curand", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 cusolver = [
-    { name = "nvidia-cublas", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
-    { name = "nvidia-cusolver", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
-    { name = "nvidia-cusparse", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
-    { name = "nvidia-nvjitlink", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cublas", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-cusolver", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-cusparse", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-nvjitlink", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 cusparse = [
-    { name = "nvidia-cusparse", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
-    { name = "nvidia-nvjitlink", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cusparse", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-nvjitlink", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 nvjitlink = [
-    { name = "nvidia-nvjitlink", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-nvjitlink", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 nvrtc = [
-    { name = "nvidia-cuda-nvrtc", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cuda-nvrtc", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 nvtx = [
-    { name = "nvidia-nvtx", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-nvtx", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 
 [[package]]
@@ -1504,7 +1510,9 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/2e/7e/9ecd0285e3153532ae07aeb88063c43c72b4221cf0d4d123b02f3682e3ff/greenlet-3.5.5-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:49520f0c95a48b42cf55414b8e8479beb274ea70431afc33e3f79903c71f4380", size = 295809, upload-time = "2026-08-10T13:25:34.023Z" },
     { url = "https://files.pythonhosted.org/packages/35/73/60e4bbcc89252037b18087f2ec16405d5b2d5be42dde191bbf3667e96102/greenlet-3.5.5-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:55272212cbc5f43d1d723725ab931f1939969b7e9523882ca58b55061769d053", size = 611910, upload-time = "2026-08-10T14:14:35.18Z" },
     { url = "https://files.pythonhosted.org/packages/a4/17/cd5134be659cd4a443e7a61ae670dabec165a814c51162916d637b6dd38e/greenlet-3.5.5-cp312-cp312-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:655bca754a2ef4efcb0eb48a94d3f4593536d0f3d48f8ed44343c01d16a92f95", size = 624198, upload-time = "2026-08-10T14:27:25.229Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/30/87c212b5c684d0e72974f1063b7a9687631e8985902c06e1016542c874e7/greenlet-3.5.5-cp312-cp312-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:6ca5d6ae0739e5764f2cfcfaa562ac5a990cbdaedca93251c5e3cf07c362371f", size = 629504, upload-time = "2026-08-10T14:30:07.967Z" },
     { url = "https://files.pythonhosted.org/packages/78/ac/5c5b959999b6f09c3026b5dfe171575bc3121c5236ce74f495096f25b203/greenlet-3.5.5-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:147b25a42e5ca5be3d42356e8f608b37af715a1c196e9bf9d1627f3341adfe1d", size = 621439, upload-time = "2026-08-10T13:40:49.391Z" },
+    { url = "https://files.pythonhosted.org/packages/63/2c/eb487fafc9f50ffff2b1e0b697f70fb34bf150821c08ab225aacf5583a7e/greenlet-3.5.5-cp312-cp312-manylinux_2_39_riscv64.whl", hash = "sha256:1b5ed9162c0c098e0bbc2cf88a94f433c1b8926f831745252e099e5d83e17759", size = 432462, upload-time = "2026-08-10T14:30:02.309Z" },
     { url = "https://files.pythonhosted.org/packages/c8/8b/6acf112ed8aee499f25b4d6949820fb02ac950ff9c1f3d793bd5be0599f2/greenlet-3.5.5-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:27493374cff1d1b7919dc8126547f2aea582737e3046147b434b1e12de56389b", size = 1581342, upload-time = "2026-08-10T14:15:05.653Z" },
     { url = "https://files.pythonhosted.org/packages/b8/d7/734e5f198888876b42d7616ff6644c075baf6b8a2412deadd6b0e1b8b20c/greenlet-3.5.5-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:12e2ee66c2aba86133f10fd99d6a8856c6d351ffb7be0e4d52ef2cc5fbb705b2", size = 1645744, upload-time = "2026-08-10T13:40:30.353Z" },
     { url = "https://files.pythonhosted.org/packages/de/30/1f42b88dc587b5899ee50616ad56ee40cafaf225df4fb829f10183c62a5c/greenlet-3.5.5-cp312-cp312-win_amd64.whl", hash = "sha256:49ddacd36af37735fab103846f4ee4d18a492dde72730d1699c0c8ebe30d9f18", size = 324171, upload-time = "2026-08-10T13:28:44.472Z" },
@@ -1512,7 +1520,9 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/fb/3d/8cef5f724ec0d4add2af8961d504535ec60c3cca9e464f6d03bdba29d85b/greenlet-3.5.5-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:b79fd2a5bc099b5e744f34c4c9a58954a5f4cb7529fb4b6e8446057d61b6edaa", size = 294730, upload-time = "2026-08-10T13:27:51.206Z" },
     { url = "https://files.pythonhosted.org/packages/88/4b/8e7aa3f514273aecff30a16ab1bac09ff54cfc7e6860fdd8058c37ff2499/greenlet-3.5.5-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:634cf15a233a949136879dd388e25d3296e16f3f1e217d2456797b8579ebc6ed", size = 614536, upload-time = "2026-08-10T14:14:36.589Z" },
     { url = "https://files.pythonhosted.org/packages/85/48/4e95e9dd5a8a397dc6a6345dd7f1935113d0fca4f85e89d3976da9cd988d/greenlet-3.5.5-cp313-cp313-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:499adea519f748407fc6806d20eedabac2884fd73b9f38d81236e190ba20dfef", size = 626924, upload-time = "2026-08-10T14:27:27.048Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/84/eaa476d6bf3816828d0d70e80dcc36bf30a058233bd889e707e693f6e860/greenlet-3.5.5-cp313-cp313-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:f7278591501941bb2456af102bb9cd59aab48c6cfd6e2dd68fa1290bb0c49a42", size = 632726, upload-time = "2026-08-10T14:30:09.874Z" },
     { url = "https://files.pythonhosted.org/packages/89/5d/398a1c71fa7a277deeb376c999979de6786f08fc2d5747a0b9d6e11738dd/greenlet-3.5.5-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2eabb980975cba5b93a95f6f69287d05fc05ac955bfd6a320a7c083eeb52c0b0", size = 623906, upload-time = "2026-08-10T13:40:50.501Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/f2/0cc2849ede68579291e9c59b3ab6ec1958f98681cca5b14d8fc75bf674a4/greenlet-3.5.5-cp313-cp313-manylinux_2_39_riscv64.whl", hash = "sha256:4dfc7c4470354e7b09184d1a3a985761053a2fd694ddb5b5c80242afc2c8c90b", size = 434966, upload-time = "2026-08-10T14:30:03.729Z" },
     { url = "https://files.pythonhosted.org/packages/04/1b/745450fc5ea9e0cb17d840d248f284db3363de736d362c7d2d883e3eadba/greenlet-3.5.5-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:03115c2e0a371999bf8ae616aa8d653f96641d4705c457aebaa187276e9f7537", size = 1581430, upload-time = "2026-08-10T14:15:06.853Z" },
     { url = "https://files.pythonhosted.org/packages/d4/29/d51b296e3191bb15d3d81ec375af1909e4466c0f395d744ed475801798a9/greenlet-3.5.5-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:4441153ffba21b90d3ca89fe3d31f5c093ae6c0bf0cfdfc98f54cde22f95b62e", size = 1645684, upload-time = "2026-08-10T13:40:32.133Z" },
     { url = "https://files.pythonhosted.org/packages/12/63/369f1a1625e64e9e31df3963c6044056e3fdfa3fa3fdba3c54ffefa6e987/greenlet-3.5.5-cp313-cp313-win_amd64.whl", hash = "sha256:95c5b1f4b3a193f8a0c2de4bfdcb48d119f7f1063941f1de1f2168051b3e52dd", size = 324075, upload-time = "2026-08-10T13:26:58.974Z" },
@@ -1520,7 +1530,9 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/7f/8c/080e881fa2be95ff1ddbd6994b2bab3b1a78df3b3fcab39306011764fcc7/greenlet-3.5.5-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:d4a389a852e392a6366058651a20fa5ba40d979865aa81bea2ccbdc44805070d", size = 295309, upload-time = "2026-08-10T13:26:03.032Z" },
     { url = "https://files.pythonhosted.org/packages/25/cc/0ac614e6586c0e42d4cc281a5819150f4f43685744a4c5ff77139286409d/greenlet-3.5.5-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:70b157cd319873e8b544ddc2de158f55bbd0a9b0218c8ce9332039801518e328", size = 661185, upload-time = "2026-08-10T14:14:37.867Z" },
     { url = "https://files.pythonhosted.org/packages/5e/b9/6808725354be8ad305dfe5172377664fc9642d4fc043be246b3314cf4482/greenlet-3.5.5-cp314-cp314-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:8bdfd1424abcf26832961e766570cae79efdb9599d709088c9cb6ef82b194926", size = 673419, upload-time = "2026-08-10T14:27:28.652Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/52/f005d579acde46c3d1cc3cab1c9f3d5708c8a3006a4120e8cf5da801afe9/greenlet-3.5.5-cp314-cp314-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:d98ef6f92e67c6dbf299dbfd8facc1b0d2d9cedf91e325e73b3d0373fe4309d8", size = 677863, upload-time = "2026-08-10T14:30:11.663Z" },
     { url = "https://files.pythonhosted.org/packages/42/2e/40c509967da7f254680826a2fa0dd22138ec79946c70b97542d74cde8b43/greenlet-3.5.5-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:182de51c6b572a705f2fafaab2e783bcf7d2760940229dfe73086cbae037af3e", size = 670822, upload-time = "2026-08-10T13:40:51.833Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/8a/a75f8a2bdcef3c358a3147cdc9db3aa83755f0a038f766ab0bedb66f512c/greenlet-3.5.5-cp314-cp314-manylinux_2_39_riscv64.whl", hash = "sha256:159df1942d88e8f784cbb38d6f18bdb365cd11319cfbb3e89623de2b97892d53", size = 480554, upload-time = "2026-08-10T14:30:05.171Z" },
     { url = "https://files.pythonhosted.org/packages/2d/22/c3c2eee4a8fe191d6d1d183086c56133d646024e3d70bfd414829f64560b/greenlet-3.5.5-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:8fec3f165dfe332e490c3247c0f6c23b0bfc45f06496ad7f00ddb00e3d35e4dc", size = 1628469, upload-time = "2026-08-10T14:15:08.11Z" },
     { url = "https://files.pythonhosted.org/packages/f7/87/25babd09b94cb1f03e71db815fde463f0262e40cfbd953d58a8d77311351/greenlet-3.5.5-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:c6ce25fee6cabc8bf22cb8b52e642cbb821be5b9aec8094d07ff03378141b8e9", size = 1691952, upload-time = "2026-08-10T13:40:33.502Z" },
     { url = "https://files.pythonhosted.org/packages/2e/3d/5cc9701117ea4dc0eb7bf1f4f9b7888a6e2e5277ddfae095805ace50f2b6/greenlet-3.5.5-cp314-cp314-win_amd64.whl", hash = "sha256:7dffc5c859fe6059974df1e37d7923d654a83e2ae18fdd616994270e001115e1", size = 327458, upload-time = "2026-08-10T13:27:02.868Z" },
@@ -1528,14 +1540,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/24/e0/50cd600b469e5734c72709b6b1838b6bc63f307b573c772c3132d6ecfe92/greenlet-3.5.5-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:0e5a7de979d764aea1f5b6e95cf92b5b37741b9823702041f34b126e7f690277", size = 305471, upload-time = "2026-08-10T13:26:20.568Z" },
     { url = "https://files.pythonhosted.org/packages/75/a3/77acd66dfc6387b5219b2080806c0cabb73c10eb1bb44b413c40a62015ba/greenlet-3.5.5-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:fef01bd457f11fc158b130ca0027a3c365693280e8e231b65bdaf57999f39f5b", size = 672470, upload-time = "2026-08-10T14:14:39.058Z" },
     { url = "https://files.pythonhosted.org/packages/b9/71/0d178142dca3ec19f46fb2212ae73d30ad53b9d548dc64804086033a7089/greenlet-3.5.5-cp314-cp314t-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:5173a72310725a74afc82c164f0e52cb8ad0de62f2bb623f24f6c0cc07d80272", size = 679973, upload-time = "2026-08-10T14:27:30.072Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/ac/0d7887aa4bbfc9eba075cc428244dfc96f623478454d5ec81180d0d6bd5a/greenlet-3.5.5-cp314-cp314t-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:5e9ec2e7c98e895fcea0c5cc57b2606cf86ece6d0a56578f3eb225e2af4f0387", size = 681587, upload-time = "2026-08-10T14:30:13.519Z" },
     { url = "https://files.pythonhosted.org/packages/6e/31/46eb8567302eaf787abf88d09df014e14ae3baf460af1b8b0efdbd3efcd5/greenlet-3.5.5-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:44f08341873200ba8a60a8bc14ace3d91f1754f7fa7bc66157714a8cd420a476", size = 676634, upload-time = "2026-08-10T13:40:53.004Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/18/8d58ba1c429b0383e3219a3d0e0bba241d0444d8ed05b73349953c7d7c7b/greenlet-3.5.5-cp314-cp314t-manylinux_2_39_riscv64.whl", hash = "sha256:102817506f6090b5176c746a82603341a549b40e5c3d5b72a4c672228a918c41", size = 510175, upload-time = "2026-08-10T14:30:07.047Z" },
     { url = "https://files.pythonhosted.org/packages/a3/e9/b88bbf5b29970cb84172dc2c32aa3e5e579ceb94c808e81c826454138850/greenlet-3.5.5-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:d246c0db9a2513cd45f019ba178ea4d4d4705bd210ee465e2c15d76a1ab13874", size = 1637320, upload-time = "2026-08-10T14:15:09.317Z" },
     { url = "https://files.pythonhosted.org/packages/6d/8c/7631ed29cc6f0392f11830076e172ce4885e70b0bc2c1bce1731176d4b4e/greenlet-3.5.5-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:72507285b5caa1d17904a3f7c322ca780823a54170a0e04ec3f37bcc60d4db71", size = 1697412, upload-time = "2026-08-10T13:40:34.924Z" },
     { url = "https://files.pythonhosted.org/packages/da/0f/f7dd935f9c4cb1be49098770587f54d8a78518e55c89bce86c4fb4109057/greenlet-3.5.5-cp314-cp314t-win_amd64.whl", hash = "sha256:7805655781fb8f28a55d05fe57ed61f5f10f1892fb587673e3bb5264f28041f0", size = 331514, upload-time = "2026-08-10T13:29:20.611Z" },
     { url = "https://files.pythonhosted.org/packages/b7/e5/681b01f8fbc1b55232822f99e8f8afeb78a55a7c76a7bf9dbdc7ccb03a6d/greenlet-3.5.5-cp315-cp315-macosx_11_0_universal2.whl", hash = "sha256:c0db80fcd5b8aece93f66c64f78a786bbb6b96c5fe63ef5a5a4581ecf8bab206", size = 295975, upload-time = "2026-08-10T13:28:45.985Z" },
     { url = "https://files.pythonhosted.org/packages/11/f2/69b488cd9e7267bf4b0fe8cdebf25d8d6df680d21bdf41150d23e23d6652/greenlet-3.5.5-cp315-cp315-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6b241c32f912ada659808d68e308c568baf577eebf757d15471472de0c18cfad", size = 666823, upload-time = "2026-08-10T14:14:40.222Z" },
     { url = "https://files.pythonhosted.org/packages/84/d4/d5bc2fdebbdda0c94555925ba79948b8395d75a7f6a36cc85dce5bab9f11/greenlet-3.5.5-cp315-cp315-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:ef6a08349401d8eaf3cb12688ac8557de95788556b8631ef17555a4a173022c0", size = 677613, upload-time = "2026-08-10T14:27:31.543Z" },
+    { url = "https://files.pythonhosted.org/packages/65/53/4e13642efc4d7ad6554ecb2242a5be42666b2e1a067323e88dfc0124a04b/greenlet-3.5.5-cp315-cp315-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:37faa97daccb6d9f4c2141ce3118d023c3c5506864a7d8bdf726f665018c1f76", size = 681436, upload-time = "2026-08-10T14:30:14.839Z" },
     { url = "https://files.pythonhosted.org/packages/bd/93/542d8a3a90f3b35c6ad8bf7e56a03010287f2cafa289a5b7985b5207db39/greenlet-3.5.5-cp315-cp315-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f2e3d061b8e13aec2f0441689b3c71b244a20e5d274a52cb0f7e31bd1d139552", size = 675930, upload-time = "2026-08-10T13:40:54.205Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/32/188447c9a468d6977d2989397226b0c6b65ab6f4cf943f931643328512fc/greenlet-3.5.5-cp315-cp315-manylinux_2_39_riscv64.whl", hash = "sha256:b18007dc2473a7942fd157366b55f01da6fed7ce85318591005b419e0a439474", size = 487404, upload-time = "2026-08-10T14:30:08.903Z" },
     { url = "https://files.pythonhosted.org/packages/52/b5/89c9f2e8460d71101037d47a1feed11928615a5edd42370be290e0657eeb/greenlet-3.5.5-cp315-cp315-musllinux_1_2_aarch64.whl", hash = "sha256:9ab5f5b93655e77fe0d6c2dfd22b5eac751bb1f876d8ec21761b7c1fb9266007", size = 1633878, upload-time = "2026-08-10T14:15:10.693Z" },
     { url = "https://files.pythonhosted.org/packages/b8/60/297de93f3b02ac78a5e04d32bb8bbe3080f4a73d8ed95016561463b70618/greenlet-3.5.5-cp315-cp315-musllinux_1_2_x86_64.whl", hash = "sha256:f0e5a21bd4452a88cf032fc43c4a5b307ab1380eacb63b5988f9c0317885e773", size = 1696597, upload-time = "2026-08-10T13:40:36.252Z" },
     { url = "https://files.pythonhosted.org/packages/18/25/54c6eaff4f337fb670215e89eb2d00d9499487b658e709d4b477be4a342e/greenlet-3.5.5-cp315-cp315-win_amd64.whl", hash = "sha256:469dbb0a78625642f4a626cfd0c6e8bccc0385b5e49189b6308bbe849ec88a8e", size = 327700, upload-time = "2026-08-10T13:28:06.752Z" },
@@ -1543,7 +1559,9 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/10/e2/3144c0a116067ac1e30457b0139a94d60d1d36a86e015de68e9ac87cb3bc/greenlet-3.5.5-cp315-cp315t-macosx_11_0_universal2.whl", hash = "sha256:68184dfcf50ccaa8e864770fe0633a7e27250ea9329f8192ef47ee9ecfd78e1c", size = 306387, upload-time = "2026-08-10T13:27:00.897Z" },
     { url = "https://files.pythonhosted.org/packages/5c/a1/cb4223a7e9b9f43b8807e8eb212358bfe2dfaa174a9ea2889eb1714dcba2/greenlet-3.5.5-cp315-cp315t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9ec0dc0e59dc9c61af5c47348365ccbbd7addfafe0a93b00336ff3da2907bdc6", size = 676472, upload-time = "2026-08-10T14:14:41.417Z" },
     { url = "https://files.pythonhosted.org/packages/9e/cd/a154b4498e5d8f12ada291cfb3b8d596eadde2177f5bf09a9be699d2a446/greenlet-3.5.5-cp315-cp315t-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:e604f58e35833fc46ef20302bcb314dddbfd3fcf33a4f936216d51dd678d63ae", size = 684238, upload-time = "2026-08-10T14:27:32.946Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/f4/e450a68a152f819491d8c7df6a8254e761d87e6a78759268961f8c5bd4dd/greenlet-3.5.5-cp315-cp315t-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:2888a3a38bc5ee5bb6c438372197152e815837e4fab7ed7a1f86ef18ffd58ad1", size = 686022, upload-time = "2026-08-10T14:30:15.96Z" },
     { url = "https://files.pythonhosted.org/packages/bf/bb/b0031d260c2968a3c87deebc51d80c64e499377f993aafe06ee3b7488cc2/greenlet-3.5.5-cp315-cp315t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:40239b5384f96da3963585cc6d7eaa9b56f8ae67e8d92cc82dd9e202fc847de3", size = 681246, upload-time = "2026-08-10T13:40:55.402Z" },
+    { url = "https://files.pythonhosted.org/packages/18/23/17e63d6bf3b9c9b9dbea981b7f643a71f79603bdfb4f1c3a9cf353e22aed/greenlet-3.5.5-cp315-cp315t-manylinux_2_39_riscv64.whl", hash = "sha256:1e8d9391fe77f15649589a907cef972dbbd6352ef7ff7dc0492f658c0c26495f", size = 516951, upload-time = "2026-08-10T14:30:10.907Z" },
     { url = "https://files.pythonhosted.org/packages/9a/07/da554b71ab88e649da146e1065d86a48a5c5d92e50ab74ef41b504aa7f56/greenlet-3.5.5-cp315-cp315t-musllinux_1_2_aarch64.whl", hash = "sha256:a1eaccf5c3a1d3e46dead602c72e6836731e8e245c9de6a27764567b6b62d4c0", size = 1642735, upload-time = "2026-08-10T14:15:11.92Z" },
     { url = "https://files.pythonhosted.org/packages/78/76/26a3782a051677668af9d92beaa47cd87ba9dd5072f762961144a03dd4c6/greenlet-3.5.5-cp315-cp315t-musllinux_1_2_x86_64.whl", hash = "sha256:19e4e026fe20691f333b8eb1a3bc9625eceba8c3f9d62ec5a6f8581afbc6b5a5", size = 1700925, upload-time = "2026-08-10T13:40:37.656Z" },
     { url = "https://files.pythonhosted.org/packages/28/d9/fe7baf4190c2ae71f267efb9de21b3172bb35bc0ed1ef53dd6027d658e33/greenlet-3.5.5-cp315-cp315t-win_amd64.whl", hash = "sha256:712aee154f648bde84634654bb38bb78c69ac640c37a45c9effed800735049d8", size = 331829, upload-time = "2026-08-10T13:26:48.851Z" },
@@ -1904,8 +1922,8 @@ wheels = [
 
 [[package]]
 name = "iohub"
-version = "0.3.11.dev12+719ba12"
-source = { git = "https://github.com/czbiohub-sf/iohub?rev=719ba12c6932b23d84de86d87168777520c290d9#719ba12c6932b23d84de86d87168777520c290d9" }
+version = "0.3.11"
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "blosc2" },
     { name = "dask", extra = ["array"] },
@@ -1922,6 +1940,10 @@ dependencies = [
     { name = "xarray" },
     { name = "zarr" },
     { name = "zarrs" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a5/cc/b69b2f71f526b1e556602e8346001e0c8fc93af0e2f2c939254d9067b812/iohub-0.3.11.tar.gz", hash = "sha256:b8de0698d4dcd25671858abb6d80875b643170780ccb62588c04cdf04e0cd42b", size = 338704, upload-time = "2026-08-17T21:31:46.898Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/46/6ebbe269d557941eedf6ec1518f10a24a29e4d98b8057a4f05b51191c7bd/iohub-0.3.11-py3-none-any.whl", hash = "sha256:827d94ef028023fbdfe9d30cfb2be3629ccfdb4053ec898bcd8da20040f23fea", size = 108142, upload-time = "2026-08-17T21:31:45.683Z" },
 ]
 
 [[package]]
@@ -3281,7 +3303,7 @@ name = "nvidia-cublas"
 version = "13.1.1.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cuda-nvrtc" },
+    { name = "nvidia-cuda-nvrtc", marker = "sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a7/a1/0bd24ee8c8d03adac032fd2909426a00c88f8c57961b1277ded97f91119f/nvidia_cublas-13.1.1.3-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:b7a210458267ac818974c53038fbec2e969d5c99f305ab15c72522fa9f001dd5", size = 542848918, upload-time = "2026-04-08T18:46:22.985Z" },
@@ -3320,7 +3342,7 @@ name = "nvidia-cudnn-cu13"
 version = "9.20.0.48"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas" },
+    { name = "nvidia-cublas", marker = "sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/56/c5/83384d846b2fd17c44bd499b36c75a45ed4f095fbbb2252294e89cea5c5c/nvidia_cudnn_cu13-9.20.0.48-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:e31454ae00094b0c55319d9d15b6fa2fc50a9e1c0f5c8c80fb75258234e731e1", size = 444574296, upload-time = "2026-03-09T19:28:27.751Z" },
@@ -3332,7 +3354,7 @@ name = "nvidia-cufft"
 version = "12.0.0.61"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink" },
+    { name = "nvidia-nvjitlink", marker = "sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8b/ae/f417a75c0259e85c1d2f83ca4e960289a5f814ed0cea74d18c353d3e989d/nvidia_cufft-12.0.0.61-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:2708c852ef8cd89d1d2068bdbece0aa188813a0c934db3779b9b1faa8442e5f5", size = 214053554, upload-time = "2025-09-04T08:31:38.196Z" },
@@ -3362,9 +3384,9 @@ name = "nvidia-cusolver"
 version = "12.0.4.66"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas" },
-    { name = "nvidia-cusparse" },
-    { name = "nvidia-nvjitlink" },
+    { name = "nvidia-cublas", marker = "sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "nvidia-cusparse", marker = "sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "nvidia-nvjitlink", marker = "sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c8/c3/b30c9e935fc01e3da443ec0116ed1b2a009bb867f5324d3f2d7e533e776b/nvidia_cusolver-12.0.4.66-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:02c2457eaa9e39de20f880f4bd8820e6a1cfb9f9a34f820eb12a155aa5bc92d2", size = 223467760, upload-time = "2025-09-04T08:33:04.222Z" },
@@ -3376,7 +3398,7 @@ name = "nvidia-cusparse"
 version = "12.6.3.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink" },
+    { name = "nvidia-nvjitlink", marker = "sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f8/94/5c26f33738ae35276672f12615a64bd008ed5be6d1ebcb23579285d960a9/nvidia_cusparse-12.6.3.3-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:80bcc4662f23f1054ee334a15c72b8940402975e0eab63178fc7e670aa59472c", size = 162155568, upload-time = "2025-09-04T08:33:42.864Z" },
@@ -3663,7 +3685,7 @@ name = "pexpect"
 version = "4.9.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "ptyprocess" },
+    { name = "ptyprocess", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/42/92/cc564bf6381ff43ce1f4d06852fc19a2f11d180f23dc32d9588bee2f149d/pexpect-4.9.0.tar.gz", hash = "sha256:ee7d41123f3c9911050ea2c2dac107568dc43b2d3b0c7557a33212c398ead30f", size = 166450, upload-time = "2023-11-25T09:07:26.339Z" }
 wheels = [
@@ -5187,8 +5209,8 @@ name = "secretstorage"
 version = "3.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cryptography" },
-    { name = "jeepney" },
+    { name = "cryptography", marker = "sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "jeepney", marker = "sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1c/03/e834bcd866f2f8a49a85eaff47340affa3bfa391ee9912a952a1faa68c7b/secretstorage-3.5.0.tar.gz", hash = "sha256:f04b8e4689cbce351744d5537bf6b1329c6fc68f91fa666f60a380edddcd11be", size = 19884, upload-time = "2025-11-23T19:02:53.191Z" }
 wheels = [


### PR DESCRIPTION
The skill could already post to Slack, but nothing ever called `notify.sh` — every message was one the agent chose to send while polling. A run finishing at 3am notified nobody, and a completed step was invisible until someone attached to tmux. These runs take hours to days.

The pipeline now posts on its own:

```
:rocket: 2026_08_11_A549_SEC61B_DENV_1 — reconstruction started
```operator:  Ivan Ivanov (ivan.ivanov)
pipeline:  mantis_v2
positions: 54
steps:     6 — flat-field, deskew, phase reconstruction, virtual staining, assemble, track
input:     /hpc/instruments/cm.mantis/2026_08_11_A549_SEC61B_DENV_1.ome.zarr
output:    /hpc/projects/.../2026_08_11_A549_SEC61B_DENV_debug
host:      gpu-sm01-15```

:white_check_mark: 2026_08_11_A549_SEC61B_DENV_1 — deskew complete [2/6]
```output: /hpc/projects/.../1-deskew/2026_08_11_A549_SEC61B_DENV_1.zarr```

:checkered_flag: 2026_08_11_A549_SEC61B_DENV_1 — reconstruction complete @Ivan Ivanov
```pipeline:  mantis_v2
succeeded: 287
cached:    0
restarted: 1 (1 preempted)
duration:  6h 5m
assembled: /hpc/projects/.../5-assemble/2026_08_11_A549_SEC61B_DENV_1.zarr```
```

| when | emoji | pings |
|---|---|---|
| run start | :rocket: | no |
| each step completes (×6) | :white_check_mark: | no |
| run end | :checkered_flag: | **yes** |
| run end, failed / aborted | :x: / :warning: | **yes** |

Only run end @-mentions the operator, so a ping always means "this needs you" — and it gets its own emoji so it is not six lookalikes deep in a channel. The mention sits at the end of the title, so every message opens with its emoji and dataset regardless.

## Validated on a real 54-position run

`2026_08_11_A549_SEC61B_DENV_debug`, all six steps from scratch: **287 succeeded, 1 restarted (preempted), 0 failed**, `5-assemble` verified at 54 positions, `(67, 6, 86, 1664, 1193) float32`, 11T on disk. **All 8 notifications delivered** — `.notify/notify.log` was never created, and it is only written when a post fails.

Also relaunched a completed 341-task run to confirm hash-neutrality: **341 CACHED, unchanged**, only the six notify tasks executed. An immediate second relaunch sent **zero** step messages.

## Design decisions worth reviewing

**Per-step completion hooks the `done` channel each subworkflow already emits, as a cacheable process rather than a `.subscribe { }`.** This is the core of the change. A `-resume` run replays the whole dataflow graph, so cached tasks still emit and a subscribe closure would fire all six messages within seconds of a relaunch. As an ordinary cacheable process the notify task is cached too, so it sends nothing — Nextflow's task cache *is* the "already announced" record, per-output-directory and surviving `-resume`, with no state files. A subscribe closure would also block a dataflow thread on an HTTP POST between one step finishing and the next being submitted.

**Configuration is two optional environment variables, not pipeline params.** `BIAHUB_SLACK_WEBHOOK` (a credential; ask a biahub dev) and `BIAHUB_SLACK_ID`. Neither gates a run — without them every message prints instead of posting and nothing else changes. The environment already reaches every task per the ENVIRONMENT CONTRACT, so this needs no plumbing, and neither value can reach `.command.sh`, a work dir, a log, or a task hash.

**The poster is `biahub nf notify` (Python, stdlib `urllib`) rather than a bundled script**, chiefly so this does not create `nextflow/bin/` — Nextflow folds that directory into every task hash, which would have invalidated all 341 cached tasks in each live run dir.

**No Block Kit.** A Block Kit section caps text at 3000 chars against 40000 for top-level `text`, the wrong direction for a payload whose worst case is a traceback. Mentions must sit in top-level `text` to be delivered, so `text` carries the ping and the attachment carries the detail plus a severity colour. At `--level info` the payload is byte-identical to the old `{"text": ...}`.

**`restarted:`, not `failed:` or `preempted:`.** A preempted position that then succeeded used to read as `failed: 1, retries: 1` — as if the run were broken. `workflow.stats` has no exit codes, so failed attempts are classified from `trace.txt`. And the exit code alone is not enough either: 143 is SIGTERM, which SLURM sends for preemption *and* for a wall-time kill (`nextflow.config:39` says as much), so the cause comes from a batched `sacct -X` on the job ids in `native_id`, falling back to exit codes when sacct cannot answer. Always reported, including `restarted: 0`.

## Five bugs found by testing, none visible from reading

1. Nextflow 26's strict parser rejects `workflow.onComplete = {}` at script scope, and `++`.
2. Inside the handler closure the implicit `workflow` resolves to **null**, so `workflow.stats` threw an NPE that Nextflow swallowed into a bare "Failed to invoke event handler" — the run-end message would silently never have sent.
3. **`waitForOrKill` destroys the notifier during JVM shutdown**, so on a failed run the message was never posted at all. Measured by pointing the webhook at a local HTTP server and counting requests: success delivered, failure delivered nothing. A probe inside a real failed teardown showed `waitForOrKill` SIGTERMing the child while `waitFor(timeout, unit)` let it survive.
4. Dropping the output capture then made the no-webhook console fallback vanish into an unread pipe; fixed with `inheritIO()`.
5. `params.max_positions as int` throws on an unset param.

## Robustness

Retry only `408/429/5xx` and transport errors, never `400/403/404/410` — a revoked webhook cannot be fixed by repeating the request. Honour `Retry-After`, capped. Keep the **tail** when truncating, since a traceback ends with the exception, and take the last non-blank line of `errorMessage` for the same reason. Strip ANSI and collapse `\r`, or tqdm/cellpose output arrives as one enormous line. Neutralize ``` so the fence cannot break. Mask the webhook in error text. `onComplete` only, never `onComplete` *and* `onError`, which would double-post. **Every path exits 0** — a notification must never fail a two-day reconstruction. Delivery problems are recorded by the notifier itself in `<output>/nextflow/.notify/notify.log`, because at teardown the caller may not survive to log them.

## Also included

- `attempt` added to `trace.fields`, **appended** after the 14 defaults so `$4` name / `$5` status / `$6` exit do not move.
- Docs: a "Setting it up" section (both vars optional, where to get the webhook, how to find a member ID, and the format — `U0A2ZH9CS8S`, not `@Ivan Ivanov`, which never pings); SKILL.md offers to append them to `~/.bashrc`. Drops the "retries exceed ~20% of tasks" threshold, which measures preemption pressure rather than dataset health. Fixes two errors found against real runs — `trace.txt` had no `attempt` column, and `slurm_output/` uses short step names — and records that `ProcessFailedException` is **not** a terminal-failure signal (33 occurrences in one healthy run's log).
- Two commits unrelated to notifications, easy to drop: relocking iohub to the released `0.3.11` (the lock carried a git source while `pyproject.toml` asked for `>=0.3.11`) and removing the now-obsolete "pinned iohub" language. I verified `_contiguous_runs` (iohub#460), `_write_units.py` (iohub#455), and `layout='bf2raw'` are all in the release before rewording anything.

## Tests

62 new tests across `tests/test_utils/test_notify.py` and `tests/test_cli/test_nf_cli.py` — truncation boundaries, ANSI/`\r`/backtick handling, member-ID validation, payload shape per level, retry/no-retry per status code with `urlopen` monkeypatched, the operator lookup and its fallbacks, and the self-written failure log. Full suite: **220 passed, 1 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
