### PR TITLE
fix(nextflow): use "BF" as the reconstruct input channel name

### DIFF
--- a/nextflow/configs/a549/reconstruct.yml
+++ b/nextflow/configs/a549/reconstruct.yml
@@ -1,7 +1,7 @@
 # input_channel_names must match the brightfield channel name in the DESKEWED
 # store exactly — a mismatch fails at compute_transfer_function, after
 # flat-field and deskew have already run.
-input_channel_names: ["BF - Oblique"]
+input_channel_names: ["BF"]
 time_indices: "all"
 reconstruction_dimension: 3
 phase:

--- a/nextflow/configs/zebrafish/reconstruct.yml
+++ b/nextflow/configs/zebrafish/reconstruct.yml
@@ -1,7 +1,7 @@
 # input_channel_names must match the brightfield channel name in the DESKEWED
 # store exactly — a mismatch fails at compute_transfer_function, after
 # flat-field and deskew have already run.
-input_channel_names: ["BF - Oblique"]
+input_channel_names: ["BF"]
 time_indices: "all"
 reconstruction_dimension: 3
 phase:


### PR DESCRIPTION
The brightfield channel was renamed from `BF - Oblique` to `BF` on the microscope. `input_channel_names` in the reconstruct configs must match the channel name in the deskewed store exactly, so both `nextflow/configs/a549/reconstruct.yml` and `nextflow/configs/zebrafish/reconstruct.yml` are updated to `["BF"]`.

Without this, `reconstruct` fails at `compute_transfer_function` on new acquisitions — after flat-field and deskew have already run.

### Not changed (flagging for a follow-up call)

Three other spots still mention `BF - Oblique`. None of them break on the new name, so I left them out of this scoped change:

- `.claude/skills/reconstruct-with-nextflow/templates/rename_channels.py` — the `RENAMES` map still translates `BF - Oblique` → `BF`, and `BF` is already in `PASSTHROUGH`, so new and old data both come out as `BF`. Worth keeping until no old acquisitions are being reprocessed.
- `nextflow/configs/a549/qc.yaml` — a comment explaining why brightfield is excluded from the SNR floors; the name in it is now stale but has no functional effect.
- `settings/example_flat_field_settings.yml` — a standalone example, not part of the Nextflow configs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)