### PR TITLE
build(deps): imaging-qc 0.5.0, and read Z stacks by max in the default QC configs

### DIFF
--- a/nextflow/configs/a549/qc.yaml
+++ b/nextflow/configs/a549/qc.yaml
@@ -75,9 +75,23 @@ blank:
   gate:
     granularity: channel
 
+# NORMALIZE OFF, measured rather than preferred. With `normalize: true` this
+# metric divides gradient energy by an intensity scale, and in the empty planes
+# that divisor is near zero — so noise becomes the largest value in the stack.
+# On 2026_08_11_A549_SEC61B_DENV it peaked at Z 3-19 (SNR ~5 there, i.e. no
+# signal) and ANTI-correlated with SNR across Z, rho -0.31 to -0.69. Raw, on the
+# same pixels, it peaks at Z 31-37 — inside the in-focus band where SNR peaks —
+# and correlates at rho +0.97 to +0.99. It is a focus metric again.
+#
+# ⚠ `hard_floor` below is a NORMALIZED bound and is inert against raw values,
+# which run 179-934 on GFP: it cannot fire. Recalibration is deliberately
+# deferred — the floor is channel-scale dependent (BF, Phase3D and the
+# predictions each sit on their own scale), so it needs reading off healthy runs
+# per channel, like the SNR floors. The relative outlier fence still gates this
+# metric in the meantime.
 tenengrad:
   threshold: 0.0
-  normalize: true
+  normalize: false
   granularity: slice
   gate:
     hard_floor: 0.001
@@ -90,9 +104,28 @@ tenengrad:
 report:
   max_timepoints: 5
   compact: false
+  # MAX over Z, not the default median, for both per-Z metrics. The question a
+  # reader asks of a Z stack is "is there usable signal / focus anywhere in it",
+  # and a median over 86 planes answers a different one: two thirds of this
+  # store's planes are out of focus, so the median is dragged toward the floor.
+  # Measured on GFP: median-over-Z SNR 12.0 against max-over-Z 26.7.
+  #
+  # REPORT-SIDE ONLY. Gates still collapse Z by mean (`any()` for booleans), so
+  # a panel and a verdict describe different reductions of the same rows — worth
+  # remembering before calibrating a bound against a plot.
+  #
+  # No `group_positions:` yet. It is report-level, so it would apply to every
+  # panel at once, and the right value differs by form: `range_drift` is
+  # unreadable at 972 traces and wants per-well medians, while a facetgrid's
+  # distribution is the point and collapsing 54 fields to 6 destroys it (the GFP
+  # panel's max falls 21.8 -> 15.3). Per-entry grouping is imaging-qc#221.
   metric_archetypes:
-    signal_to_noise: facetgrid
-    tenengrad: facetgrid
+    signal_to_noise:
+      archetype: facetgrid
+      aggregate: {Z: max}
+    tenengrad:
+      archetype: facetgrid
+      aggregate: {Z: max}
     intensity_stats: range_drift
   metric_labels:
     signal_to_noise: "Signal-to-Noise Ratio"

--- a/nextflow/configs/zebrafish/qc.yaml
+++ b/nextflow/configs/zebrafish/qc.yaml
@@ -61,9 +61,23 @@ blank:
   gate:
     granularity: channel
 
+# NORMALIZE OFF, measured rather than preferred. With `normalize: true` this
+# metric divides gradient energy by an intensity scale, and in the empty planes
+# that divisor is near zero — so noise becomes the largest value in the stack.
+# On 2026_08_11_A549_SEC61B_DENV it peaked at Z 3-19 (SNR ~5 there, i.e. no
+# signal) and ANTI-correlated with SNR across Z, rho -0.31 to -0.69. Raw, on the
+# same pixels, it peaks at Z 31-37 — inside the in-focus band where SNR peaks —
+# and correlates at rho +0.97 to +0.99. It is a focus metric again.
+#
+# ⚠ `hard_floor` below is a NORMALIZED bound and is inert against raw values,
+# which run 179-934 on GFP: it cannot fire. Recalibration is deliberately
+# deferred — the floor is channel-scale dependent (BF, Phase3D and the
+# predictions each sit on their own scale), so it needs reading off healthy runs
+# per channel, like the SNR floors. The relative outlier fence still gates this
+# metric in the meantime.
 tenengrad:
   threshold: 0.0
-  normalize: true
+  normalize: false
   granularity: slice
   gate:
     hard_floor: 0.001
@@ -76,9 +90,28 @@ tenengrad:
 report:
   max_timepoints: 5
   compact: false
+  # MAX over Z, not the default median, for both per-Z metrics. The question a
+  # reader asks of a Z stack is "is there usable signal / focus anywhere in it",
+  # and a median over 86 planes answers a different one: two thirds of this
+  # store's planes are out of focus, so the median is dragged toward the floor.
+  # Measured on GFP: median-over-Z SNR 12.0 against max-over-Z 26.7.
+  #
+  # REPORT-SIDE ONLY. Gates still collapse Z by mean (`any()` for booleans), so
+  # a panel and a verdict describe different reductions of the same rows — worth
+  # remembering before calibrating a bound against a plot.
+  #
+  # No `group_positions:` yet. It is report-level, so it would apply to every
+  # panel at once, and the right value differs by form: `range_drift` is
+  # unreadable at 972 traces and wants per-well medians, while a facetgrid's
+  # distribution is the point and collapsing 54 fields to 6 destroys it (the GFP
+  # panel's max falls 21.8 -> 15.3). Per-entry grouping is imaging-qc#221.
   metric_archetypes:
-    signal_to_noise: facetgrid
-    tenengrad: facetgrid
+    signal_to_noise:
+      archetype: facetgrid
+      aggregate: {Z: max}
+    tenengrad:
+      archetype: facetgrid
+      aggregate: {Z: max}
     intensity_stats: range_drift
   metric_labels:
     signal_to_noise: "Signal-to-Noise Ratio"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -117,7 +117,7 @@ index-strategy = "unsafe-best-match"
 # than its directory. That project also relaxed `iohub==0.3.2` to a floor so both
 # can share one environment — biahub needs iohub>=0.3.11 for the
 # gapped-shard-write fix.
-imaging_qc_pipeline = { git = "https://github.com/czbiohub-sf/imaging-qc-pipeline", rev = "2be2ee6529adfb990503e3289f19ecfa142b1b5a" }
+imaging_qc_pipeline = { git = "https://github.com/czbiohub-sf/imaging-qc-pipeline", rev = "bd0b494ed1edf8be629254344e6e4bd6df1b3141" }
 
 [tool.hatch.metadata]
 allow-direct-references = true

--- a/uv.lock
+++ b/uv.lock
@@ -366,7 +366,7 @@ requires-dist = [
     { name = "dask", extras = ["array"] },
     { name = "humanize" },
     { name = "imageio-ffmpeg" },
-    { name = "imaging-qc-pipeline", extras = ["interactive"], marker = "extra == 'qc'", git = "https://github.com/czbiohub-sf/imaging-qc-pipeline?rev=2be2ee6529adfb990503e3289f19ecfa142b1b5a" },
+    { name = "imaging-qc-pipeline", extras = ["interactive"], marker = "extra == 'qc'", git = "https://github.com/czbiohub-sf/imaging-qc-pipeline?rev=bd0b494ed1edf8be629254344e6e4bd6df1b3141" },
     { name = "iohub", specifier = ">=0.3.11" },
     { name = "largestinteriorrectangle" },
     { name = "llvmlite", specifier = ">=0.41.0" },
@@ -1917,8 +1917,8 @@ wheels = [
 
 [[package]]
 name = "imaging-qc-pipeline"
-version = "0.4.0a2"
-source = { git = "https://github.com/czbiohub-sf/imaging-qc-pipeline?rev=2be2ee6529adfb990503e3289f19ecfa142b1b5a#2be2ee6529adfb990503e3289f19ecfa142b1b5a" }
+version = "0.5.0"
+source = { git = "https://github.com/czbiohub-sf/imaging-qc-pipeline?rev=bd0b494ed1edf8be629254344e6e4bd6df1b3141#bd0b494ed1edf8be629254344e6e4bd6df1b3141" }
 dependencies = [
     { name = "dask", extra = ["array"] },
     { name = "hydra-core" },
@@ -5594,6 +5594,20 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/61/72/9e03975701c808767c19f394f670941a962204a4f6a00eeaf56b560348e8/statsmodels-0.15.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:65e64afc2655a486ea44a5ffe4e2b05ee3abbcb10ea61d1c02d3e9e519338d9b", size = 11907800, upload-time = "2026-08-27T15:05:49.786Z" },
     { url = "https://files.pythonhosted.org/packages/4f/a7/c467019a8bf1ab6a07ca88004f0a1d4ea2dae89642aa804e49437b256243/statsmodels-0.15.0-cp314-cp314t-win_amd64.whl", hash = "sha256:edee066ac9b171d95c3de925225331a21de1deb5b6452f252bc853e44566e72b", size = 11559083, upload-time = "2026-08-27T15:06:05.872Z" },
     { url = "https://files.pythonhosted.org/packages/54/10/dc78352367cd5bb298340b57c390c944b66236f6d026cc238bc8264c7633/statsmodels-0.15.0-cp314-cp314t-win_arm64.whl", hash = "sha256:40b2737456e75d96866943e33017a1dffc9166025ee33b7eb373fbe8c7a85e09", size = 11029613, upload-time = "2026-08-27T10:39:10.043Z" },
+    { url = "https://files.pythonhosted.org/packages/de/cb/a1f5ad730cb66c7d911ebb45413880333d837f1cffff990a4c6d2c541b95/statsmodels-0.15.0-cp315-cp315-macosx_10_15_x86_64.whl", hash = "sha256:d48ba61db0d13d3033330e6bd1f864dfa9b48c0b952b3b0f7570206b35d552e5", size = 11702125, upload-time = "2026-08-30T16:04:07.635Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/db/fb95f242adce112c1507e2062ad6b7b00aea338925f2a03fbe47973c4d72/statsmodels-0.15.0-cp315-cp315-macosx_11_0_arm64.whl", hash = "sha256:24b9917a09bbe0227047e512a40652c4b9117c2cfbf19c4a5b9971a8944a8606", size = 11571622, upload-time = "2026-08-30T16:04:29.558Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/3f/f4cc7e5f4d6c8f46551aee63e59d9b964881070f552400ebb76667b39ad9/statsmodels-0.15.0-cp315-cp315-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:333d0c70f269ff98b647f157d2ae7fbcf0617e6f9a5b1817fc6609766502292c", size = 11780713, upload-time = "2026-08-30T07:40:06.332Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/20/fa315a013f70efa6674adfaca59365ea7562371914c408551fc3c399792f/statsmodels-0.15.0-cp315-cp315-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:80b946d7c922f46f045f25e50daf13439f79c05e403ba50081cad509892c8b26", size = 12070117, upload-time = "2026-08-30T07:40:27.04Z" },
+    { url = "https://files.pythonhosted.org/packages/91/43/a63f7880050c2c24056fa8d663b7c8a1816b25864660abbc73afff3f3558/statsmodels-0.15.0-cp315-cp315-musllinux_1_2_x86_64.whl", hash = "sha256:cf897abce5616e2763ab7d7a7fa914677df87a649971f877b83a358c98f6e291", size = 12105153, upload-time = "2026-08-30T07:40:45.814Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/d4/523ddb13862c228407297754486b6c9e8777e5114f4532b667b47728c544/statsmodels-0.15.0-cp315-cp315-win_amd64.whl", hash = "sha256:511a4f9cadbf91a690bfa863bb3e25dce583d8140046886fdf35fbfabfbce401", size = 11352844, upload-time = "2026-08-30T16:04:48.14Z" },
+    { url = "https://files.pythonhosted.org/packages/53/59/f3058214e61b15582ef17d761c9333def46960ee521313409b2705791029/statsmodels-0.15.0-cp315-cp315-win_arm64.whl", hash = "sha256:0cb6228713fe47046b606daee63ed4473a7c246fa97cf0a6d6f20d3b0c96c051", size = 10866685, upload-time = "2026-08-30T16:05:03.971Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/2d/43089b37f4bbbf7373929cd198de6cbdb0b5a4580a6e5e32bf9fe74fccab/statsmodels-0.15.0-cp315-cp315t-macosx_10_15_x86_64.whl", hash = "sha256:27e9467fae83ff327c9d16ae5ea7e771bcdd66a682f49aa324eeefea5584f2d5", size = 11858149, upload-time = "2026-08-30T16:05:20.585Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/38/ca88421b81666cdcfc3d0eb12c714f80f2be327669ececbb5930b68a71c0/statsmodels-0.15.0-cp315-cp315t-macosx_11_0_arm64.whl", hash = "sha256:ecf84918dcd410ab34d3d85d34e0b16ebb10319c9fc77dbf9a1f1a49324c59f8", size = 11739931, upload-time = "2026-08-30T16:05:37.286Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/64/98b9e2b1fbfdc4e2392bff349718d8dc796403006a3106ec375c59a5d3f8/statsmodels-0.15.0-cp315-cp315t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5891ad077b36d6401e44967739df3d2cdd380a0e6e9e46dadec7e3d3a828af55", size = 11657996, upload-time = "2026-08-30T07:41:05.608Z" },
+    { url = "https://files.pythonhosted.org/packages/34/6d/d8c9e73013ee854031218e8a044ba679535268bc61cf59466f19ac8d980c/statsmodels-0.15.0-cp315-cp315t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:af80f9658c48792947fc754a026ffbebca61a8b483253781973f604a67cf1f8c", size = 11893402, upload-time = "2026-08-30T07:41:27.553Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/f5/b9b47f3c688a8af1b199af96e098b8f20897a60b45187c57ce6fcde77a5f/statsmodels-0.15.0-cp315-cp315t-musllinux_1_2_x86_64.whl", hash = "sha256:583eb2a46f7c7a5c34a26715c8b6d92199bfb4f04623db5fff9902a3c7c832d3", size = 11934786, upload-time = "2026-08-30T07:41:46.809Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/08/608871f18bc18c6cba0b484e81fd25a023ef3ca6541f6793ec839fa49e1f/statsmodels-0.15.0-cp315-cp315t-win_amd64.whl", hash = "sha256:38038823fbe86f11e09433b4a0f4af5f102327c3137a1604b002ce3cf722a31f", size = 11549124, upload-time = "2026-08-30T16:05:53.179Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/eb/90a506dbee5cde669e2ef28565ff6b7a0791ab415eab2da82f92d033cccc/statsmodels-0.15.0-cp315-cp315t-win_arm64.whl", hash = "sha256:90df413d7e09474f7e7cbf8807440c1bf76298cdd9daabf9141f76d7627c9151", size = 11021454, upload-time = "2026-08-30T16:06:08.124Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Upgrades the QC dependency and, on the strength of what the new version measures, changes how the default configs read a Z stack.

## 1. Dependency: imaging-qc `0.4.0a2` -> `0.5.0` (`bd0b494`)

Verified the upgrade is metric-preserving before adopting it. Recomputed the whole `v3` A549 store on both versions and compared value by value: **5,882,868 / 5,882,868 identical**, and no position changed verdict.

What does change is intended, and is the reason for the bump:

- **Blank precedence.** A channel detected as blank no longer cascades a pile of derived flags; the dependent metrics come back null instead of failing. `low_signal_to_noise__bf_oblique` goes 10 -> 0 with 41 nulls, `low_tenengrad` 17 -> 12. Fewer flags, and the ones left mean something.
- **Per-entry `aggregate:`** in the report, which is what section 2 uses.
- **Flat plan v5** (`items[]` replacing `waves[]`) — the Nextflow driver was already adapted for this on #298.
- `report --config <file>` keeps the `report:` block (imaging-qc#201), which is what let the configs flatten to one file per store.

## 2. Default configs: max over Z for SNR and tenengrad, and tenengrad stops normalizing

Both `nextflow/configs/a549/qc.yaml` and `nextflow/configs/zebrafish/qc.yaml`.

**Max, not the default median.** The question a reader asks of a Z stack is "is there usable signal or focus *anywhere* in it". A median over 86 planes answers a different one — two thirds of this store's planes are out of focus, so it is dragged toward the floor. On GFP: median-over-Z SNR **12.0** against max-over-Z **26.7**.

**`tenengrad: normalize: false`,** which is what makes max-over-Z correct for it rather than actively wrong. Normalized, the metric divides gradient energy by an intensity scale, and in empty planes that divisor is near zero — so noise becomes the largest value in the stack. Measured on `2026_08_11_A549_SEC61B_DENV`:

| | peak Z | rho vs SNR across Z |
|---|---|---|
| `normalize: true` (before) | 3-19 — empty, SNR ~5 | **-0.31 to -0.69** |
| `normalize: false` (now) | 31-37 — the in-focus band, where SNR peaks | **+0.97 to +0.99** |

Harness verified first: recomputing with `normalize: true` reproduces the shipped table 2580/2580 identical, so the two runs differ only in that flag.

**No aggregation for anything else** — `intensity_stats` stays `range_drift`, and no `group_positions:` (see below).

## Known gap, deliberately deferred

⚠ **tenengrad's `hard_floor: 0.001` is now inert.** It is a normalized bound, and raw values run 179-934 on GFP — it cannot fire. Visible in the verdicts, where tenengrad passes with a summary value of 7623. Not guessed at here because the raw scale is per channel (BF near 2800, Phase3D near 1e-10, the predictions elsewhere again), so one scalar cannot serve six channels; it needs reading off healthy runs per channel, the way the SNR floors were. The relative outlier fence still gates the metric meanwhile.

## Notes

- `aggregate:` is **report-side only.** Gates still collapse Z by a hard-coded mean, so a panel and a verdict are two different reductions of the same rows. Asked upstream to gate by the configured reducer: imaging-qc#222.
- `group_positions:` omitted because it is report-*level*, so it would hit every panel at once — and the right value differs by form. `range_drift` is unreadable at 972 traces and wants per-well medians, while a facetgrid's distribution *is* the point and collapsing 54 fields to 6 destroys it (the GFP panel's max falls 21.8 -> 15.3). Requested as a per-entry key upstream: imaging-qc#221.
- Also filed upstream from this work: imaging-qc#220 (`metric_asrchetypes` typo silently accepted).

## Test

Full pipeline end to end on the A549 subset with the shipped configs: **11 tasks, 0 failed**, both report tabs, all 7 plots, and 0 unrecognized-key warnings.
