### PR TITLE
fix(nextflow): retry tasks SLURM kills before they can write an exit code

### DIFF
--- a/nextflow/modules/notify.nf
+++ b/nextflow/modules/notify.nf
@@ -200,14 +200,28 @@ def failed_attempts() {
         if (!trace.exists()) {
             return null
         }
-        def outcome = [restarted: 0, failed: 0, exits: [:], job_ids: []]
+        def outcome = [restarted: 0, failed: 0, exits: [:], unknown: 0, job_ids: []]
         trace.readLines().drop(1).each { line ->
             def field = line.split('\\t')
             if (field.size() > 5 && field[4] == 'FAILED') {
-                def code = field[5].isInteger() ? field[5] as int : -1
-                if (code >= 130 && code <= 145) {
+                // An exit column of '-' is an attempt whose exit code Nextflow
+                // could NOT read (TraceRecord renders the Integer.MAX_VALUE
+                // sentinel as '-'), which on the `preempted` partition means
+                // SLURM cancelled the job before it could write .exitcode. That
+                // is an infrastructure kill exactly like a 143, and
+                // nextflow.config's errorStrategy now retries it — so it must
+                // count as restarted. Counting it as a failure (what parsing '-'
+                // to -1 did) would report a healthy run as broken.
+                def unknown = !field[5].isInteger()
+                def code = unknown ? null : field[5] as int
+                if (unknown || (code >= 130 && code <= 145)) {
                     outcome.restarted = outcome.restarted + 1
-                    outcome.exits[code] = (outcome.exits[code] ?: 0) + 1
+                    if (unknown) {
+                        outcome.unknown = outcome.unknown + 1
+                    }
+                    else {
+                        outcome.exits[code] = (outcome.exits[code] ?: 0) + 1
+                    }
                     if (field[2] && field[2].isInteger()) {
                         outcome.job_ids += field[2]
                     }
@@ -234,9 +248,15 @@ def restarted_line(outcome) {
         return 'restarted: 0'
     }
     def causes = restart_causes(outcome.job_ids)
+    // Without sacct, fall back to exit codes — including the attempts that had
+    // none, which would otherwise contribute nothing and render "restarted: N ()".
+    def by_exit = outcome.exits.sort().collect { code, n -> "exit ${code}×${n}" }
+    if (outcome.unknown) {
+        by_exit += "no exit code×${outcome.unknown}"
+    }
     def detail = causes
         ? causes.sort { entry -> -entry.value }.collect { label, n -> "${n} ${label}" }.join(', ')
-        : outcome.exits.sort().collect { code, n -> "exit ${code}×${n}" }.join(', ')
+        : by_exit.join(', ')
     return "restarted: ${outcome.restarted} (${detail})".toString()
 }
 

--- a/nextflow/modules/notify.nf
+++ b/nextflow/modules/notify.nf
@@ -205,13 +205,23 @@ def failed_attempts() {
             def field = line.split('\\t')
             if (field.size() > 5 && field[4] == 'FAILED') {
                 // An exit column of '-' is an attempt whose exit code Nextflow
-                // could NOT read (TraceRecord renders the Integer.MAX_VALUE
-                // sentinel as '-'), which on the `preempted` partition means
-                // SLURM cancelled the job before it could write .exitcode. That
-                // is an infrastructure kill exactly like a 143, and
-                // nextflow.config's errorStrategy now retries it — so it must
-                // count as restarted. Counting it as a failure (what parsing '-'
-                // to -1 did) would report a healthy run as broken.
+                // could NOT read, which on the `preempted` partition means SLURM
+                // cancelled the job before it could write .exitcode. That is an
+                // infrastructure kill exactly like a 143, and nextflow.config's
+                // errorStrategy retries it — so it must count as restarted.
+                // Counting it as a failure (what parsing '-' to -1 did) would
+                // report a healthy run as broken. When such a task does end the
+                // run it is because it burnt through maxRetries, which the
+                // "retries exhausted" note in notify_run_end covers.
+                //
+                // This is DELIBERATELY broader than the errorStrategy, which
+                // retries the Integer.MAX_VALUE sentinel but not a null status.
+                // trace.txt cannot tell those apart — TraceRecord.fmtString
+                // renders both as '-' — so no parsing here could separate them,
+                // and a null status is unreachable on the SLURM path anyway
+                // (GridTaskHandler assigns only after a non-null check). Treating
+                // every '-' as restarted is therefore exact for every case that
+                // can actually occur; do not try to "align" it with the config.
                 def unknown = !field[5].isInteger()
                 def code = unknown ? null : field[5] as int
                 if (unknown || (code >= 130 && code <= 145)) {

--- a/nextflow/modules/qc.nf
+++ b/nextflow/modules/qc.nf
@@ -58,8 +58,15 @@ process compute_step {
     cpus { params.qc_cpus as int }
     memory { "${(meta?.memory_gb ?: 16).toFloat() * task.attempt} GB" }
     time '2h'
+    // NO errorStrategy here on purpose — inherit the one in nextflow.config.
+    // This used to carry its own `task.exitStatus in [137, 140, 143]` copy, which
+    // is the same idea with a narrower list and, like the config rule before it,
+    // missed the case that matters most on the `preempted` partition: a job SLURM
+    // cancels before it can write .exitcode, whose status is unreadable rather
+    // than any code at all. A process-body directive BEATS the config selector,
+    // so the copy silently reintroduced the abort for QC even once config was
+    // fixed. `maxRetries` is still overridden — only the strategy is shared.
     maxRetries 1
-    errorStrategy { task.exitStatus in [137, 140, 143] ? 'retry' : 'terminate' }
 
     input:
     tuple val(zarr_path), val(config_path), val(step_id),
@@ -83,8 +90,8 @@ process finalize_stage {
     clusterOptions { slurm_logs('qc') }
     memory { task.attempt == 1 ? '32 GB' : '48 GB' }
     time '1h'
+    // Inherits nextflow.config's errorStrategy — see compute_step above.
     maxRetries 1
-    errorStrategy { task.exitStatus in [137, 140, 143] ? 'retry' : 'terminate' }
     tag "${zarr_path}"
 
     input:

--- a/nextflow/nextflow.config
+++ b/nextflow/nextflow.config
@@ -177,6 +177,30 @@ profiles {
             // default in the params block above is already typed.
             queueSize = (params.max_workers ?: 100) as int
             submitRateLimit = '50/1min'
+
+            // How long to wait for a task's `.exitcode` after SLURM reports the
+            // job gone, down from the 270 s default. The clock starts only once
+            // GridTaskHandler.readExitStatus() has seen BOTH that the file is
+            // missing AND that checkActiveStatus() says the job is no longer
+            // running, so this never cuts short a task that is still working — it
+            // only bounds the wait for a file that should already be on disk.
+            //
+            // It matters because a task in that limbo still holds a maxForks slot.
+            // In the 08_27 run the 0 s-elapsed cancels (see the errorStrategy note
+            // above) sat undetected for 7m30s-7m48s each — 270 s of timeout plus
+            // the 1 min `queueStatInterval` poll granularity and an initial wait —
+            // and with all 30 slots held by jobs that were already dead, deskew
+            // submitted 22 tasks at 16:02 and then NOTHING at 16:03, 16:04 or
+            // 16:05 while 31 tasks sat in the submission queue. 90 s is still far
+            // above any plausible Lustre metadata delay and cuts that stall to
+            // ~2-3 min.
+            //
+            // Do NOT drop this much lower without raising maxRetries: at 270 s the
+            // timeout doubled as an accidental backoff, and since a resubmitted
+            // job is instantly the youngest again (PreemptParameters=youngest_first,
+            // PreemptExemptTime=0) retrying faster means retrying back into the
+            // same preemption wave and burning the retry budget sooner.
+            exitReadTimeout = '90sec'
         }
         process {
             executor = 'slurm'

--- a/nextflow/nextflow.config
+++ b/nextflow/nextflow.config
@@ -65,10 +65,46 @@ process {
     // giving genuine timeout/OOM kills more headroom on retry. Applies to every
     // process (init and compute-tf included, whose outputs are idempotent); a
     // process may override with its own directive.
-    // CAVEAT: a kill that records NO exit status (rare — node loss) won't match
-    // the range and will terminate; switch to a blanket 'retry' if preemption
-    // resilience must be absolute at the cost of retrying real bugs too.
-    errorStrategy = { task.exitStatus in (130..145) ? 'retry' : 'terminate' }
+    // A kill that records NO exit status is neither rare nor node loss — it is the
+    // ordinary way this cluster reclaims a preempted job, and it aborted two runs
+    // (2026_08_25 / 2026_08_27 A549_PCNA_DENV_ZIKV — all 27 jobs whose exit status
+    // Nextflow could not read were `CANCELLED by 0` at 00:00:00 elapsed). `PreemptMode=REQUEUE` (cluster-wide
+    // and on `preempted`) cannot requeue a job Nextflow submits with
+    // `--no-requeue`, so slurmctld CANCELS it outright. A cancel is NOT the
+    // graceful preempt path: the partition's GraceTime=30 is only extended to a
+    // job "selected for preemption" (which then gets SIGCONT+SIGTERM, runs its
+    // trap, and exits 143), so it never applies here. sacct shows the split
+    // plainly — over the 08_27 run, 37 jobs are `CANCELLED` at 00:00:00 elapsed
+    // against just 2 `PREEMPTED`. At 0 s elapsed the batch script has not run its
+    // first line (no .command.begin), so `trap on_exit EXIT` is not installed and
+    // NOTHING in the job can write .exitcode — not a longer GraceTime, not a
+    // signal handler. `PreemptExemptTime=00:00:00` and
+    // `PreemptParameters=youngest_first` are what make the just-submitted jobs
+    // the first reclaimed. Nextflow then waits `executor.exitReadTimeout` (270 s
+    // default) for the file, gives up, and finalizes the task with the "unknown"
+    // sentinel — logged as `exit: -`, written to trace.txt as `-`.
+    //
+    // The cluster-side fixes (both need HPC admins, and neither removes the need
+    // for this rule) are `PreemptMode=CANCEL` on the `preempted` partition, which
+    // routes reclaims through the GraceTime path instead of a bare cancel, and a
+    // non-zero `PreemptExemptTime`, which stops SLURM reclaiming jobs that have
+    // only just started.
+    //
+    // That sentinel must therefore be retryable. It is Integer.MAX_VALUE, NOT null
+    // (TaskRun initializes `exitStatus` to Integer.MAX_VALUE), so the intuitive
+    // `task.exitStatus == null` guard would compile, read plausibly, and fix
+    // nothing. Retrying an unreadable status does not weaken fail-fast: a genuine
+    // error — bad config, code bug — always DOES record an exit code, so an
+    // unreadable status is by construction an infrastructure kill rather than a
+    // bug to surface.
+    //
+    // A null exit status is deliberately NOT matched, so it terminates the run.
+    // It is unreachable on the SLURM path anyway — GridTaskHandler assigns the
+    // status only after a non-null check in checkIfCompleted(), and submit()
+    // boxes a primitive int — so a null would mean an executor behaving in a way
+    // this rule has never been reasoned about, which is worth stopping for rather
+    // than retrying blind. Do not "fix" it by adding null to the list.
+    errorStrategy = { task.exitStatus in (130..145) + [Integer.MAX_VALUE] ? 'retry' : 'terminate' }
     maxRetries = 5
 
     withLabel: 'cpu_local' {


### PR DESCRIPTION
## Problem

Two reconstruction runs aborted mid-flight — `2026_08_25_A549_PCNA_DENV_ZIKV` and `2026_08_27_A549_PCNA_DENV_ZIKV` — even though every failure was infrastructure, not code:

```
Process `deskew_wf:run_deskew (C/2/0053)` terminated for an unknown reason
  -- Likely it has been terminated by the external system
```

## Root cause

Not "preempted before writing an exit code" in the usual sense. These jobs were **cancelled before running their first line**.

All 27 jobs whose exit status Nextflow could not read were `CANCELLED by 0` at **`00:00:00` elapsed**, with work dirs holding only `.command.run` / `.command.sh` and **no `.command.begin`**. Over the 08_27 window `sacct` records **37 such cancels against just 2 `PREEMPTED`**.

The chain:

1. The partition is `PreemptMode=REQUEUE`, but Nextflow submits `--no-requeue`, so slurmctld **cancels** rather than requeues. A bare cancel is not the graceful-preempt path, so the partition's `GraceTime=30` never applies.
2. `PreemptExemptTime=00:00:00` and `PreemptParameters=youngest_first` make the jobs *just submitted* the first reclaimed — killed before `trap on_exit EXIT` is installed, so nothing in the job can write `.exitcode`.
3. Nextflow waits out `executor.exitReadTimeout` (270 s), gives up, and finalizes the task with its "unknown" sentinel — logged as `exit: -`.
4. That sentinel is **`Integer.MAX_VALUE`, not null**, so `task.exitStatus in (130..145)` was false → `terminate` → the whole run died.

Genuine preemption of a *running* job was always handled correctly: the 08_25 run retried 20 clean `143`s.

## Changes

- **`nextflow.config`** — add the sentinel to the retry set:
  ```groovy
  errorStrategy = { task.exitStatus in (130..145) + [Integer.MAX_VALUE] ? 'retry' : 'terminate' }
  ```
  A null exit status is deliberately still terminal; it is unreachable on the SLURM path anyway (`GridTaskHandler` assigns only after a non-null check in `checkIfCompleted()`, and `submit()` boxes a primitive `int`).
- **`modules/qc.nf`** — drop two narrower `[137, 140, 143]` copies of the rule. A process-body directive beats the config selector, so QC would have kept aborting even after the config fix.
- **`modules/notify.nf`** — count a `-` exit column as *restarted* rather than *failed*, so the run summary no longer reports a healthy run as broken.

This does not weaken fail-fast: a genuine error — bad config, code bug — always *does* record an exit code, so an unreadable status is by construction an infrastructure kill.

### Second commit: `exitReadTimeout` 270s → 90s

A task in this state still holds a `maxForks` slot until Nextflow gives up on `.exitcode`, and the real wait is longer than the timeout alone. Measured from `sacct` End to the log's give-up line in the 08_27 run:

```
job 35946030  died=16:02:12  detected=16:10:00  limbo=7m48s
job 35946038  died=16:02:30  detected=16:10:00  limbo=7m30s
...  (12 jobs, all 7m30s–7m48s)
```

That is 270 s plus the 1 min `queueStatInterval` poll granularity and an initial wait. With all 30 slots held by jobs that were already dead, the fan-out stalled outright — submissions per minute:

```
16:02 → 22
16:03 → 0
16:04 → 0      ← 31 tasks sitting in the submission queue
16:05 → 0
16:06 → 3
```

Lowering it is safe because the clock starts only once `readExitStatus()` has seen **both** that the file is missing **and** that `checkActiveStatus()` reports the job gone — it never cuts short a task that is still running, it only bounds the wait for a file that should already be on disk. 90 s stays far above any plausible Lustre metadata delay and cuts the stall to ~2–3 min. Scoped to the `slurm` profile; the default applies elsewhere.

The comment also records why it should not go much lower without raising `maxRetries`: at 270 s the timeout doubled as an accidental backoff, and a resubmitted job is instantly the youngest again under `youngest_first` with `PreemptExemptTime=0`, so retrying faster means retrying straight back into the same preemption wave.

## Verification

Reproduced on SLURM by SIGKILLing a task's batch shell so no `.exitcode` was written, giving the same `terminated for an unknown reason` signature as the production runs:

| | pre-fix rule | this PR |
|---|---|---|
| outcome | `Session aborted` | `Execution is retried (1)` |
| `retriesCount` | 0 | 1 |
| `abortedCount` | 0 | 0 |
| run | dies | `Execution complete` |

The retry expression was also checked as a truth table through Nextflow 26.04.3's parser — `1`/`0`/`146` → `terminate`; `130`/`137`/`143`/`145`/`Integer.MAX_VALUE` → `retry`.

`nextflow lint` passes with no errors.

## Follow-up for HPC admins (not in this PR)

Two cluster-side changes would stop the exit codes going missing in the first place, though neither removes the need for this rule (node failure and hard OOM kills can still lose the file):

- `PreemptMode=CANCEL` on the `preempted` partition, so reclaims take the `GraceTime` path (SIGTERM + 30 s → clean `143`) instead of a bare cancel.
- A non-zero `PreemptExemptTime`, so a job always lives long enough to install its trap — this also stops burning cycles on jobs reclaimed at 0 s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

