### PR TITLE
feat(nextflow): run every step's init before any compute starts

### DIFF
--- a/.claude/skills/reconstruct-with-nextflow/references/caveats.md
+++ b/.claude/skills/reconstruct-with-nextflow/references/caveats.md
@@ -291,6 +291,12 @@ plate for *all* positions with data in only the first — correct and expected.
 Do not treat such a store as a deliverable, and delete it before a real run so
 `-resume` cannot reuse it.
 
+Since the init phase moved to the front of the run, this is visible sooner and
+for every step at once: a smoke test creates the full-width plate for
+flat-field, deskew, reconstruct, virtual-stain, assemble AND track within the
+first minutes, before a single position has been computed. Nothing changed
+about what ends up on disk — only when it appears.
+
 (Related, for pipeline developers: a param passed as `--foo 1` on the command
 line arrives as a String; coerce numeric params at the point of use and test
 via the CLI — see the comments in `nextflow/modules/common.nf`.)

--- a/.claude/skills/reconstruct-with-nextflow/references/monitoring.md
+++ b/.claude/skills/reconstruct-with-nextflow/references/monitoring.md
@@ -122,10 +122,12 @@ Two traps, both hit for real:
 
 - **Name the store.** A bare `$d/*.zarr/*/*/*/` overcounts `2-reconstruct`, which
   also holds `transfer_function.zarr` (10 instead of 8 for an 8-position plate).
-- **This counts scaffolds, not finished work.** Each step's cached `init-*` task
-  creates every position's metadata up front, so a step shows its full position
-  count from the moment it starts — a step whose every task *failed* still reads
-  8/8 here. Use it for "has this step started", never for "is this step done".
+- **This counts scaffolds, not finished work.** Every step's `init_*` task runs
+  in the run's first minutes — the pipeline does the whole init chain before any
+  compute — and each creates every position's metadata up front. So EVERY step
+  reads its full position count from a few minutes into the run, including steps
+  that will not start for hours and steps whose every task later fails. Use this
+  only to confirm the init phase completed; it says nothing about progress.
   `trace.txt` is the only authoritative source for completion:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -187,6 +187,8 @@ nextflow/
 
 Each step module runs the same CLI you would run by hand, in two phases: `biahub <step> --init` creates the output store and reports the CPU/memory/time a single position needs, then Nextflow fans out one `biahub <step> --cluster debug` task per position with those resources. `--cluster debug` makes the CLI do the work in-process, so Nextflow — not `submitit` — owns job submission.
 
+**A run does every step's `--init` first, before any compute.** Each `--init` is metadata-only — it reads the input store's channel names, shape and scale, derives the output geometry from the config, and creates the output plate — so it needs its input store to exist, not to hold data. That lets the inits chain: flat-field's scaffolds the plate deskew's reads, and so on down to tracking, whose init reads the assembled plate `concatenate --init` created. The whole chain runs on the head node in the run's first minutes, so a typo in `track.yml` stops the run there instead of after every reconstruction step has been paid for. QC's `plan-stage` and `estimate-resources` join the same phase for the same reason.
+
 ### Running a pipeline
 
 Install [Nextflow](https://www.nextflow.io/docs/latest/install.html) (requires Java 17+), then launch from the `nextflow/` directory so that `nextflow.config` is picked up automatically:

--- a/biahub/apply_inverse_transfer_function.py
+++ b/biahub/apply_inverse_transfer_function.py
@@ -66,6 +66,15 @@ def _init_output_plate(
         **output_metadata,
         metadata_sources=input_plate,
         metadata_keys=PROVENANCE_METADATA_KEYS,
+        # The record waveorder itself writes once a position is reconstructed
+        # (waveorder/cli/apply_inverse_transfer_function.py, "Save metadata at
+        # position level, keyed by output channel names"), written here so the
+        # plate carries it from the moment it exists -- the next step's
+        # create_empty_plate inherits provenance at plate-creation time, and
+        # the pipeline scaffolds every store before any of them hold data.
+        # waveorder merges into whatever is already under "waveorder" and
+        # re-assigns the same key, so its own write stays idempotent.
+        extra_metadata={"waveorder": {",".join(channel_names): settings.model_dump()}},
     )
 
     return input_shape, channel_names

--- a/biahub/concatenate.py
+++ b/biahub/concatenate.py
@@ -381,6 +381,7 @@ def _prepare_concatenate(settings: ConcatenateSettings, output_dirpath: Path) ->
         position_keys=[p.parts[-3:] for p in output_position_paths],
         metadata_sources=list(reversed(source_plates)),
         metadata_keys=PROVENANCE_METADATA_KEYS,
+        extra_metadata={"biahub-concatenate": settings.model_dump()},
         **output_metadata,
     )
     click.echo(f"Created {output_dirpath} ({len(output_position_paths)} positions)")
@@ -511,17 +512,6 @@ def concatenate(
             prep["all_slicing_params"],
             strict=True,
         ):
-            # Preserve extra_metadata written by create_empty_plate's
-            # metadata_sources — process_single_position overwrites it with None
-            # when the kwarg is absent (iohub <= 0.3.7) — and record this step's
-            # own provenance alongside it.
-            with open_ome_zarr(str(output_position_path), layout="fov", mode="r") as pos:
-                existing_extra = pos.zattrs.get("extra_metadata")
-            merged_extra = {
-                **(existing_extra or {}),
-                "biahub-concatenate": settings.model_dump(),
-            }
-
             job = executor.submit(
                 process_single_position,
                 copy_n_paste,
@@ -534,7 +524,6 @@ def concatenate(
                 num_workers=slurm_args["slurm_cpus_per_task"],
                 resume=resume,
                 resume_token=settings_fingerprint(settings),
-                extra_metadata=merged_extra,
                 zyx_slicing_params=zyx_slicing_params,
             )
             jobs.append(job)

--- a/biahub/deskew.py
+++ b/biahub/deskew.py
@@ -637,6 +637,7 @@ def _init_output_plate(
         ),
         metadata_sources=input_plate,
         metadata_keys=PROVENANCE_METADATA_KEYS,
+        extra_metadata={"biahub-deskew": settings.model_dump()},
     )
 
     return (T, C, Z, Y, X), channel_names
@@ -709,7 +710,6 @@ def deskew(
         "average_n_slices": settings.average_n_slices,
         "overhang_fill": settings.overhang_fill,
         "device": settings.device,
-        "extra_metadata": {"biahub-deskew": settings.model_dump()},
     }
 
     slurm_args = {

--- a/biahub/flat_field.py
+++ b/biahub/flat_field.py
@@ -194,6 +194,7 @@ def _init_output_plate(
         dtype=np.float32,
         metadata_sources=input_plate,
         metadata_keys=PROVENANCE_METADATA_KEYS,
+        extra_metadata={"biahub-flat_field": settings.model_dump()},
     )
 
     return (T, C, Z, Y, X), all_channel_names
@@ -288,7 +289,6 @@ def flat_field(
 
     flat_field_args = {
         "target_indices": target_indices,
-        "extra_metadata": {"biahub-flat_field": settings.model_dump()},
     }
 
     slurm_args = {

--- a/biahub/track.py
+++ b/biahub/track.py
@@ -964,13 +964,8 @@ def _init_output_plate(
         dtype=np.uint32,
         metadata_sources=input_plate,
         metadata_keys=PROVENANCE_METADATA_KEYS,
+        extra_metadata={"biahub-track": settings.model_dump(mode="json")},
     )
-
-    # Record provenance on each output position, mirroring the extra_metadata
-    # block that the process_single_position-based commands write.
-    with open_ome_zarr(output_dirpath, mode="r+") as output_plate:
-        for _, output_position in output_plate.positions():
-            output_position.zattrs["biahub-track"] = settings.model_dump(mode="json")
 
     click.echo(f"Created {output_dirpath} ({len(position_keys)} positions)")
 

--- a/biahub/virtual_stain.py
+++ b/biahub/virtual_stain.py
@@ -271,16 +271,8 @@ def _init_output_plate(
         version=resolve_ome_zarr_version(input_position_dirpaths[0], output_ome_zarr_version),
         metadata_sources=input_plate,
         metadata_keys=PROVENANCE_METADATA_KEYS,
+        extra_metadata=extra_metadata,
     )
-
-    if extra_metadata:
-        for input_position_dirpath in input_position_dirpaths:
-            position_key = Path(input_position_dirpath).parts[-3:]
-            with open_ome_zarr(
-                str(Path(output_dirpath).joinpath(*position_key)), mode="r+"
-            ) as output_position:
-                for key, value in extra_metadata.items():
-                    output_position.zattrs[key] = value
 
     return (T, C, Z, Y, X)
 

--- a/nextflow/mantis-v2.nf
+++ b/nextflow/mantis-v2.nf
@@ -417,11 +417,11 @@ workflow {
     // gated on every store's finalize, so its completion is exactly "QC of all
     // stores is done". Its report directory stands in for an output zarr.
     def step_events = [
-        [label: 'init (configs validated)', done: init_done,                 output: out],
-        [label: 'flat-field',               done: ff_done.done,              output: ff_output],
-        [label: 'deskew',                   done: deskew_done.done,          output: deskew_output],
-        [label: 'phase reconstruction',     done: reconstruct_done.done,     output: reconstruct_output],
-        [label: 'virtual staining',         done: virtual_stain_done.done,   output: virtual_stain_output],
+        [label: 'initialize',           done: init_done,                 output: out],
+        [label: 'flat-field',           done: ff_done.done,              output: ff_output],
+        [label: 'deskew',               done: deskew_done.done,          output: deskew_output],
+        [label: 'phase reconstruction', done: reconstruct_done.done,     output: reconstruct_output],
+        [label: 'virtual staining',     done: virtual_stain_done.done,   output: virtual_stain_output],
     ]
     if (assemble_on) step_events << [label: 'assemble', done: assemble_done.done, output: assemble_output]
     if (track_on)    step_events << [label: 'track',    done: track_done.done,    output: track_output]

--- a/nextflow/mantis-v2.nf
+++ b/nextflow/mantis-v2.nf
@@ -11,11 +11,16 @@ nextflow.enable.dsl = 2
 //       directory_layout() below), and
 //    2. the ORDER steps run in and what each step reads/writes.
 //
-//  Each step's subworkflow (e.g. deskew_wf) is path-agnostic and speaks only in
-//  zarr: this pipeline hands it explicit input_zarr/output_zarr paths. The
-//  pipeline itself speaks in `input`/`output`, where `input` may NOT be a zarr
-//  (in some pipelines the first step converts raw input to zarr). To reorder
-//  steps, change where a step reads from here; the modules stay untouched.
+//  Each step's subworkflows (e.g. deskew_init_wf / deskew_run_wf) are
+//  path-agnostic and speak only in zarr: this pipeline hands them explicit
+//  input_zarr/output_zarr paths. The pipeline itself speaks in `input`/`output`,
+//  where `input` may NOT be a zarr (in some pipelines the first step converts
+//  raw input to zarr). To reorder steps, change where a step reads from here;
+//  the modules stay untouched.
+//
+//  EVERY STEP IS SPLIT INTO AN INIT AND A RUN SUBWORKFLOW, and this file runs
+//  all the inits before any of the runs. See the INIT PHASE comment in the
+//  workflow body for why that is possible and what it buys.
 //
 //  Flat-field → deskew → reconstruct → virtual-stain → assemble → track → QC is
 //  the full chain: assemble concatenates the deskew/reconstruct/virtual-stain
@@ -47,13 +52,13 @@ params.qc_config = null
 params.qc_track_config = null
 
 include { collect_positions; dataset_name; check_environment } from './modules/common'
-include { deskew_wf } from './modules/deskew'
-include { flat_field_wf } from './modules/flat_field'
-include { reconstruct_wf } from './modules/reconstruct'
-include { virtual_stain_wf } from './modules/virtual_stain'
-include { track_wf } from './modules/tracking'
-include { assemble_wf } from './modules/assembly'
-include { qc_stage_wf; qc_report_wf; qc_report_spec } from './modules/qc'
+include { flat_field_init_wf; flat_field_run_wf } from './modules/flat_field'
+include { deskew_init_wf; deskew_run_wf } from './modules/deskew'
+include { reconstruct_init_wf; reconstruct_tf_wf; reconstruct_run_wf } from './modules/reconstruct'
+include { virtual_stain_init_wf; virtual_stain_run_wf } from './modules/virtual_stain'
+include { assemble_init_wf; assemble_run_wf } from './modules/assembly'
+include { track_init_wf; track_run_wf } from './modules/tracking'
+include { qc_plan_wf; qc_compute_wf; qc_report_wf; qc_report_spec } from './modules/qc'
 include { notify_step; notify_run_start; notify_run_end } from './modules/notify'
 
 // Output directory layout for the reconstruction steps — single source of
@@ -101,12 +106,6 @@ def step_directories(performed) {
     return layout
 }
 
-
-// The reconstruction steps, in the order they run, as they are named in Slack.
-// One list so the run-start announcement cannot disagree with the per-step
-// messages. A function rather than a bare assignment for the same reason
-// directory_layout() is one: Nextflow's DSL2 parser allows only declarations at
-// script scope.
 workflow {
     if (!params.input)              error "Provide --input"
     if (!params.output)             error "Provide --output"
@@ -162,91 +161,200 @@ workflow {
     collect_positions(params.input)
     all_positions = collect_positions.out
 
-    // ----- Flat-field -------------------------------------------------------
-    // The pipeline input is already a zarr, so flat-field reads it directly and
-    // writes the flat-field step directory. When a convert step is added ahead
-    // of flat-field, point ff_input at the convert output instead — flat_field_wf
-    // doesn't care where its input comes from.
-    ff_trigger = channel.value(true)
-    ff_input  = params.input
-    ff_output = "${out}/${layout.flat_field}/${ds}.zarr"
+    // ----- Where each step reads and writes ---------------------------------
+    // Resolved up front, because BOTH phases below need them and the init phase
+    // wires steps together by path before any of them has run. The pipeline
+    // input is already a zarr, so flat-field reads it directly. When a convert
+    // step is added ahead of flat-field, point ff_input at the convert output
+    // instead — the step modules don't care where their input comes from.
+    ff_input             = params.input
+    ff_output            = "${out}/${layout.flat_field}/${ds}.zarr"
+    deskew_output        = "${out}/${layout.deskew}/${ds}.zarr"
+    reconstruct_output   = "${out}/${layout.reconstruct}/${ds}.zarr"
+    virtual_stain_output = "${out}/${layout.virtual_stain}/${ds}.zarr"
+    assemble_output      = assemble_on ? "${out}/${layout.assemble}/${ds}.zarr" : null
+    track_output         = track_on    ? "${out}/${layout.track}/${ds}.zarr"    : null
 
-    ff_done = flat_field_wf(all_positions, ff_input, ff_output, params.flat_field_config, ff_trigger)
+    // ========================================================================
+    //  INIT PHASE — every config parsed, every output store scaffolded, before
+    //  any compute is submitted.
+    //
+    //  WHY THIS IS POSSIBLE. Every `--init` is metadata-only: it reads the first
+    //  input position's channel names, shape and scale, derives the output
+    //  geometry from the config, creates the output plate (create_empty_plate is
+    //  idempotent) and prints the RESOURCES line. Nothing reads a pixel. So a
+    //  step's init needs its input store to EXIST, not to be FILLED — and the
+    //  store that has to exist is the one the previous step's init just created.
+    //  That is why the chain below is serial: flat-field's init makes the plate
+    //  deskew's init reads, and so on down to tracking, whose init reads the
+    //  assembled plate that `concatenate --init` scaffolded.
+    //
+    //  WHY IT IS WORTH IT. Before this, a config was not parsed until the step
+    //  that consumes it was about to run, so a typo in track.yml surfaced seven
+    //  hours in, with every reconstruction step already paid for. Now the whole
+    //  chain runs on the head node in the run's first minutes, and it is real
+    //  validation rather than a schema check: concatenate resolves its channel
+    //  mapping against all three source stores, virtual-stain validates its
+    //  predict config against VisCy's schema, and every settings model is
+    //  constructed with `extra="forbid"`.
+    //
+    //  DO NOT PARALLELISE THIS. Each init depends on the plate the one before it
+    //  created; running them concurrently would race on stores that do not exist
+    //  yet. It is cheap precisely because it is metadata-only — seconds per step
+    //  — so there is nothing to win.
+    //
+    //  Provenance depends on this ordering too. `create_empty_plate` inherits a
+    //  source store's `biahub-*` zattrs at plate-creation time and only for
+    //  positions it creates, so each step must stamp its OWN record during init
+    //  (iohub's `extra_metadata`) or the chain would be empty by the time the
+    //  next plate is made. See stamp-at-init in biahub/utils/ngff.py's callers.
+    // ========================================================================
+    ff_init = flat_field_init_wf(ff_input, ff_output, params.flat_field_config,
+                                 channel.value('start'))
+    dk_init = deskew_init_wf(ff_output, deskew_output, params.deskew_config,
+                             ff_init.done)
+    rc_init = reconstruct_init_wf(deskew_output, reconstruct_output, params.reconstruct_config,
+                                  dk_init.done)
+    vs_init = virtual_stain_init_wf(reconstruct_output, virtual_stain_output,
+                                    params.virtual_stain_config, rc_init.done)
 
-    // ----- Deskew -----------------------------------------------------------
-    // Deskew reads flat-field's output and waits on ff_done before starting.
-    deskew_trigger = ff_done.done
-    deskew_input  = ff_output
-    deskew_output = "${out}/${layout.deskew}/${ds}.zarr"
+    // Collected so the gate below can name them all. The chain is serial, so
+    // waiting on the last one already implies the rest — they are listed anyway
+    // because QC planning hangs off the side of the chain rather than extending
+    // it, and because a future step inserted here should not have to notice.
+    def init_signals = [vs_init.done]
 
-    deskew_done = deskew_wf(all_positions, deskew_input, deskew_output, params.deskew_config, deskew_trigger)
-
-    // ----- Reconstruct ------------------------------------------------------
-    // Phase reconstruction runs on the deskewed output and waits on deskew_done.
-    // It reads the deskewed brightfield channel — which channel is reconstructed
-    // is set by `input_channel_names` in the reconstruct config, not here.
-    reconstruct_trigger = deskew_done.done
-    reconstruct_input   = deskew_output
-    reconstruct_output  = "${out}/${layout.reconstruct}/${ds}.zarr"
-
-    reconstruct_done = reconstruct_wf(all_positions, reconstruct_input, reconstruct_output, params.reconstruct_config, reconstruct_trigger)
-
-    // ----- Virtual stain ----------------------------------------------------
-    // Virtual staining runs cytoland (VisCy) prediction on the reconstructed
-    // output and waits on reconstruct_done. A `viscy preprocess` step inside the
-    // subworkflow computes the normalization statistics the model needs; which
-    // source/target channels are used is set by the virtual-stain config, not
-    // here.
-    virtual_stain_trigger = reconstruct_done.done
-    virtual_stain_input   = reconstruct_output
-    virtual_stain_output  = "${out}/${layout.virtual_stain}/${ds}.zarr"
-
-    virtual_stain_done = virtual_stain_wf(all_positions, virtual_stain_input, virtual_stain_output, params.virtual_stain_config, virtual_stain_trigger)
-
-    // ----- Assemble ---------------------------------------------------------
-    // Concatenate the deskew, reconstruct, and virtual-stain outputs channel-wise
-    // into a single multichannel plate, waiting on virtual_stain_done. Unlike the
-    // per-position steps this runs single-shot on ONE reserved compute node
-    // (`concatenate --cluster debug` iterates every position in-process); which
-    // channels/crops come from each source is set by the concatenate config, not
-    // here. The config's concat_data_paths are placeholders — the subworkflow
-    // injects the three source paths via --concat-data-paths (resolve mode).
     if (assemble_on) {
-        assemble_output = "${out}/${layout.assemble}/${ds}.zarr"
-        assemble_done = assemble_wf(
-            deskew_output,
-            reconstruct_output,
-            virtual_stain_output,
-            assemble_output,
-            params.concatenate_config,
-            virtual_stain_done.done
-        )
+        // Assemble reads the deskew, reconstruct and virtual-stain stores. Its
+        // init resolves those three paths into the config and creates the
+        // assembled plate from their metadata — which is how a concatenate
+        // config naming a channel no source store has fails here rather than
+        // after virtual staining.
+        as_init = assemble_init_wf(deskew_output, reconstruct_output, virtual_stain_output,
+                                   assemble_output, params.concatenate_config, vs_init.done)
+        init_signals << as_init.done
     }
 
-    // ----- Track ------------------------------------------------------------
-    // Track reads the ASSEMBLED plate for both of its inputs: assemble already
-    // carries the phase and virtual-stain channels (concatenate preserves channel
-    // names, so the track config's channel names resolve unchanged), so the plate
-    // structure and the image data come from the same store. It waits on
-    // assemble_done, which means tracking now runs AFTER assemble rather than in
-    // parallel with it — the tradeoff for the single input is that the whole plate
-    // must be assembled first. Two consequences of reading the assembled plate:
-    // any Z/Y/X crop or time_indices subset in the concatenate config is what
-    // tracking sees, and the intermediate stores are no longer needed once
-    // assemble is verified. To go back to the parallel wiring, point track_input
-    // at reconstruct_output, track_input_images at virtual_stain_output, and gate
-    // on virtual_stain_done.
     if (track_on) {
-        track_output = "${out}/${layout.track}/${ds}.zarr"
-        track_done = track_wf(all_positions, assemble_output, assemble_output, track_output,
-                              params.track_config, assemble_done.done)
+        // Track reads the ASSEMBLED plate for both of its inputs: assemble
+        // already carries the phase and virtual-stain channels (concatenate
+        // preserves channel names, so the track config's channel names resolve
+        // unchanged), so the plate structure and the image data come from the
+        // same store. Its init also warms the shared cellpose weights cache,
+        // which is better done here than with N GPU workers racing for it.
+        tk_init = track_init_wf(assemble_output, track_output, params.track_config,
+                                as_init.done)
+        init_signals << tk_init.done
     }
 
-    // ----- QC ---------------------------------------------------------------
-    // QC reads the finished stores, gated on the step that wrote each one:
-    // the ASSEMBLED plate on assemble_done (the same signal track waits on, so
-    // image QC runs CONCURRENTLY with tracking), and the tracking store on
-    // track_done. Neither extends the critical path ahead of itself.
+    // QC's planning verbs belong in this phase for the same reason the step
+    // inits do — `plan-stage` and `estimate-resources` read the store's
+    // structure and validate the config, and read no pixels. Each store's plan
+    // is gated on the init that scaffolded it. The tab label is the step
+    // directory, which is unique per store by construction.
+    def qc_stores = []
+    if (qc_on) {
+        if (qc_image_on) {
+            qc_stores << [label: layout.assemble, zarr: assemble_output,
+                          config: params.qc_config, scaffolded: as_init.done]
+        }
+        if (qc_track_on) {
+            qc_stores << [label: layout.track, zarr: track_output,
+                          config: params.qc_track_config, scaffolded: tk_init.done]
+        }
+
+        // The trigger is mapped, NOT combined. `combine` concatenates the two
+        // items, so what the producer emits leaks into the tuple's arity: an
+        // init emits one token and gave `[zarr, config, token]`, but a collected
+        // producer emits a LIST of every position's output, so the tuple became
+        // `[zarr, config, p1, p2, … p30]` and a three-parameter closure could not
+        // be spread across it — `MissingMethodException`, after seven hours.
+        // Mapping reads nothing out of the trigger, so no producer's payload
+        // shape can reach this.
+        //
+        // Every step's `done` is a VALUE channel by contract (see the step
+        // modules' emit blocks), so this is one plan per store however many
+        // items the producer itself emitted.
+        qc_plan_inputs = channel.empty()
+        qc_stores.each { st ->
+            qc_plan_inputs = qc_plan_inputs.mix( st.scaffolded.map { tuple(st.zarr, st.config) } )
+        }
+        qc_plan = qc_plan_wf(qc_plan_inputs)
+        init_signals << qc_plan.done
+    }
+
+    // ONE gate for the whole compute phase: nothing reaches SLURM until every
+    // config in the run has been parsed and every output store exists. Mixed
+    // and collected the same way notify_events is below, because a workflow body
+    // is graph construction and `init_signals` is a plain Groovy list of
+    // channels, not a channel of channels.
+    init_gate = channel.empty()
+    init_signals.each { signal -> init_gate = init_gate.mix(signal) }
+    init_done = init_gate.collect().map { 'done' }
+
+    // ========================================================================
+    //  COMPUTE PHASE
+    //
+    //  The per-step barriers are unchanged: each step waits for every position
+    //  of the one before it. Letting a single position flow through the steps
+    //  independently is issue #304, and is blocked on two whole-plate steps —
+    //  `viscy preprocess` and single-shot `concatenate` — not on this wiring.
+    // ========================================================================
+    ff_done = flat_field_run_wf(all_positions, ff_input, ff_output,
+                                params.flat_field_config, ff_init.resources, init_done)
+
+    deskew_done = deskew_run_wf(all_positions, ff_output, deskew_output,
+                                params.deskew_config, dk_init.resources, ff_done.done)
+
+    // The transfer function is built from the deskewed plate's SHAPE alone, so
+    // it is gated on init_done rather than on the deskew data. It overlaps
+    // flat-field and deskew instead of sitting between them and reconstruction.
+    tf = reconstruct_tf_wf(deskew_output, reconstruct_output, params.reconstruct_config,
+                           init_done)
+
+    // Phase reconstruction runs on the deskewed output. Which channel is
+    // reconstructed is set by `input_channel_names` in the reconstruct config.
+    reconstruct_done = reconstruct_run_wf(all_positions, deskew_output, reconstruct_output,
+                                          params.reconstruct_config, rc_init.resources,
+                                          tf.done, deskew_done.done)
+
+    // Virtual staining runs cytoland (VisCy) prediction on the reconstructed
+    // output. Its `viscy preprocess` pass reads every position's pixels and
+    // writes the normalization statistics prediction reads back, which is why
+    // this step keeps a whole-plate barrier ahead of it.
+    virtual_stain_done = virtual_stain_run_wf(all_positions, reconstruct_output,
+                                              virtual_stain_output,
+                                              params.virtual_stain_config,
+                                              vs_init.resources, reconstruct_done.done)
+
+    // Concatenate the deskew, reconstruct and virtual-stain outputs channel-wise
+    // into a single multichannel plate. Unlike the per-position steps this runs
+    // single-shot on ONE reserved compute node (`concatenate --cluster debug`
+    // iterates every position in-process).
+    if (assemble_on) {
+        assemble_done = assemble_run_wf(assemble_output, params.concatenate_config,
+                                        as_init.resources, virtual_stain_done.done)
+    }
+
+    // Tracking runs AFTER assemble rather than in parallel with it — the
+    // tradeoff for reading one store instead of two is that the whole plate must
+    // be assembled first. Two consequences: any Z/Y/X crop or time_indices subset
+    // in the concatenate config is what tracking sees, and the intermediate
+    // stores are no longer needed once assemble is verified. To go back to the
+    // parallel wiring, point the first input at reconstruct_output, the second at
+    // virtual_stain_output, and gate on virtual_stain_done.
+    if (track_on) {
+        track_done = track_run_wf(all_positions, assemble_output, assemble_output,
+                                  track_output, params.track_config,
+                                  tk_init.resources, assemble_done.done)
+    }
+
+    // ----- QC compute -------------------------------------------------------
+    // Planned in the init phase; the compute it planned is gated on the step
+    // that wrote each store — the ASSEMBLED plate on assemble_done (the same
+    // signal track waits on, so image QC runs CONCURRENTLY with tracking), and
+    // the tracking store on track_done. Neither extends the critical path ahead
+    // of itself.
     //
     // A QC verdict cannot fail the pipeline: `imaging-qc gate` exits 0 whether
     // positions pass or fail, recording the verdict in each store's own
@@ -255,42 +363,25 @@ workflow {
     qc_report_dir = params.qc_report_dir ?: "${out}/qc/report"
 
     if (qc_on) {
-        // Tab label is the step directory, which is unique per store by
-        // construction — the spec requires unique labels.
-        def qc_stores = []
-        if (params.qc_config) {
-            qc_stores << [label: layout.assemble, zarr: assemble_output,
-                          config: params.qc_config, trigger: assemble_done.done]
-        }
-        if (params.qc_track_config) {
-            qc_stores << [label: layout.track, zarr: track_output,
-                          config: params.qc_track_config, trigger: track_done.done]
-        }
-
         // Written at launch, before any QC task runs: everything in it is known
         // from the layout above, so a malformed spec fails now rather than after
         // hours of compute.
         def spec = qc_report_spec(qc_stores, "${out}/qc/report_spec.yaml", "QC — ${ds}")
 
-        // Each store waits only on its own producer, so they QC independently.
-        //
-        // The trigger is mapped, NOT combined. `combine` concatenates the two
-        // items, so what the producer emits leaks into the tuple's arity: assemble
-        // emits one path and gave `[zarr, config, path]`, but tracking emits a
-        // COLLECTED LIST of every position's output, so the tuple became
-        // `[zarr, config, p1, p2, … p30]` and a three-parameter closure could not
-        // be spread across it — `MissingMethodException`, after seven hours, with
-        // every reconstruction step already finished. Mapping reads nothing out of
-        // the trigger, so no producer's payload shape can reach this.
-        //
-        // `.first()` because a trigger is a signal, not a stream: one QC run per
-        // store however many items its producer emits.
-        qc_inputs = channel.empty()
-        qc_stores.each { st ->
-            qc_inputs = qc_inputs.mix( st.trigger.first().map { tuple(st.zarr, st.config) } )
+        // Keyed [zarr, config] to match what qc_plan_wf emitted, so each store's
+        // planned work is released by its own producer and no other. Mapped, not
+        // combined, for the reason spelled out at qc_plan_inputs above.
+        qc_compute_ready = channel.empty()
+        if (qc_image_on) {
+            qc_compute_ready = qc_compute_ready.mix(
+                assemble_done.done.map { tuple(assemble_output, params.qc_config) } )
+        }
+        if (qc_track_on) {
+            qc_compute_ready = qc_compute_ready.mix(
+                track_done.done.map { tuple(track_output, params.qc_track_config) } )
         }
 
-        qc = qc_stage_wf(qc_inputs)
+        qc = qc_compute_wf(qc_plan.items, qc_plan.stores, qc_compute_ready)
         qc_report = qc_report_wf(qc.done, spec, qc_report_dir)
     }
 
@@ -306,9 +397,10 @@ workflow {
     //
     // Nothing here reads a position count. It is the same for every step, so
     // saying it six times adds nothing; the run-start message reports it once.
-    // That also removes a trap: assemble_wf's output carries a single path
-    // String rather than the collected position list, and `('a/b.zarr' as List)`
+    // That also removes a trap: assemble's output carries a single path String
+    // rather than the collected position list, and `('a/b.zarr' as List)`
     // explodes into characters.
+    //
     // ONE list of the steps this run actually performed, in order, each with the
     // channel that says it finished and the artifact it produced. Both the
     // run-start announcement and the per-step messages read it, so they cannot
@@ -316,14 +408,20 @@ workflow {
     // than hard-coded numbers, which is what lets a skipped step renumber the
     // messages without renumbering any directory.
     //
+    // The init phase leads the list. It is not a reconstruction step, but it is
+    // the first thing that can fail and the first thing that finishing means
+    // something: every config is good and every output store exists. Its
+    // "artifact" is the run directory.
+    //
     // QC contributes ONE entry, not one per store: the report is a single task
     // gated on every store's finalize, so its completion is exactly "QC of all
     // stores is done". Its report directory stands in for an output zarr.
     def step_events = [
-        [label: 'flat-field',           done: ff_done.done,            output: ff_output],
-        [label: 'deskew',               done: deskew_done.done,        output: deskew_output],
-        [label: 'phase reconstruction', done: reconstruct_done.done,   output: reconstruct_output],
-        [label: 'virtual staining',     done: virtual_stain_done.done, output: virtual_stain_output],
+        [label: 'init (configs validated)', done: init_done,                 output: out],
+        [label: 'flat-field',               done: ff_done.done,              output: ff_output],
+        [label: 'deskew',                   done: deskew_done.done,          output: deskew_output],
+        [label: 'phase reconstruction',     done: reconstruct_done.done,     output: reconstruct_output],
+        [label: 'virtual staining',         done: virtual_stain_done.done,   output: virtual_stain_output],
     ]
     if (assemble_on) step_events << [label: 'assemble', done: assemble_done.done, output: assemble_output]
     if (track_on)    step_events << [label: 'track',    done: track_done.done,    output: track_output]

--- a/nextflow/modules/assembly.nf
+++ b/nextflow/modules/assembly.nf
@@ -189,8 +189,15 @@ workflow assemble_run_wf {
     prev_done
 
     main:
+    // GATE CHANNELS ARE MAPPED TO A TOKEN BEFORE COMBINING, never combined raw.
+    // `combine` FLATTENS a list-valued item into the tuple, so what the producer
+    // happens to emit leaks into the tuple's arity: a step's `done` is a COLLECTED
+    // list of every position, which turned [pos, meta] into
+    // [pos, meta, p1, p2, … p54] and blew up a three-parameter closure with
+    // `MissingMethodException` — after the previous step had already run. Mapping
+    // reads nothing out of the gate, so no producer's payload shape can reach here.
     ready = resources
-        .combine(prev_done)
+        .combine(prev_done.map { 'done' })
         .map { meta, _gate -> meta }
 
     as_done = run_concatenate(output_zarr, resolved_config_path(config), ready)

--- a/nextflow/modules/assembly.nf
+++ b/nextflow/modules/assembly.nf
@@ -1,5 +1,5 @@
-// Assembly subworkflow: resolve concat config → init (RESOURCES) → single-shot
-// concatenate.
+// Assembly subworkflows: init (resolve concat config → scaffold → RESOURCES)
+// and run (single-shot concatenate).
 //
 // Unlike the per-position steps (deskew, reconstruct, …), concatenate combines
 // N source stores channel-wise at each position, so there is no single `-i` to
@@ -13,14 +13,19 @@
 // This is the "reserve a compute node + --cluster debug" approach. To parallelise
 // positions across the reserved node's cores later, switch the run step to
 // `--cluster local` (submitit spawns one subprocess per position) and size the
-// resources for the concurrent fan-out.
+// resources for the concurrent fan-out. Making this step work ACROSS positions
+// is biahub#301, and is also what a per-position pipeline DAG (biahub#304)
+// would need.
 //
-// Like the other steps, a cheap `--init` step on the login node creates the
-// output plate (create_empty_plate is idempotent) and emits the RESOURCES line
-// that sizes the compute node. Path injection: the source zarr paths are
-// Nextflow runtime values, so passing `--concat-data-paths` templates them into
-// concat_data_paths (resolve mode) — also a login-node step — before init/run
-// read the config.
+// BOTH init steps read only METADATA — `resolve_concatenate_config` templates
+// paths into the config, and `concatenate --init` reads each source position's
+// shape/dtype/channel names to resolve the output channel mapping and create
+// the plate (create_empty_plate is idempotent). Neither reads a pixel, so both
+// run against source stores that have been scaffolded but not yet filled, which
+// is what lets them join the pipeline's up-front init phase. Resolving the
+// channel mapping there is the point: a concatenate config naming a channel no
+// source store has now fails in the first minutes rather than after every
+// reconstruction step has completed.
 
 include { parse_resources; slurm_logs; slurm_log_dir } from './common'
 
@@ -42,7 +47,11 @@ process resolve_concatenate_config {
     // Write the resolved config alongside the source config (config_dir) so it
     // sits with the rest of the run's configs. `rm -f` first because resolve
     // mode's `-o` refuses to overwrite an existing file, so a rerun would
-    // otherwise fail on the stale copy.
+    // otherwise fail on the stale copy. NOTE: this is not hermetic — the file
+    // lands next to the user's configs rather than in the work dir, so two runs
+    // sharing a config directory overwrite each other's copy. Unchanged by the
+    // move into the init phase, except that it now happens in the run's first
+    // minutes rather than hours in.
     script:
     def resolved = "${config_dir}/concatenate_resolved.yml"
     """
@@ -122,33 +131,73 @@ process run_concatenate {
 }
 
 
+// The resolved config lives beside the source config. Both subworkflows need
+// the path and the pipeline invokes them separately, so derive it in one place.
+def resolved_config_path(config) {
+    return "${new File(config.toString()).parent}/concatenate_resolved.yml"
+}
+
+
+// Resolve the source paths into the config and scaffold the assembled plate.
+//
 // take:
 //   deskew_zarr        LF source store to concatenate
 //   reconstruct_zarr   phase source store to concatenate
 //   virtual_stain_zarr virtual-stain source store to concatenate
 //   output_zarr        path to the assembled output plate.zarr
 //   config             path to the concatenate settings YAML (placeholder paths)
-//   prev_done          gating channel — assembly starts once this emits
-workflow assemble_wf {
+//   trigger            gating channel — init starts once this emits
+// emit:
+//   resources    the RESOURCES payload sizing the single-shot task
+//   done         fires once the assembled plate exists
+workflow assemble_init_wf {
     take:
     deskew_zarr
     reconstruct_zarr
     virtual_stain_zarr
     output_zarr
     config
-    prev_done
+    trigger
 
     main:
     def config_dir = new File(config.toString()).parent
-    def resolved_config_path = "${config_dir}/concatenate_resolved.yml"
 
     resolved = resolve_concatenate_config(
         deskew_zarr, reconstruct_zarr, virtual_stain_zarr,
-        config_dir, config, prev_done.map { 'done' }
+        config_dir, config, trigger.map { 'done' }
     )
-    resources = init_concatenate(resolved, output_zarr).map { stdout_text -> parse_resources(stdout_text) }
-    as_done = run_concatenate(output_zarr, resolved_config_path, resources)
+    init_out = init_concatenate(resolved, output_zarr)
 
     emit:
-    done = as_done
+    resources = init_out.map { stdout_text -> parse_resources(stdout_text) }.first()
+    done      = init_out.map { 'done' }.first()
+}
+
+
+// Concatenate the whole plate in one task.
+//
+// take:
+//   output_zarr  path to the assembled output plate.zarr
+//   config       path to the concatenate settings YAML (locates the resolved copy)
+//   resources    RESOURCES payload from assemble_init_wf
+//   prev_done    gating channel — every source store holds data
+workflow assemble_run_wf {
+    take:
+    output_zarr
+    config
+    resources
+    prev_done
+
+    main:
+    ready = resources
+        .combine(prev_done)
+        .map { meta, _gate -> meta }
+
+    as_done = run_concatenate(output_zarr, resolved_config_path(config), ready)
+
+    emit:
+    // `.first()` so this is a VALUE channel like every other step's `done`:
+    // run_concatenate is single-shot, so its output is a one-item queue, and
+    // the steps gated on it would each have to re-signal it otherwise.
+    done = as_done.first()
 }

--- a/nextflow/modules/deskew.nf
+++ b/nextflow/modules/deskew.nf
@@ -123,10 +123,17 @@ workflow deskew_run_wf {
     prev_done
 
     main:
+    // GATE CHANNELS ARE MAPPED TO A TOKEN BEFORE COMBINING, never combined raw.
+    // `combine` FLATTENS a list-valued item into the tuple, so what the producer
+    // happens to emit leaks into the tuple's arity: a step's `done` is a COLLECTED
+    // list of every position, which turned [pos, meta] into
+    // [pos, meta, p1, p2, … p54] and blew up a three-parameter closure with
+    // `MissingMethodException` — after the previous step had already run. Mapping
+    // reads nothing out of the gate, so no producer's payload shape can reach here.
     pos_meta = positions
         .flatMap { items -> items }
         .combine(resources)
-        .combine(prev_done)
+        .combine(prev_done.map { 'done' })
         .map { pos, meta, _gate -> [pos, meta] }
 
     dk_done = run_deskew(pos_meta, input_zarr, output_zarr, config) | collect

--- a/nextflow/modules/deskew.nf
+++ b/nextflow/modules/deskew.nf
@@ -1,11 +1,18 @@
-// Deskew subworkflow: init → parse_resources → fan-out run × N positions.
+// Deskew subworkflows: init (scaffold + resources) and run (fan-out × N).
 //
-// This subworkflow is PATH-AGNOSTIC. Callers pass the input zarr, output zarr,
-// and config explicitly; the module has no idea where it sits in the pipeline
+// This module is PATH-AGNOSTIC. Callers pass the input zarr, output zarr, and
+// config explicitly; the module has no idea where it sits in the pipeline
 // directory layout. That's deliberate — deskew can read raw input, a 0-convert
 // store, a flat-field corrected store, or anything else, and write anywhere.
 // The orchestrating pipeline (see mantis-v2.nf) owns the layout and
 // the order of steps; this module just deskews whatever it's handed.
+//
+// INIT AND RUN ARE SEPARATE SUBWORKFLOWS. The pipeline runs every step's init
+// ahead of every step's compute, so that a bad config fails in the first
+// minutes rather than hours in. `biahub deskew --init` reads only the input
+// plate's METADATA — channel names and shape, with the deskewed shape derived
+// analytically — so it runs happily against a store its upstream step has
+// scaffolded but not yet filled. See the INIT PHASE comment in mantis-v2.nf.
 //
 // run_deskew uses `--cluster debug` so that submitit's DebugExecutor runs the
 // work in-process.  Nextflow already handles per-position fan-out and resource
@@ -70,27 +77,57 @@ process run_deskew {
 }
 
 
+// Validate the config and scaffold the output plate. Metadata-only and cheap,
+// so it belongs in the pipeline's up-front init phase.
+//
 // take:
-//   positions    collected channel of position keys (e.g. ['A/1/0', 'B/1/0'])
 //   input_zarr   path to the input plate.zarr to deskew (any starting point)
 //   output_zarr  path to the deskewed output plate.zarr
 //   config       path to the deskew settings YAML
-//   prev_done    gating channel — deskew starts once this emits
-workflow deskew_wf {
+//   trigger      gating channel — init starts once this emits
+// emit:
+//   resources    the RESOURCES payload sizing one position's task
+//   done         fires once the output plate exists
+workflow deskew_init_wf {
+    take:
+    input_zarr
+    output_zarr
+    config
+    trigger
+
+    main:
+    init_out = init_deskew(input_zarr, output_zarr, config, trigger.map { 'done' })
+
+    emit:
+    resources = init_out.map { stdout_text -> parse_resources(stdout_text) }.first()
+    done      = init_out.map { 'done' }.first()
+}
+
+
+// Fan out one deskew task per position.
+//
+// take:
+//   positions    collected channel of position keys (e.g. ['A/1/0', 'B/1/0'])
+//   input_zarr   path to the input plate.zarr to deskew
+//   output_zarr  path to the deskewed output plate.zarr
+//   config       path to the deskew settings YAML
+//   resources    RESOURCES payload from deskew_init_wf
+//   prev_done    gating channel — compute starts once this emits
+workflow deskew_run_wf {
     take:
     positions
     input_zarr
     output_zarr
     config
+    resources
     prev_done
 
     main:
-    init_out = init_deskew(input_zarr, output_zarr, config, prev_done.map { 'done' })
-    resources = init_out.map { stdout_text -> parse_resources(stdout_text) }
-
     pos_meta = positions
         .flatMap { items -> items }
         .combine(resources)
+        .combine(prev_done)
+        .map { pos, meta, _gate -> [pos, meta] }
 
     dk_done = run_deskew(pos_meta, input_zarr, output_zarr, config) | collect
 

--- a/nextflow/modules/flat_field.nf
+++ b/nextflow/modules/flat_field.nf
@@ -1,10 +1,15 @@
-// Flat-field subworkflow: init → parse_resources → fan-out run × N positions.
+// Flat-field subworkflows: init (scaffold + resources) and run (fan-out × N).
 //
-// This subworkflow is PATH-AGNOSTIC. Callers pass the input zarr, output zarr,
-// and config explicitly; the module has no idea where it sits in the pipeline
+// This module is PATH-AGNOSTIC. Callers pass the input zarr, output zarr, and
+// config explicitly; the module has no idea where it sits in the pipeline
 // directory layout. The orchestrating pipeline (see mantis-v2.nf) owns the
 // layout and the order of steps; this module just applies flat-field correction
 // to whatever it's handed.
+//
+// INIT AND RUN ARE SEPARATE SUBWORKFLOWS. The pipeline runs every step's init
+// ahead of every step's compute, so that a bad config fails in the first
+// minutes rather than hours in — which means it, not this module, decides when
+// each phase happens. See the INIT PHASE comment in mantis-v2.nf.
 //
 // run_flat_field uses `--cluster debug` so that submitit's DebugExecutor runs
 // the work in-process.  Nextflow already handles per-position fan-out and
@@ -69,27 +74,67 @@ process run_flat_field {
 }
 
 
+// Validate the config and scaffold the output plate. Metadata-only and cheap,
+// so it belongs in the pipeline's up-front init phase.
+//
+// take:
+//   input_zarr   path to the input plate.zarr (raw input)
+//   output_zarr  path to the flat-field corrected output plate.zarr
+//   config       path to the flat-field settings YAML
+//   trigger      gating channel — init starts once this emits
+// emit:
+//   resources    the RESOURCES payload sizing one position's task
+//   done         fires once the output plate exists
+workflow flat_field_init_wf {
+    take:
+    input_zarr
+    output_zarr
+    config
+    trigger
+
+    main:
+    init_out = init_flat_field(input_zarr, output_zarr, config, trigger.map { 'done' })
+
+    emit:
+    // `.first()` turns the init's one-shot stdout into a VALUE channel, which is
+    // the contract every step module here emits on: both outputs cross a
+    // subworkflow boundary and are combined against a per-position queue
+    // channel, and a value channel makes that a gate rather than a one-item
+    // cross product whose behaviour depends on how many consumers read it.
+    //
+    // Nextflow logs one deduplicated "operator `first` is useless when applied
+    // to a value channel" per run because THIS pipeline happens to trigger every
+    // init from a value channel, which already makes `stdout` one. That is a
+    // property of the caller, not of the module, so the guard stays.
+    resources = init_out.map { stdout_text -> parse_resources(stdout_text) }.first()
+    done      = init_out.map { 'done' }.first()
+}
+
+
+// Fan out one flat-field task per position.
+//
 // take:
 //   positions    collected channel of position keys (e.g. ['A/1/0', 'B/1/0'])
 //   input_zarr   path to the input plate.zarr (raw input)
 //   output_zarr  path to the flat-field corrected output plate.zarr
 //   config       path to the flat-field settings YAML
-//   prev_done    gating channel — flat-field starts once this emits
-workflow flat_field_wf {
+//   resources    RESOURCES payload from flat_field_init_wf
+//   prev_done    gating channel — compute starts once this emits
+workflow flat_field_run_wf {
     take:
     positions
     input_zarr
     output_zarr
     config
+    resources
     prev_done
 
     main:
-    init_out = init_flat_field(input_zarr, output_zarr, config, prev_done.map { 'done' })
-    resources = init_out.map { stdout_text -> parse_resources(stdout_text) }
-
     pos_meta = positions
         .flatMap { items -> items }
         .combine(resources)
+        .combine(prev_done)
+        .map { pos, meta, _gate -> [pos, meta] }
 
     ff_done = run_flat_field(pos_meta, input_zarr, output_zarr, config) | collect
 

--- a/nextflow/modules/flat_field.nf
+++ b/nextflow/modules/flat_field.nf
@@ -130,10 +130,17 @@ workflow flat_field_run_wf {
     prev_done
 
     main:
+    // GATE CHANNELS ARE MAPPED TO A TOKEN BEFORE COMBINING, never combined raw.
+    // `combine` FLATTENS a list-valued item into the tuple, so what the producer
+    // happens to emit leaks into the tuple's arity: a step's `done` is a COLLECTED
+    // list of every position, which turned [pos, meta] into
+    // [pos, meta, p1, p2, … p54] and blew up a three-parameter closure with
+    // `MissingMethodException` — after the previous step had already run. Mapping
+    // reads nothing out of the gate, so no producer's payload shape can reach here.
     pos_meta = positions
         .flatMap { items -> items }
         .combine(resources)
-        .combine(prev_done)
+        .combine(prev_done.map { 'done' })
         .map { pos, meta, _gate -> [pos, meta] }
 
     ff_done = run_flat_field(pos_meta, input_zarr, output_zarr, config) | collect

--- a/nextflow/modules/qc.nf
+++ b/nextflow/modules/qc.nf
@@ -139,7 +139,7 @@ process generate_unified_report {
 
 
 // ---------------------------------------------------------------------------
-//  qc_stage_wf: plan-driven QC stage execution
+//  QC stage execution, split into a PLAN half and a COMPUTE half.
 //
 //  plan-stage emits plan.json v5 to stdout: {version, stage, items[]}, one flat
 //  list. Nextflow fans every item out to a compute task, counts them as the
@@ -149,11 +149,33 @@ process generate_unified_report {
 //  finding nothing could ever put a second wave in a plan.
 //
 //  Only the items keys are read, so additive schema bumps stay compatible.
+//
+//  THE SPLIT IS THE SAME ONE THE STEP MODULES MAKE, for the same reason. Both
+//  planning verbs read only the store's STRUCTURE — position list, T extent,
+//  shape and dtype; imaging-qc's own comment in cli/planning.py is "Neither
+//  reads a pixel" — and they validate the config before opening the store at
+//  all (`validate_plan_config` for plan-stage, `build_stage_config` for
+//  estimate-resources, which is the stricter of the two). So a QC config can be
+//  checked against a store that has been SCAFFOLDED but not yet filled, which
+//  in mantis-v2 is the run's first minutes rather than after the step that
+//  produces the store has finished. Only `compute` needs pixels.
+//
+//  What this does NOT catch is a channel name the store does not have:
+//  imaging-qc resolves `channels:` inside `compute` (io/subset.py), not at plan
+//  time. Worth an upstream issue; the store is already open there.
 // ---------------------------------------------------------------------------
 
-workflow qc_stage_wf {
+// take:
+//   plan_inputs   Channel of tuple(zarr_path, config_path); the stores must
+//                 EXIST, but need not hold data
+// emit:
+//   items         one entry per work item, [zarr, config, step_id, position,
+//                 chunk_id, time_indices, meta]
+//   stores        one [zarr, config] per planned store, for the merge
+//   done          fires once every config has planned — "the QC configs are good"
+workflow qc_plan_wf {
     take:
-    plan_inputs      // Channel of tuple(zarr_path, config_path)
+    plan_inputs
 
     main:
     plan_out = plan_stage(plan_inputs)
@@ -168,7 +190,7 @@ workflow qc_stage_wf {
             tuple([z, cfg], (r.estimate_gb ?: 16) as Double)
         }
 
-    items = plan_out
+    plan_items = plan_out
         .map { z, cfg, json_text -> tuple([z, cfg], json_text) }
         .join(est_mem)
         .flatMap { key, json_text, mem ->
@@ -190,12 +212,43 @@ workflow qc_stage_wf {
             }
         }
 
-    done = compute_step(items)
+    emit:
+    items  = plan_items
+    stores = plan_out.map { z, cfg, _json -> [z, cfg] }
+    done   = plan_out.collect().map { 'done' }
+}
+
+
+// take:
+//   items          from qc_plan_wf
+//   stores         from qc_plan_wf
+//   compute_ready  Channel of tuple(zarr_path, config_path), one per store,
+//                  emitted once that store HOLDS DATA
+workflow qc_compute_wf {
+    take:
+    items
+    stores
+    compute_ready
+
+    main:
+    // Planning ran as soon as the store existed; the compute it planned still
+    // has to wait for the step that fills that store. `combine(..., by: 0)` on
+    // the [zarr, config] key rather than `join`, because a plan contributes MANY
+    // items per store and `join` is 1:1 — it would release one work item per
+    // store and silently drop the rest.
+    ready_items = items
+        .map { z, cfg, step_id, position, chunk_id, time_indices, meta ->
+            tuple([z, cfg], [step_id, position, chunk_id, time_indices, meta])
+        }
+        .combine(compute_ready.map { z, cfg -> tuple([z, cfg], 'ready') }, by: 0)
+        .map { key, item, _ready -> [key[0], key[1]] + item }
+
+    done = compute_step(ready_items)
 
     // `.count()` is the barrier: every item's shard is on disk before the stage
     // merge reads them. finalize_stage consolidates, then gates — one merge per
     // stage, which is all there is now that waves are gone.
-    merged = plan_out.map { z, cfg, _json -> [z, cfg] }
+    merged = stores
         .combine(done.count())
         .map { z, cfg, _n -> [z, cfg] }
         | finalize_stage

--- a/nextflow/modules/reconstruct.nf
+++ b/nextflow/modules/reconstruct.nf
@@ -1,7 +1,7 @@
-// Reconstruct subworkflow: init → compute TF → fan-out apply-inv-tf × N positions.
+// Reconstruct subworkflows: init, transfer function, and fan-out × N positions.
 //
-// This subworkflow is PATH-AGNOSTIC. Callers pass the input zarr, output zarr,
-// and config explicitly; the module has no idea where it sits in the pipeline
+// This module is PATH-AGNOSTIC. Callers pass the input zarr, output zarr, and
+// config explicitly; the module has no idea where it sits in the pipeline
 // directory layout. The TF zarr path is derived from the output_zarr's parent
 // directory (the module's internal convention).
 //
@@ -9,11 +9,17 @@
 // CLI validates it and only warns if those pixel sizes disagree with the input
 // zarr metadata.  No resolved config is written.
 //
-// Three-phase pattern:
-// 1. init_apply_inv_tf: validates the config, creates the output plate,
-//    emits RESOURCES:
-// 2. compute_transfer_function: one-shot TF computation using hardcoded resources
-// 3. run_apply_inv_tf: per-position inverse TF application using RESOURCES
+// Three phases, THREE SUBWORKFLOWS, because the pipeline schedules each of them
+// at a different time (see mantis-v2.nf):
+// 1. reconstruct_init_wf: validates the config, creates the output plate, emits
+//    RESOURCES. Metadata-only, head node, part of the up-front init phase.
+// 2. reconstruct_tf_wf: one-shot TF computation on hardcoded resources. This is
+//    real compute, but it depends only on the input plate's SHAPE — waveorder
+//    builds the transfer function from the first position's dimensions, reading
+//    no pixels — so the pipeline starts it as soon as the input store has been
+//    SCAFFOLDED, and it overlaps the upstream steps' compute instead of sitting
+//    on the critical path between them and reconstruction.
+// 3. reconstruct_run_wf: per-position inverse TF application, gated on the TF.
 //
 // run_apply_inv_tf uses `--cluster debug` so that submitit's DebugExecutor runs
 // the work in-process.  Nextflow already handles per-position fan-out and
@@ -114,37 +120,94 @@ process run_apply_inv_tf {
 }
 
 
+// The TF zarr path, derived from the output plate's parent directory. Exposed
+// as a function because both reconstruct_tf_wf and reconstruct_run_wf need it
+// and the pipeline invokes them separately.
+def transfer_function_path(output_zarr) {
+    return "${new File(output_zarr).parent}/transfer_function.zarr"
+}
+
+
+// Validate the config and scaffold the output plate. Metadata-only and cheap,
+// so it belongs in the pipeline's up-front init phase.
+//
+// take:
+//   input_zarr   path to the input plate.zarr (deskew output)
+//   output_zarr  path to the reconstructed output plate.zarr
+//   config       path to the reconstruct settings YAML
+//   trigger      gating channel — init starts once this emits
+// emit:
+//   resources    the RESOURCES payload sizing one position's task
+//   done         fires once the output plate exists
+workflow reconstruct_init_wf {
+    take:
+    input_zarr
+    output_zarr
+    config
+    trigger
+
+    main:
+    init_out = init_apply_inv_tf(input_zarr, output_zarr, config, trigger.map { 'done' })
+
+    emit:
+    resources = init_out.map { stdout_text -> parse_resources(stdout_text) }.first()
+    done      = init_out.map { 'done' }.first()
+}
+
+
+// Compute the transfer function once for the whole plate.
+//
+// take:
+//   input_zarr   path to the input plate.zarr (deskew output); only its shape
+//                is read, so a scaffolded-but-empty store is enough
+//   output_zarr  path to the reconstructed output plate.zarr (locates the TF)
+//   config       path to the reconstruct settings YAML
+//   trigger      gating channel — the TF starts once this emits
+workflow reconstruct_tf_wf {
+    take:
+    input_zarr
+    output_zarr
+    config
+    trigger
+
+    main:
+    tf_zarr = transfer_function_path(output_zarr)
+    tf_done = compute_transfer_function(trigger.map { 'done' }, input_zarr, tf_zarr, config)
+
+    emit:
+    done = tf_done.first()
+}
+
+
+// Fan out one inverse-TF task per position.
+//
 // take:
 //   positions    collected channel of position keys (e.g. ['A/1/0', 'B/1/0'])
 //   input_zarr   path to the input plate.zarr (deskew output)
 //   output_zarr  path to the reconstructed output plate.zarr
 //   config       path to the reconstruct settings YAML
-//   prev_done    gating channel — reconstruct starts once this emits
-workflow reconstruct_wf {
+//   resources    RESOURCES payload from reconstruct_init_wf
+//   tf_done      gating channel — the transfer function exists
+//   prev_done    gating channel — the input store holds data
+workflow reconstruct_run_wf {
     take:
     positions
     input_zarr
     output_zarr
     config
+    resources
+    tf_done
     prev_done
 
     main:
-    def output_dir = new File(output_zarr).parent
-    def tf_zarr     = "${output_dir}/transfer_function.zarr"
-
-    init_out = init_apply_inv_tf(input_zarr, output_zarr, config, prev_done.map { 'done' })
-    run_resources = init_out.map { stdout_text -> parse_resources(stdout_text) }
-    // compute_transfer_function uses hardcoded resources (see process body),
-    // but is gated on init so the output plate exists before the phases proceed.
-    init_done = init_out.map { 'done' }
-
-    tf_done = compute_transfer_function(init_done, input_zarr, tf_zarr, config)
+    tf_zarr = transfer_function_path(output_zarr)
 
     pos_meta = positions
         .flatMap { items -> items }
-        .combine(run_resources)
+        .combine(resources)
         .combine(tf_done)
-        .map { pos, meta, _tf -> [pos, meta] }
+        .combine(prev_done)
+        .map { pos, meta, _tf, _gate -> [pos, meta] }
 
     rc_done = run_apply_inv_tf(pos_meta, input_zarr, output_zarr, tf_zarr, config) | collect
 

--- a/nextflow/modules/reconstruct.nf
+++ b/nextflow/modules/reconstruct.nf
@@ -202,11 +202,18 @@ workflow reconstruct_run_wf {
     main:
     tf_zarr = transfer_function_path(output_zarr)
 
+    // GATE CHANNELS ARE MAPPED TO A TOKEN BEFORE COMBINING, never combined raw.
+    // `combine` FLATTENS a list-valued item into the tuple, so what the producer
+    // happens to emit leaks into the tuple's arity: a step's `done` is a COLLECTED
+    // list of every position, which turned [pos, meta] into
+    // [pos, meta, p1, p2, … p54] and blew up a three-parameter closure with
+    // `MissingMethodException` — after the previous step had already run. Mapping
+    // reads nothing out of the gate, so no producer's payload shape can reach here.
     pos_meta = positions
         .flatMap { items -> items }
         .combine(resources)
-        .combine(tf_done)
-        .combine(prev_done)
+        .combine(tf_done.map { 'ready' })
+        .combine(prev_done.map { 'done' })
         .map { pos, meta, _tf, _gate -> [pos, meta] }
 
     rc_done = run_apply_inv_tf(pos_meta, input_zarr, output_zarr, tf_zarr, config) | collect

--- a/nextflow/modules/tracking.nf
+++ b/nextflow/modules/tracking.nf
@@ -1,11 +1,22 @@
-// Tracking subworkflow: init → parse_resources → fan-out run × N positions.
+// Tracking subworkflows: init (scaffold + resources + weights cache) and run
+// (fan-out × N positions).
 //
-// This subworkflow is PATH-AGNOSTIC. Callers pass the input zarr (plate
-// structure), input images zarr (image data for tracking), output zarr,
-// and config explicitly.
+// This module is PATH-AGNOSTIC. Callers pass the input zarr (plate structure),
+// input images zarr (image data for tracking), output zarr, and config
+// explicitly.
 //
-// Tracking is a 2-input step: reads reconstruct for plate structure and
-// virtual-stain for image data.
+// Tracking is a 2-input step: `input_zarr` supplies the plate structure and
+// `input_images_zarr` the pixels. mantis-v2.nf passes the assembled plate for
+// both.
+//
+// INIT AND RUN ARE SEPARATE SUBWORKFLOWS, and hoisting init is worth more here
+// than anywhere else: the tracking config is the LAST one a run would otherwise
+// parse, so a typo in it used to surface after every reconstruction step and
+// the assembly had finished. `biahub track --init` reads only the input plate's
+// shape and scale (z-slice resolution is data-free), so it runs against the
+// assembled plate as soon as `concatenate --init` has scaffolded it. It also
+// warms the shared cellpose weights cache, which is strictly better done before
+// any GPU worker exists to race for it.
 
 include { parse_resources; slurm_logs; slurm_log_dir } from './common'
 
@@ -64,29 +75,59 @@ process run_track {
 }
 
 
+// Validate the config, scaffold the output plate, warm the cellpose weights.
+// Metadata-only and cheap, so it belongs in the pipeline's up-front init phase.
+//
+// take:
+//   input_zarr   path to the input plate.zarr (plate structure)
+//   output_zarr  path to the tracking output plate.zarr
+//   config       path to the track settings YAML
+//   trigger      gating channel — init starts once this emits
+// emit:
+//   resources    the RESOURCES payload sizing one position's task
+//   done         fires once the output plate exists
+workflow track_init_wf {
+    take:
+    input_zarr
+    output_zarr
+    config
+    trigger
+
+    main:
+    init_out = init_track(input_zarr, output_zarr, config, trigger.map { 'done' })
+
+    emit:
+    resources = init_out.map { stdout_text -> parse_resources(stdout_text) }.first()
+    done      = init_out.map { 'done' }.first()
+}
+
+
+// Fan out one tracking task per position.
+//
 // take:
 //   positions          collected channel of position keys
-//   input_zarr         path to reconstruct output zarr (plate structure)
-//   input_images_zarr  path to virtual-stain output zarr (image data for tracking)
-//   output_zarr        path to tracking output zarr
-//   config             path to track settings YAML
-//   prev_done          gating channel
-workflow track_wf {
+//   input_zarr         plate structure store
+//   input_images_zarr  image data store
+//   output_zarr        path to the tracking output plate.zarr
+//   config             path to the track settings YAML
+//   resources          RESOURCES payload from track_init_wf
+//   prev_done          gating channel — the input stores hold data
+workflow track_run_wf {
     take:
     positions
     input_zarr
     input_images_zarr
     output_zarr
     config
+    resources
     prev_done
 
     main:
-    init_out = init_track(input_zarr, output_zarr, config, prev_done.map { 'done' })
-    resources = init_out.map { stdout_text -> parse_resources(stdout_text) }
-
     pos_meta = positions
         .flatMap { items -> items }
         .combine(resources)
+        .combine(prev_done)
+        .map { pos, meta, _gate -> [pos, meta] }
 
     tk_done = run_track(pos_meta, input_zarr, input_images_zarr, output_zarr, config) | collect
 

--- a/nextflow/modules/tracking.nf
+++ b/nextflow/modules/tracking.nf
@@ -123,10 +123,17 @@ workflow track_run_wf {
     prev_done
 
     main:
+    // GATE CHANNELS ARE MAPPED TO A TOKEN BEFORE COMBINING, never combined raw.
+    // `combine` FLATTENS a list-valued item into the tuple, so what the producer
+    // happens to emit leaks into the tuple's arity: a step's `done` is a COLLECTED
+    // list of every position, which turned [pos, meta] into
+    // [pos, meta, p1, p2, … p54] and blew up a three-parameter closure with
+    // `MissingMethodException` — after the previous step had already run. Mapping
+    // reads nothing out of the gate, so no producer's payload shape can reach here.
     pos_meta = positions
         .flatMap { items -> items }
         .combine(resources)
-        .combine(prev_done)
+        .combine(prev_done.map { 'done' })
         .map { pos, meta, _gate -> [pos, meta] }
 
     tk_done = run_track(pos_meta, input_zarr, input_images_zarr, output_zarr, config) | collect

--- a/nextflow/modules/virtual_stain.nf
+++ b/nextflow/modules/virtual_stain.nf
@@ -1,7 +1,8 @@
-// Virtual-stain subworkflow: init + preprocess → fan-out run × N positions.
+// Virtual-stain subworkflows: init (scaffold + resources) and run (preprocess +
+// fan-out × N).
 //
-// This subworkflow is PATH-AGNOSTIC. Callers pass the input zarr, output zarr,
-// and config explicitly; the module has no idea where it sits in the pipeline
+// This module is PATH-AGNOSTIC. Callers pass the input zarr, output zarr, and
+// config explicitly; the module has no idea where it sits in the pipeline
 // directory layout. The orchestrating pipeline (see mantis-v2.nf) owns the
 // layout and the order of steps; this module just virtually stains whatever
 // it's handed.
@@ -15,14 +16,18 @@
 // own SLURM jobs. See:
 // examples/submitit_debug_nextflow/2026-05-27-submitit-debug-nextflow-concerns.md
 //
-// Three-phase pattern:
-// 1. init_virtual_stain: validates the config, creates the output plate with
-//    the predicted channels, emits RESOURCES:
+// Three phases, split across TWO subworkflows by whether they need DATA:
+// 1. init_virtual_stain: validates the predict config against VisCy's schema,
+//    creates the output plate with the predicted channels, emits RESOURCES.
+//    Metadata-only, so it joins the pipeline's up-front init phase.
 // 2. run_virtual_stain_preprocess: `viscy preprocess` over the whole input
 //    plate. virtual_stain_position reads precomputed normalization statistics
 //    from the input store (viscy_data.read_norm_meta) and errors if they are
 //    missing, so this must run before fan-out. NOTE: this MUTATES the input
-//    store by writing normalization metadata into it.
+//    store by writing normalization metadata into it, and it reads every
+//    position's PIXELS — so unlike the other one-shot steps it cannot be
+//    hoisted, and it is what keeps a whole-plate barrier ahead of this step
+//    (biahub#304).
 // 3. run_virtual_stain: per-position GPU prediction using RESOURCES.
 //
 // Both `biahub virtual-stain` and `viscy` live in biahub's optional `stain`
@@ -121,32 +126,60 @@ process run_virtual_stain {
 }
 
 
+// Validate the predict config and scaffold the output plate. Metadata-only and
+// cheap, so it belongs in the pipeline's up-front init phase.
+//
+// take:
+//   input_zarr   path to the input plate.zarr (reconstruct output)
+//   output_zarr  path to the virtual-stain output plate.zarr
+//   config       path to the virtual-stain (viscy predict) settings YAML
+//   trigger      gating channel — init starts once this emits
+// emit:
+//   resources    the RESOURCES payload sizing one position's task
+//   done         fires once the output plate exists
+workflow virtual_stain_init_wf {
+    take:
+    input_zarr
+    output_zarr
+    config
+    trigger
+
+    main:
+    init_out = init_virtual_stain(input_zarr, output_zarr, config, trigger.map { 'done' })
+
+    emit:
+    resources = init_out.map { stdout_text -> parse_resources(stdout_text) }.first()
+    done      = init_out.map { 'done' }.first()
+}
+
+
+// Compute normalization statistics over the whole input plate, then fan out one
+// GPU prediction per position.
+//
 // take:
 //   positions    collected channel of position keys (e.g. ['A/1/0', 'B/1/0'])
 //   input_zarr   path to the input plate.zarr (reconstruct output)
 //   output_zarr  path to the virtual-stain output plate.zarr
 //   config       path to the virtual-stain (viscy predict) settings YAML
-//   prev_done    gating channel — virtual stain starts once this emits
-workflow virtual_stain_wf {
+//   resources    RESOURCES payload from virtual_stain_init_wf
+//   prev_done    gating channel — the input store holds data for EVERY position,
+//                which preprocess requires
+workflow virtual_stain_run_wf {
     take:
     positions
     input_zarr
     output_zarr
     config
+    resources
     prev_done
 
     main:
-    init_out = init_virtual_stain(input_zarr, output_zarr, config, prev_done.map { 'done' })
-    resources = init_out.map { stdout_text -> parse_resources(stdout_text) }
-
-    // Preprocess the whole plate in parallel with init; both gate the fan-out.
     vs_preprocess = run_virtual_stain_preprocess(input_zarr, prev_done.map { 'done' })
-
-    ready = resources.combine(vs_preprocess)
 
     pos_meta = positions
         .flatMap { items -> items }
-        .combine(ready)
+        .combine(resources)
+        .combine(vs_preprocess.first())
         .map { pos, meta, _preprocess_done -> [pos, meta] }
 
     vs_done = run_virtual_stain(pos_meta, input_zarr, output_zarr, config) | collect

--- a/nextflow/qc-standalone.nf
+++ b/nextflow/qc-standalone.nf
@@ -20,7 +20,7 @@
 
 nextflow.enable.dsl = 2
 
-include { qc_stage_wf; qc_report_wf; qc_report_spec } from './modules/qc'
+include { qc_plan_wf; qc_compute_wf; qc_report_wf; qc_report_spec } from './modules/qc'
 include { check_environment }                             from './modules/common'
 
 
@@ -61,6 +61,11 @@ workflow {
     def report_dir = params.qc_report_dir ?: "${params.output}/qc/report"
     def spec = qc_report_spec(qc_stores, "${params.output}/qc/report_spec.yaml", "QC report")
 
-    qc = qc_stage_wf(plan_inputs)
+    // Plan and compute run back to back here: a standalone run is pointed at
+    // stores that already hold data, so `compute_ready` is just the manifest and
+    // there is no scaffolded-but-empty phase to wait out. mantis-v2 puts the two
+    // halves in different phases — see the qc_plan_wf header.
+    plan = qc_plan_wf(plan_inputs)
+    qc = qc_compute_wf(plan.items, plan.stores, plan_inputs)
     qc_report_wf(qc.done, spec, report_dir)
 }

--- a/nextflow/tests/gate_shapes.nf
+++ b/nextflow/tests/gate_shapes.nf
@@ -1,0 +1,78 @@
+#!/usr/bin/env nextflow
+
+// Asserts the shape of every gate expression the step modules use.
+//
+// WHY THIS EXISTS. `nextflow lint` and `nextflow run -preview` both pass on a
+// gate that is wired wrong, because the failure is a RUNTIME arity mismatch:
+// it fires only when the gate channel actually emits, which for `deskew_run_wf`
+// is after flat-field has run all N positions. A full run found it the
+// expensive way once (54 positions of flat-field, then
+// `MissingMethodException`); this file finds it in ten seconds.
+//
+// THE TRAP. `combine` FLATTENS a list-valued item into the tuple, so what the
+// producer happens to emit leaks into the tuple's arity. A step's `done` is a
+// COLLECTED list of every position, so combining it raw turns [pos, meta] into
+// [pos, meta, p1, p2, … pN] and no fixed-parameter closure can be spread across
+// it. Mapping the gate to a token first reads nothing out of it, so no
+// producer's payload shape can reach the closure.
+//
+// Run it directly; it exits non-zero if a gate regresses:
+//     nextflow run nextflow/tests/gate_shapes.nf
+//
+// Keep the channel shapes below in step with the real ones:
+//   positions       collect() of position keys              (common.nf)
+//   resources       value map from parse_resources          (<step>_init_wf)
+//   collected_done  `run_<step> | collect` — a LIST         (<step>_run_wf)
+//   single_done     run_concatenate's single output path    (assemble_run_wf)
+//   tf_done         compute_transfer_function's `val true`  (reconstruct_tf_wf)
+
+nextflow.enable.dsl = 2
+
+def check(label, got, want) {
+    if (got != want) {
+        error "${label}: expected ${want}, got ${got}"
+    }
+    println "ok  ${label}  ->  ${got}"
+}
+
+workflow {
+    def keys = ['A/1/0', 'A/1/1', 'A/1/2']
+    def meta = [cpus: 16, mem_gb: 224, time_minutes: 110]
+
+    positions      = channel.of(keys).collect()
+    resources      = channel.value(meta)
+    collected_done = channel.fromList(keys).collect()      // a step's `done`: a LIST
+    single_done    = channel.value('/path/out.zarr')  // run_concatenate's `done`
+    tf_done        = channel.value(true)
+
+    // flat_field_run_wf / deskew_run_wf / track_run_wf
+    positions.flatMap { it }
+        .combine(resources)
+        .combine(collected_done.map { 'done' })
+        .map { pos, m, _gate -> [pos, m] }
+        .collect()
+        .subscribe { check('per-position gate', it.size(), keys.size() * 2) }
+
+    // reconstruct_run_wf — two gates
+    positions.flatMap { it }
+        .combine(resources)
+        .combine(tf_done.map { 'ready' })
+        .combine(collected_done.map { 'done' })
+        .map { pos, m, _tf, _gate -> [pos, m] }
+        .collect()
+        .subscribe { check('reconstruct gate', it.size(), keys.size() * 2) }
+
+    // assemble_run_wf — single-shot, gate only
+    resources.combine(collected_done.map { 'done' })
+        .map { m, _gate -> m }
+        .subscribe { check('assemble gate', it, meta) }
+
+    // A gate that is a single value, not a list, must work through the same
+    // expression — assemble's `done` is one path, and track gates on it.
+    positions.flatMap { it }
+        .combine(resources)
+        .combine(single_done.map { 'done' })
+        .map { pos, m, _gate -> [pos, m] }
+        .collect()
+        .subscribe { check('scalar gate', it.size(), keys.size() * 2) }
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -119,6 +119,19 @@ index-strategy = "unsafe-best-match"
 # gapped-shard-write fix.
 imaging_qc_pipeline = { git = "https://github.com/czbiohub-sf/imaging-qc-pipeline", rev = "bd0b494ed1edf8be629254344e6e4bd6df1b3141" }
 
+# Pin iohub to czbiohub-sf/iohub#feat/create-empty-plate-extra-metadata, which
+# adds `create_empty_plate(extra_metadata=...)`. Drop this back to a PyPI floor
+# once that lands and is released.
+#
+# The Nextflow pipeline scaffolds every step's output store before any of them
+# holds data, so each step has to record its OWN provenance during `--init`:
+# `create_empty_plate` inherits an upstream store's `biahub-*` zattrs at
+# plate-creation time and only for positions it creates, so a record written at
+# compute time would never reach the next plate. Writing it through
+# `extra_metadata` rather than in a second pass afterwards is what makes that
+# free — the function already holds an open handle to every position.
+iohub = { git = "https://github.com/czbiohub-sf/iohub", rev = "2ee15ff77c3c345cbfe58d5ff8a29b914dd3dadb" }
+
 [tool.hatch.metadata]
 allow-direct-references = true
 

--- a/tests/test_cli/test_init_provenance.py
+++ b/tests/test_cli/test_init_provenance.py
@@ -1,0 +1,123 @@
+"""Provenance is stamped by ``--init``, not by the per-position compute.
+
+The Nextflow pipeline scaffolds every step's output store up front, before any
+of them hold data (see ``nextflow/mantis-v2.nf``). ``create_empty_plate``
+inherits a source store's provenance at plate-creation time and only for
+positions it creates, so a step whose own record landed at compute time would
+never be inherited: each downstream plate is created while its input store is
+still empty. These tests pin the property that makes the chain hold.
+"""
+
+import pytest
+import yaml
+
+from click.testing import CliRunner
+from iohub.ngff import open_ome_zarr
+
+from biahub.cli.main import cli
+
+
+@pytest.fixture()
+def flat_field_config(tmp_path):
+    config_path = tmp_path / "flat_field.yml"
+    config_path.write_text(yaml.dump({"channel_names": None}))
+    return config_path
+
+
+def _init(runner, command, input_zarr, config, output_zarr):
+    result = runner.invoke(
+        cli,
+        [
+            command,
+            "-i",
+            f"{input_zarr}/A/1/0",
+            f"{input_zarr}/B/1/0",
+            f"{input_zarr}/B/2/0",
+            "-c",
+            str(config),
+            "-o",
+            str(output_zarr),
+            "--init",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    return result
+
+
+def _position_zattrs(store_path):
+    """Every position's custom (non-OME) zattrs keys, as a list of key sets."""
+    with open_ome_zarr(str(store_path), mode="r") as plate:
+        return [
+            {key for key in dict(position.zattrs) if key != "ome"}
+            for _name, position in plate.positions()
+        ]
+
+
+def test_flat_field_init_stamps_own_provenance(tmp_path, example_plate, flat_field_config):
+    plate_path, _ = example_plate
+    output_path = tmp_path / "flatfield.zarr"
+
+    _init(CliRunner(), "flat-field", plate_path, flat_field_config, output_path)
+
+    for keys in _position_zattrs(output_path):
+        assert "biahub-flat_field" in keys
+
+
+def test_deskew_init_stamps_own_provenance(tmp_path, example_plate, example_deskew_settings):
+    plate_path, _ = example_plate
+    config_path, _ = example_deskew_settings
+    output_path = tmp_path / "deskew.zarr"
+
+    _init(CliRunner(), "deskew", plate_path, config_path, output_path)
+
+    for keys in _position_zattrs(output_path):
+        assert "biahub-deskew" in keys
+
+
+def test_provenance_chains_across_inits_on_empty_stores(
+    tmp_path, example_plate, flat_field_config, example_deskew_settings
+):
+    """Deskew's ``--init`` inherits flat-field's record from a store with no data.
+
+    This is the pipeline's init phase in miniature: nothing is computed between
+    the two calls, so the only way ``biahub-flat_field`` can reach the deskewed
+    plate is if flat-field's ``--init`` wrote it.
+    """
+    plate_path, _ = example_plate
+    deskew_config, _ = example_deskew_settings
+    flat_field_out = tmp_path / "flatfield.zarr"
+    deskew_out = tmp_path / "deskew.zarr"
+
+    runner = CliRunner()
+    _init(runner, "flat-field", plate_path, flat_field_config, flat_field_out)
+    _init(runner, "deskew", flat_field_out, deskew_config, deskew_out)
+
+    for keys in _position_zattrs(deskew_out):
+        assert {"biahub-flat_field", "biahub-deskew"} <= keys
+
+
+def test_init_refreshes_its_own_record_on_rerun(
+    tmp_path, example_plate, example_deskew_settings
+):
+    """A changed config updates the record rather than leaving the first one.
+
+    ``create_empty_plate`` is idempotent and skips the metadata copy for
+    positions that already exist, so this only holds because the step's own
+    record is written on every position the call names.
+    """
+    plate_path, _ = example_plate
+    _, settings = example_deskew_settings
+    output_path = tmp_path / "deskew.zarr"
+    runner = CliRunner()
+
+    first = tmp_path / "deskew_first.yml"
+    first.write_text(yaml.dump({**settings, "keep_overhang": True}))
+    _init(runner, "deskew", plate_path, first, output_path)
+
+    second = tmp_path / "deskew_second.yml"
+    second.write_text(yaml.dump({**settings, "keep_overhang": False}))
+    _init(runner, "deskew", plate_path, second, output_path)
+
+    with open_ome_zarr(str(output_path), mode="r") as plate:
+        for _name, position in plate.positions():
+            assert position.zattrs["biahub-deskew"]["keep_overhang"] is False

--- a/uv.lock
+++ b/uv.lock
@@ -367,7 +367,7 @@ requires-dist = [
     { name = "humanize" },
     { name = "imageio-ffmpeg" },
     { name = "imaging-qc-pipeline", extras = ["interactive"], marker = "extra == 'qc'", git = "https://github.com/czbiohub-sf/imaging-qc-pipeline?rev=bd0b494ed1edf8be629254344e6e4bd6df1b3141" },
-    { name = "iohub", specifier = ">=0.3.11" },
+    { name = "iohub", git = "https://github.com/czbiohub-sf/iohub?rev=2ee15ff77c3c345cbfe58d5ff8a29b914dd3dadb" },
     { name = "largestinteriorrectangle" },
     { name = "llvmlite", specifier = ">=0.41.0" },
     { name = "markdown" },
@@ -872,7 +872,7 @@ name = "cryptography"
 version = "50.0.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
+    { name = "cffi", marker = "platform_python_implementation != 'PyPy' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/bb/ad/5d6702db60b1e40b41ef513b6967ff5848f307d50f8449baf1634f5908f1/cryptography-50.0.1.tar.gz", hash = "sha256:5dd9bda1c12b4162f6ff568eeb5e0ff956c28d14406e875cfe8a63a2d414ff20", size = 880381, upload-time = "2026-08-25T19:45:45.499Z" }
 wheels = [
@@ -910,7 +910,7 @@ name = "cuda-bindings"
 version = "13.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cuda-pathfinder" },
+    { name = "cuda-pathfinder", marker = "sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ce/67/5e7dba1ba576dd73da5dee894ca076ca5e959450dfff66d6d510a255d1f7/cuda_bindings-13.3.1-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c7855c4868aabc0cfae28abbe83d56734bdfbd08f08fc234ac1912a12858bf49", size = 6025351, upload-time = "2026-05-29T23:11:49.685Z" },
@@ -941,43 +941,43 @@ wheels = [
 
 [package.optional-dependencies]
 cublas = [
-    { name = "nvidia-cublas", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
-    { name = "nvidia-cuda-nvrtc", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cublas", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-cuda-nvrtc", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 cudart = [
-    { name = "nvidia-cuda-runtime", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cuda-runtime", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 cufft = [
-    { name = "nvidia-cufft", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
-    { name = "nvidia-nvjitlink", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cufft", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-nvjitlink", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 cufile = [
-    { name = "nvidia-cufile", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cufile", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 cupti = [
-    { name = "nvidia-cuda-cupti", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cuda-cupti", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 curand = [
-    { name = "nvidia-curand", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-curand", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 cusolver = [
-    { name = "nvidia-cublas", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
-    { name = "nvidia-cusolver", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
-    { name = "nvidia-cusparse", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
-    { name = "nvidia-nvjitlink", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cublas", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-cusolver", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-cusparse", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-nvjitlink", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 cusparse = [
-    { name = "nvidia-cusparse", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
-    { name = "nvidia-nvjitlink", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cusparse", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-nvjitlink", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 nvjitlink = [
-    { name = "nvidia-nvjitlink", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-nvjitlink", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 nvrtc = [
-    { name = "nvidia-cuda-nvrtc", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cuda-nvrtc", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 nvtx = [
-    { name = "nvidia-nvtx", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-nvtx", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 
 [[package]]
@@ -2007,8 +2007,8 @@ wheels = [
 
 [[package]]
 name = "iohub"
-version = "0.3.11"
-source = { registry = "https://pypi.org/simple" }
+version = "0.3.12.dev6+2ee15ff"
+source = { git = "https://github.com/czbiohub-sf/iohub?rev=2ee15ff77c3c345cbfe58d5ff8a29b914dd3dadb#2ee15ff77c3c345cbfe58d5ff8a29b914dd3dadb" }
 dependencies = [
     { name = "blosc2" },
     { name = "dask", extra = ["array"] },
@@ -2025,10 +2025,6 @@ dependencies = [
     { name = "xarray" },
     { name = "zarr" },
     { name = "zarrs" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/a5/cc/b69b2f71f526b1e556602e8346001e0c8fc93af0e2f2c939254d9067b812/iohub-0.3.11.tar.gz", hash = "sha256:b8de0698d4dcd25671858abb6d80875b643170780ccb62588c04cdf04e0cd42b", size = 338704, upload-time = "2026-08-17T21:31:46.898Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/f4/46/6ebbe269d557941eedf6ec1518f10a24a29e4d98b8057a4f05b51191c7bd/iohub-0.3.11-py3-none-any.whl", hash = "sha256:827d94ef028023fbdfe9d30cfb2be3629ccfdb4053ec898bcd8da20040f23fea", size = 108142, upload-time = "2026-08-17T21:31:45.683Z" },
 ]
 
 [[package]]
@@ -2138,7 +2134,7 @@ name = "itkwasm-downsample-emscripten"
 version = "2.0.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "itkwasm" },
+    { name = "itkwasm", marker = "sys_platform == 'emscripten'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/26/35/09d599175fc8c76de87894324520e1278d7e29d34584d5f26c5f7881dab6/itkwasm_downsample_emscripten-2.0.2.tar.gz", hash = "sha256:5d7cae3e26a23fa50890e5e50bf5b38df448a1b7f3056ed24202db04557ecee4", size = 132743, upload-time = "2026-08-12T20:29:25.022Z" }
 wheels = [
@@ -2150,8 +2146,8 @@ name = "itkwasm-downsample-wasi"
 version = "2.0.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "importlib-resources" },
-    { name = "itkwasm" },
+    { name = "importlib-resources", marker = "sys_platform != 'emscripten'" },
+    { name = "itkwasm", marker = "sys_platform != 'emscripten'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/21/b4/ad221de375a4a0655c26b8560fda9d6a310f62ecbde7887bcb318aeaabd9/itkwasm_downsample_wasi-2.0.2.tar.gz", hash = "sha256:b0f60ee4a243ecfb897406a8086c12563d1844cf665722994d0c95a82601b785", size = 9224204, upload-time = "2026-08-12T20:29:02.912Z" }
 wheels = [
@@ -3525,7 +3521,7 @@ name = "nvidia-cublas"
 version = "13.1.1.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cuda-nvrtc" },
+    { name = "nvidia-cuda-nvrtc", marker = "sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a7/a1/0bd24ee8c8d03adac032fd2909426a00c88f8c57961b1277ded97f91119f/nvidia_cublas-13.1.1.3-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:b7a210458267ac818974c53038fbec2e969d5c99f305ab15c72522fa9f001dd5", size = 542848918, upload-time = "2026-04-08T18:46:22.985Z" },
@@ -3564,7 +3560,7 @@ name = "nvidia-cudnn-cu13"
 version = "9.24.0.43"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas" },
+    { name = "nvidia-cublas", marker = "sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ca/30/7c257e3d5cb4fecb147b93895c66e29c93f8e76d74b45bb418ff0587c4ec/nvidia_cudnn_cu13-9.24.0.43-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:a6812a554a1ff0413e9c52b84c26c050380649ab9615f9c16bded368ce9f421f", size = 650976863, upload-time = "2026-07-02T16:23:39.248Z" },
@@ -3576,7 +3572,7 @@ name = "nvidia-cufft"
 version = "12.0.0.61"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink" },
+    { name = "nvidia-nvjitlink", marker = "sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8b/ae/f417a75c0259e85c1d2f83ca4e960289a5f814ed0cea74d18c353d3e989d/nvidia_cufft-12.0.0.61-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:2708c852ef8cd89d1d2068bdbece0aa188813a0c934db3779b9b1faa8442e5f5", size = 214053554, upload-time = "2025-09-04T08:31:38.196Z" },
@@ -3606,9 +3602,9 @@ name = "nvidia-cusolver"
 version = "12.0.4.66"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas" },
-    { name = "nvidia-cusparse" },
-    { name = "nvidia-nvjitlink" },
+    { name = "nvidia-cublas", marker = "sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "nvidia-cusparse", marker = "sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "nvidia-nvjitlink", marker = "sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c8/c3/b30c9e935fc01e3da443ec0116ed1b2a009bb867f5324d3f2d7e533e776b/nvidia_cusolver-12.0.4.66-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:02c2457eaa9e39de20f880f4bd8820e6a1cfb9f9a34f820eb12a155aa5bc92d2", size = 223467760, upload-time = "2025-09-04T08:33:04.222Z" },
@@ -3620,7 +3616,7 @@ name = "nvidia-cusparse"
 version = "12.6.3.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink" },
+    { name = "nvidia-nvjitlink", marker = "sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f8/94/5c26f33738ae35276672f12615a64bd008ed5be6d1ebcb23579285d960a9/nvidia_cusparse-12.6.3.3-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:80bcc4662f23f1054ee334a15c72b8940402975e0eab63178fc7e670aa59472c", size = 162155568, upload-time = "2025-09-04T08:33:42.864Z" },
@@ -3921,7 +3917,7 @@ name = "pexpect"
 version = "4.9.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "ptyprocess" },
+    { name = "ptyprocess", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/42/92/cc564bf6381ff43ce1f4d06852fc19a2f11d180f23dc32d9588bee2f149d/pexpect-4.9.0.tar.gz", hash = "sha256:ee7d41123f3c9911050ea2c2dac107568dc43b2d3b0c7557a33212c398ead30f", size = 166450, upload-time = "2023-11-25T09:07:26.339Z" }
 wheels = [
@@ -5505,8 +5501,8 @@ name = "secretstorage"
 version = "3.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cryptography" },
-    { name = "jeepney" },
+    { name = "cryptography", marker = "sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "jeepney", marker = "sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1c/03/e834bcd866f2f8a49a85eaff47340affa3bfa391ee9912a952a1faa68c7b/secretstorage-3.5.0.tar.gz", hash = "sha256:f04b8e4689cbce351744d5537bf6b1329c6fc68f91fa666f60a380edddcd11be", size = 19884, upload-time = "2025-11-23T19:02:53.191Z" }
 wheels = [


### PR DESCRIPTION
Addresses the "related change" paragraph of #304: *init for all recon steps should run at the beginning, before the actual reconstruction work starts.*

## The problem

Each step's `--init` was gated on the previous step's **compute** finishing, so a config was not parsed until the step that consumes it was about to run. A typo in `track.yml` surfaced seven hours in, with flat-field, deskew, reconstruction, virtual staining and assembly all already paid for.

## Why the inits can just be hoisted

Every `--init` is metadata-only. It reads the first input position's channel names, shape and scale, derives the output geometry from the config, creates the output plate (`create_empty_plate` is idempotent) and prints `RESOURCES:`. Nothing reads a pixel.

So a step's init needs its input store to **exist**, not to be **filled** — and the store that has to exist is the one the previous step's init just created. The inits chain:

```
init_flat_field → init_deskew → init_apply_inv_tf → init_virtual_stain
    → resolve_concatenate_config → init_concatenate → init_track
```

all on the head node, in the run's first minutes. It is real validation, not a schema check: concatenate resolves its channel mapping against all three source stores, virtual-stain validates its predict config against VisCy's schema, and every settings model is built with `extra="forbid"`.

## What changed

- Each step module splits into `<step>_init_wf` and `<step>_run_wf`. `mantis-v2.nf`, which already owned the order steps run in, now orders both phases, with one `init_done` gate between them: **nothing reaches SLURM until every config in the run has been parsed and every output store exists.**
- The per-step compute barriers are untouched. Per-position streaming is #304 proper and is blocked on `viscy preprocess` and single-shot `concatenate`, not on this wiring — see the issue comment.
- QC's `plan-stage` and `estimate-resources` join the init phase: both read only the store's structure and validate the config before opening it ("Neither reads a pixel" — imaging-qc `cli/planning.py`). `qc_stage_wf` becomes `qc_plan_wf` + `qc_compute_wf`, and each store's planned work is released by the step that filled it.
- The transfer function is built from the deskewed plate's **shape** alone, so `reconstruct_tf_wf` is gated on `init_done` rather than on deskew's data. It now overlaps flat-field and deskew instead of sitting between them and reconstruction — roughly 30 minutes off the critical path.

## The one thing that would have broken, and the fix

`create_empty_plate` inherits an upstream store's `biahub-*` zattrs **at plate-creation time and only for positions it creates**, while each step's own record was written per position at compute time. That works today only because a step's init runs after the previous step finished. Scaffold everything up front and the chain collapses — `1-deskew` would carry `biahub-deskew` and nothing else.

Fixed by stamping each step's record during `--init`, via a new `create_empty_plate(extra_metadata=...)` (czbiohub-sf/iohub#472). Putting it in `create_empty_plate` rather than in a pass afterwards costs no extra I/O — the function already holds an open handle to every position — and covers pre-existing positions, so a re-run with a changed config refreshes the record. The matching run-time write is dropped; `virtual-stain` and `track` already did this by hand and now go through the same seat.

czbiohub-sf/iohub#472 is **merged**; `iohub` is pinned to the resulting main
commit until a release carries it (`pyproject.toml`, `uv.lock`). Review there
scoped the reserved-key set to `_POSITION_OME_KEYS` and added OME-Zarr v0.4/v0.5
coverage.

## Dependency bumps riding along

- **iohub** → the merged #472 commit, for `create_empty_plate(extra_metadata=)`.
- **imaging-qc** → `c5c51dc` (imaging-qc#226), which makes `plan-stage` refuse a
  `channels:` or `per_channel_params` name no position in the store has. That
  closes the last QC config error the init phase could not catch: an unmatched
  filter used to be a legitimate zero, so the metric silently did not run and,
  if ungated, never surfaced. Raised off this pipeline's `qc_track.yaml`, whose
  `nuclei_prediction_labels` only matches if it agrees with `track.yml`'s
  `target_channel`. Verified against the v4 stores: both shipped a549 configs
  still plan 54 items at exit 0, and a mistyped channel is refused at exit 2.

## Verification

- `pytest tests` — 239 passed, 1 skipped.
- New `tests/test_cli/test_init_provenance.py`: two inits chained on a store **with no data** must still produce the full record. Both new assertions fail without this change (verified by reverting the flat-field stamp).
- DAG rendered under `-preview` and checked programmatically: all 9 init tasks are ancestors of all 9 compute tasks. Also builds for the neuromast (assemble + QC, no track), assemble-only, and reconstruction-only step sets.
- Full init chain run by hand against scaffolded, empty stores through `concatenate --init` and `track --init` (real `configs/a549/track.yml`, cellpose warm-up included). The provenance chain accumulates exactly as it does on a real run:
  ```
  1-deskew     ['biahub-deskew']
  2-recon      ['biahub-deskew', 'waveorder']
  3-vs         ['biahub-deskew', 'waveorder', 'cytoland']
  4-assemble   ['biahub-deskew', 'waveorder', 'cytoland', 'biahub-concatenate']
  5-track      ['biahub-deskew', 'waveorder', 'cytoland', 'biahub-concatenate', 'biahub-track']
  ```
  matching `2026_08_19_A549_PCNA_DENV_ZIKV` on disk.

## Full-scale run: done, and it found a bug

Ran all 54 positions of `2026_08_11_A549_SEC61B_DENV` end to end
(`.../2026_08_11_A549_SEC61B_DENV_debug/v4`), against v3 of the same data as the
reference. **The first launch failed** — see the gate-channel commit. Worth
stating plainly: neither the unit tests, nor `nextflow lint`, nor
`nextflow run -preview` catch that class of defect, because the failure is a
runtime arity mismatch that fires only when a gate channel emits. It cost all 54
positions of flat-field to surface. `nextflow/tests/gate_shapes.nf` now pins it.

Relaunched with `-resume` (flat-field came back entirely from cache) and
completed: **337 completed, 67 cached, 7 retried preemptions, 0 aborted.**

| phase | span |
|---|---|
| **init (9 tasks, head node)** | **2 min 32 s** |
| flat-field | ~37 min |
| deskew | ~20 min |
| reconstruct | ~27 min |
| virtual staining | ~2 h 40 m |
| assemble | 4 h 19 m |
| track | ~18 min |
| QC + report | ~1 h |

Every one of the nine init tasks completed before the first SLURM job was
submitted, including QC's `plan-stage`/`estimate-resources` — the latter planned
against `5-track`, a store that exists only because `track --init` scaffolded it,
two scaffold-only hops downstream of any data. `compute_transfer_function`
finished at 17:31, overlapping flat-field instead of waiting on 54 deskews.

**Provenance chain, the thing that would have broken.** Identical to v3 on all 54
positions at every step:

```
2-reconstruct  biahub-flat_field, biahub-deskew, waveorder
4-assemble     … + cytoland, biahub-concatenate
5-track        … + biahub-track
```

The `waveorder` block written at `--init` is byte-identical to v3's run-written
one, with a single `Phase3D` key — waveorder's merge overwrote in place rather
than duplicating. v3 additionally carries `normalization`; waveorder 3.0.5 (this
branch and main) never writes that key, so its absence is a dependency-version
difference, not a regression here — and it was already excluded from
`PROVENANCE_METADATA_KEYS`, so it never propagated downstream anyway.

**QC verdict, v4 vs v3:** assembled store `pass=37 fail=17` vs `pass=38 fail=16`;
tracking store `pass=44 fail=10` vs `pass=44 fail=10`. The one-position
difference on the assembled store is within the run-to-run variance the pipeline
already documents for segmentation.

Two observations that are not about this PR but came out of the run:

- assemble took **4 h 19 m** against ~2 h 15 m for v3 on the same data — it is
  single-shot on one reserved node, and it is the step #301 wants rewritten.
- track and QC run concurrently by design, so the run peaked at ~60 concurrent
  SLURM jobs. Today's pipeline therefore already exceeds a "30 total" cap
  independent of any per-position streaming; relevant to the concurrency point
  in #304.

## Note for anyone resuming an in-flight run

Task hashes change, so an output directory from an older biahub recomputes rather than resuming. biahub's own `--resume` still skips finished `(t, c)` units for flat-field, deskew and concatenate; `apply-inv-tf`, `virtual-stain` and `track` have no `--resume` and redo whole positions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

