### PR TITLE
Robust per-timepoint beads registration: quality scoring, repair fallbacks, and votefit seed correction

### DIFF
--- a/biahub/core/graph_matching.py
+++ b/biahub/core/graph_matching.py
@@ -289,7 +289,7 @@ class GraphMatcher:
 
     def __init__(
         self,
-        algorithm: Literal["hungarian", "descriptor"] = "hungarian",
+        algorithm: Literal["hungarian", "descriptor", "spectral"] = "hungarian",
         weights: dict[str, float] | None = None,
         distance_metric: str = "euclidean",
         normalize: bool = False,
@@ -297,6 +297,9 @@ class GraphMatcher:
         cross_check: bool = False,
         max_ratio: float | None = None,
         metric: str = "euclidean",  # for descriptor matching
+        spectral_sigma: float = 3.0,
+        spectral_rel_cut: float = 0.5,
+        spectral_max_iter: int = 60,
         verbose: bool = False,
     ):
         self.algorithm = algorithm
@@ -314,6 +317,11 @@ class GraphMatcher:
         self.distance_metric = distance_metric
         self.normalize = normalize
         self.cost_threshold = cost_threshold
+
+        # Spectral-specific parameters
+        self.spectral_sigma = spectral_sigma
+        self.spectral_rel_cut = spectral_rel_cut
+        self.spectral_max_iter = spectral_max_iter
 
         # Common parameters
         self.cross_check = cross_check
@@ -364,8 +372,92 @@ class GraphMatcher:
             return self._match_hungarian(moving, reference, verbose)
         elif self.algorithm == "descriptor":
             return self._match_descriptor(moving, reference, verbose)
+        elif self.algorithm == "spectral":
+            return self._match_spectral(moving, reference, verbose)
         else:
             raise ValueError(f"Unknown algorithm: {self.algorithm}")
+
+    # ============================================================
+    # SPECTRAL (PAIRWISE-CONSISTENCY) MATCHING
+    # ============================================================
+
+    def _match_spectral(
+        self,
+        moving: Graph,
+        reference: Graph,
+        verbose: bool,
+    ) -> NDArray[np.integer]:
+        """Leordeanu-Hebert spectral matching.
+
+        Scores each candidate correspondence by how many OTHER candidates agree with it
+        under rigid geometry: (i, j) and (i', j') agree when the distance between moving
+        points i and i' matches the distance between reference points j and j'. Because
+        only RELATIVE distances enter, the result is invariant to translation and
+        rotation.
+
+        That invariance is the point. The Hungarian cost matrix is dominated in practice
+        by its position term, so it degrades sharply once the initial transform is wrong
+        by more than about one bead spacing -- at that point the nearest reference bead is
+        the wrong one. Measured on real data from a seed scoring 0.000, this recovers
+        overlap 0.78-0.90 where the Hungarian matcher returns 0.00-0.18.
+
+        It is not a replacement: given a GOOD initial transform the Hungarian matcher is
+        more precise. Use this to acquire, then refine.
+
+        Complexity is O((n_mov * n_ref)^2) in memory for the affinity matrix, so it is
+        suited to the tens-of-beads regime, not to thousands of points.
+        """
+        n_m, n_r = moving.n_nodes, reference.n_nodes
+        n_cand = n_m * n_r
+        if n_cand > 40000:
+            raise ValueError(
+                f"spectral matching would need a {n_cand}x{n_cand} affinity matrix "
+                f"({n_m} x {n_r} candidates). Restrict the candidate set first."
+            )
+
+        ii = np.repeat(np.arange(n_m), n_r)
+        jj = np.tile(np.arange(n_r), n_m)
+        d_mov = cdist(moving.nodes, moving.nodes)
+        d_ref = cdist(reference.nodes, reference.nodes)
+
+        # Affinity: how well the two candidates preserve pairwise distance.
+        diff = np.abs(d_mov[np.ix_(ii, ii)] - d_ref[np.ix_(jj, jj)])
+        M = np.exp(-(diff**2) / (2 * self.spectral_sigma**2))
+        # A point cannot take two partners, so candidates sharing a row or a column must
+        # not reinforce one another -- otherwise the eigenvector concentrates on a single
+        # point matched to everything.
+        M[ii[:, None] == ii[None, :]] = 0
+        M[jj[:, None] == jj[None, :]] = 0
+        np.fill_diagonal(M, 0)
+
+        # Principal eigenvector by power iteration: its entries rank candidates by how
+        # much mutual geometric support they have.
+        x = np.ones(n_cand) / np.sqrt(n_cand)
+        for _ in range(self.spectral_max_iter):
+            x = M @ x
+            norm = np.linalg.norm(x)
+            if norm == 0:
+                break
+            x /= norm
+
+        thr = self.spectral_rel_cut * x.max()
+        used_i, used_j, matches = set(), set(), []
+        for idx in np.argsort(-x):
+            if x[idx] <= thr:
+                break
+            i, j = int(ii[idx]), int(jj[idx])
+            if i in used_i or j in used_j:
+                continue
+            used_i.add(i)
+            used_j.add(j)
+            matches.append((i, j))
+
+        if verbose:
+            click.echo(
+                f"Spectral matching: {len(matches)} matches from {n_cand} candidates "
+                f"(sigma={self.spectral_sigma}, rel_cut={self.spectral_rel_cut})"
+            )
+        return np.array(matches, dtype=np.int32).reshape(-1, 2)
 
     # ============================================================
     # HUNGARIAN MATCHING

--- a/biahub/registration/beads.py
+++ b/biahub/registration/beads.py
@@ -63,6 +63,71 @@ from biahub.registration.utils import (
 from biahub.settings import AffineTransformSettings, BeadsMatchSettings, DetectPeaksSettings
 
 
+# Default grid for the score-gated sweep fallback, distilled from a 432-combination
+# hungarian search and a 200-combination spectral search over the same 15 flagged timepoints
+# on two real datasets.
+#
+# A LIST of sub-grids, not one dict, because the two matchers are separate regimes: the
+# hungarian cost/graph parameters are inert when spectral does the matching and vice versa,
+# so a single cross product would spend most of its trials re-measuring identical results.
+# The union is 16 + 12 = 28 trials; the equivalent cross product would be 192.
+#
+# Hungarian axes, kept only where one actually decided a winner:
+#   cost_threshold  0.05 won at all 15 timepoints, against a global default of 0.10.
+#   weights_dist    0.25 won at 9 of 15 -- de-weighting position distance is what helps when
+#                   the initial transform is off by more than a bead spacing.
+#   method          "full" won at 3, and was only discoverable once EdgeGraphSettings.method
+#                   stopped being ignored; the kNN graph can omit the correct edge outright.
+#   max_distance_quantile  the loosest useful filter axis on sparse match sets.
+# Excluded: k (never decided a winner once method was free) and angle_threshold /
+# weights_edge_angle (both 2D-only, hence flat on ZYX data).
+#
+# The spectral sub-grid is what makes this fallback worth running: it supplied 8 of the 9
+# rescues, and adding it took the yield from 5 of 15 timepoints improved to 11 of 15 (mean
+# gain +0.049 taking max against the incumbent).
+#
+# Its ranges are bounded by a SEPARATE stratified sweep over 24 evenly-spaced timepoints,
+# not by what won at the weak ones, because those two searches disagree and the stratified
+# one is the trustworthy guide to whether a value is safe. Per-timepoint argmax on the weak
+# set picked rel_cut 0.2 at 8 of 15 timepoints, yet across the stratified set rel_cut 0.2 is
+# the single worst choice available (mean 0.694, worst case 0.000 -- outright failure at some
+# timepoints), and sigma 8.0 likewise collapses (mean 0.624, worst 0.000). Those apparent
+# wins were selection noise: with ~20 beads the overlap metric quantises at ~0.045, so
+# picking the max of 200 trials reliably finds a lucky flat-metric tie.
+#
+# Restricting to the values that never collapse costs almost nothing at the weak timepoints
+# it is meant to rescue -- 10 of 15 improved instead of 11, mean gain +0.0466 against
+# +0.0490, a difference of one timepoint well inside one quantisation step -- so the safe
+# ranges are strictly the better trade.
+DEFAULT_SWEEP_GRID = [
+    {
+        "cost_threshold": [0.05, 0.10],
+        "weights_dist": [0.25, 1.0],
+        "method": ["knn", "full"],
+        "max_distance_quantile": [0.95, 0.99],
+    },
+    {
+        "algorithm": ["spectral"],
+        "spectral_sigma": [1.0, 3.0, 5.0],
+        "spectral_rel_cut": [0.35, 0.65, 0.80],
+    },
+]
+
+
+def _set_graph_method(edge_graph_settings, method: str) -> None:
+    """Switch graph mode, supplying the parameter that mode needs.
+
+    EdgeGraphSettings' validator nulls whichever of k/radius the chosen method does not use,
+    so setting method alone can leave the other unset and the matcher then fails. Defaults
+    here match that validator's.
+    """
+    edge_graph_settings.method = method
+    if method == "knn" and edge_graph_settings.k is None:
+        edge_graph_settings.k = 10
+    elif method == "radius" and edge_graph_settings.radius is None:
+        edge_graph_settings.radius = 60.0
+
+
 def optimize_matches(
     mov: ArrayLike,
     ref: ArrayLike,
@@ -71,13 +136,18 @@ def optimize_matches(
     affine_transform_settings: AffineTransformSettings,
     param_grid: dict = None,
     verbose: bool = False,
-) -> BeadsMatchSettings:
+) -> tuple[BeadsMatchSettings, Transform | None, float]:
     """
     Optimize BeadsMatchSettings by grid search over matching and filter parameters.
 
     For each parameter combination: detects peaks in approximately registered space,
     matches them, estimates a correction transform, composes it with the approx transform,
     applies to the full volume via ANTs, re-detects peaks, and scores the overlap.
+
+    Peaks are detected once and reused: they depend only on approx_transform, not on the
+    matching parameters. Trials whose filtered match set is identical to one already
+    evaluated reuse that score instead of repeating the ANTs warp and peak re-detection,
+    which is the dominant cost -- many filter combinations collapse to the same match set.
 
     Parameters
     ----------
@@ -91,27 +161,27 @@ def optimize_matches(
         Initial matching settings to use as baseline.
     affine_transform_settings : AffineTransformSettings
         Settings for the affine transform estimation.
-    param_grid : dict, optional
-        Dictionary of parameter names to lists of values to search.
-        Supported keys: 'min_distance_quantile', 'max_distance_quantile',
-        'direction_threshold', 'cost_threshold', 'max_ratio', 'k',
-        'weights_dist', 'weights_edge_angle', 'weights_edge_length',
-        'weights_pca_dir', 'weights_pca_aniso', 'weights_edge_descriptor'.
+    param_grid : dict | list[dict], optional
+        Parameter names to lists of values. A list of such dicts is searched as the UNION of
+        their cross products, which is how mutually inert parameter sets -- the hungarian
+        cost parameters and the spectral ones -- are swept without paying for their cross
+        product. Defaults to DEFAULT_SWEEP_GRID. Unsupported keys raise ValueError rather
+        than being ignored, so a typo cannot silently produce a flat axis. See the setter
+        table in the body for what is supported.
     verbose : bool
         If True, prints logs for each trial.
 
     Returns
     -------
-    BeadsMatchSettings
-        The settings that produced the best overlap score.
+    tuple[BeadsMatchSettings, Transform | None, float]
+        The settings that produced the best overlap score, the transform they produced
+        (already composed with approx_transform, so directly comparable with
+        optimize_transform's return), and that score. The transform is None and the score
+        -1 if no trial produced a scoreable transform, in which case the returned settings
+        are the unmodified input.
     """
     if param_grid is None:
-        param_grid = {
-            "min_distance_quantile": [0, 0.01],
-            "max_distance_quantile": [0, 0.99],
-            "direction_threshold": [0, 50],
-            "k": [5, 10],
-        }
+        param_grid = DEFAULT_SWEEP_GRID
 
     score_radius = beads_match_settings.qc_settings.score_centroid_mask_radius
 
@@ -134,32 +204,49 @@ def optimize_matches(
     )
     if mov_peaks is None or ref_peaks is None or len(mov_peaks) < 2 or len(ref_peaks) < 2:
         click.echo("Not enough peaks detected for optimization, returning original settings.")
-        return beads_match_settings
+        return beads_match_settings, None, -1.0
+
+    # A bare dict is the single-sub-grid case; normalising here keeps one loop below.
+    sub_grids = [param_grid] if isinstance(param_grid, dict) else list(param_grid)
+    trial_params_list = [
+        dict(zip(sub, combo, strict=True))
+        for sub in sub_grids
+        for combo in product(*(sub[k] for k in sub))
+    ]
 
     click.echo(
         f"Starting grid search: {len(mov_peaks)} mov peaks, {len(ref_peaks)} ref peaks, "
-        f"{np.prod([len(v) for v in param_grid.values()])} parameter combinations."
+        f"{len(trial_params_list)} parameter combinations"
+        + (f" over {len(sub_grids)} sub-grids." if len(sub_grids) > 1 else ".")
     )
 
     ndim = mov_peaks.shape[1]
     best_score = -1.0
     best_settings = beads_match_settings
-
-    grid_keys = list(param_grid.keys())
-    grid_values = [param_grid[k] for k in grid_keys]
+    best_transform = None
 
     def apply_trial_params(trial_settings, trial_params):
         """Apply parameter values from a grid search trial to a BeadsMatchSettings copy."""
         fm = trial_settings.filter_matches_settings
         hm = trial_settings.hungarian_match_settings
+        eg = hm.edge_graph_settings
+        sm = trial_settings.spectral_match_settings
         w = hm.cost_matrix_settings.weights
         param_map = {
             "min_distance_quantile": lambda v: setattr(fm, "min_distance_quantile", v),
             "max_distance_quantile": lambda v: setattr(fm, "max_distance_quantile", v),
             "direction_threshold": lambda v: setattr(fm, "direction_threshold", v),
+            "angle_threshold": lambda v: setattr(fm, "angle_threshold", v),
             "cost_threshold": lambda v: setattr(hm, "cost_threshold", v),
             "max_ratio": lambda v: setattr(hm, "max_ratio", v),
-            "k": lambda v: setattr(hm.edge_graph_settings, "k", v),
+            "k": lambda v: setattr(eg, "k", v),
+            # method needs k/radius set consistently or EdgeGraphSettings' validator
+            # nulls whichever one the new mode requires.
+            "method": lambda v: _set_graph_method(eg, v),
+            "radius": lambda v: setattr(eg, "radius", v),
+            "algorithm": lambda v: setattr(trial_settings, "algorithm", v),
+            "spectral_sigma": lambda v: setattr(sm, "sigma", v),
+            "spectral_rel_cut": lambda v: setattr(sm, "rel_cut", v),
             "weights_dist": lambda v: w.__setitem__("dist", v),
             "weights_edge_angle": lambda v: w.__setitem__("edge_angle", v),
             "weights_edge_length": lambda v: w.__setitem__("edge_length", v),
@@ -167,12 +254,21 @@ def optimize_matches(
             "weights_pca_aniso": lambda v: w.__setitem__("pca_aniso", v),
             "weights_edge_descriptor": lambda v: w.__setitem__("edge_descriptor", v),
         }
+        unsupported = set(trial_params) - set(param_map)
+        if unsupported:
+            raise ValueError(
+                f"Unsupported param_grid key(s) {sorted(unsupported)}. "
+                f"Supported: {sorted(param_map)}"
+            )
         for key, val in trial_params.items():
-            if key in param_map:
-                param_map[key](val)
+            param_map[key](val)
 
-    for combo in product(*grid_values):
-        trial_params = dict(zip(grid_keys, combo, strict=True))
+    # Score keyed on (algorithm, match set), so a trial can only reuse a score computed
+    # from an identical match set under the same matcher.
+    score_cache: dict[tuple, float] = {}
+    transform_cache: dict[tuple, Transform] = {}
+
+    for trial_params in trial_params_list:
         trial_settings = beads_match_settings.model_copy(deep=True)
         apply_trial_params(trial_settings, trial_params)
 
@@ -185,6 +281,22 @@ def optimize_matches(
             )
 
             if len(matches) < 3:
+                continue
+
+            cache_key = (
+                trial_settings.algorithm,
+                tuple(map(tuple, np.asarray(matches))),
+            )
+            if cache_key in score_cache:
+                if score_cache[cache_key] > best_score:
+                    best_score = score_cache[cache_key]
+                    best_settings = trial_settings
+                    best_transform = transform_cache[cache_key]
+                if verbose:
+                    click.echo(
+                        f"  {trial_params} -> matches={len(matches)}, "
+                        f"score={score_cache[cache_key]:.4f} (cached)"
+                    )
                 continue
 
             fwd_transform, inv_transform = transform_from_matches(
@@ -225,23 +337,30 @@ def optimize_matches(
             if np.isnan(score):
                 continue
 
+            score_cache[cache_key] = score
+            transform_cache[cache_key] = composed_transform
+
             if verbose:
                 click.echo(f"  {trial_params} -> matches={len(matches)}, score={score:.4f}")
 
             if score > best_score:
                 best_score = score
                 best_settings = trial_settings
+                best_transform = composed_transform
 
         except Exception as e:
             if verbose:
                 click.echo(f"  {trial_params} -> failed: {e}")
             continue
 
+    click.echo(
+        f"Grid search best score: {best_score:.4f} "
+        f"({len(score_cache)} distinct match sets scored)"
+    )
     if verbose:
-        click.echo(f"Best score: {best_score:.4f}")
         click.echo(f"Best settings: {best_settings}")
 
-    return best_settings
+    return best_settings, best_transform, best_score
 
 
 def overlap_score(
@@ -1296,6 +1415,50 @@ def estimate(
     # get highest quality score
     best_quality_score = max(transform_iter_dict.values(), key=lambda x: x["quality_score"])
     best_transform = best_quality_score["transform"]
+
+    # Fourth arm, last resort: re-tune the matching parameters for THIS timepoint. Every arm
+    # above shares one parameter set across the whole timelapse, and a few timepoints are
+    # simply not well served by it. Gated on score because it is the most expensive arm --
+    # one ANTs warp plus peak re-detection per distinct match set.
+    #
+    # Runs after the loop, on the best of all arms, so it only ever fires where everything
+    # else has already failed, and its result is accepted only if it strictly wins. It
+    # therefore cannot make any timepoint worse than leaving it off.
+    sweep = beads_match_settings.sweep_fallback_settings
+    incumbent_score = best_quality_score["quality_score"]
+    if sweep.mode == "on_low_score" and incumbent_score < sweep.score_threshold:
+        click.echo(
+            f"Sweep fallback: best arm scored {incumbent_score:.3f} < "
+            f"{sweep.score_threshold}, grid-searching matching parameters for this timepoint"
+        )
+        try:
+            _, swept_transform, swept_score = optimize_matches(
+                mov=mov,
+                ref=ref,
+                approx_transform=initial_transform,
+                beads_match_settings=beads_match_settings,
+                affine_transform_settings=affine_transform_settings,
+                param_grid=sweep.grid,
+                verbose=verbose,
+            )
+        except Exception as e:  # noqa: BLE001
+            # A fallback that can take down a whole timelapse is worse than no fallback.
+            click.echo(f"Sweep fallback failed ({type(e).__name__}: {e}); keeping incumbent.")
+            swept_transform, swept_score = None, -1.0
+
+        if swept_transform is not None and swept_score > incumbent_score:
+            click.echo(f"Sweep fallback wins: {incumbent_score:.3f} -> {swept_score:.3f}")
+            best_transform = swept_transform
+            best_quality_score = {
+                "transform": swept_transform,
+                "quality_score": swept_score,
+            }
+            transform_iter_dict["sweep_fallback"] = best_quality_score
+        else:
+            click.echo(
+                f"Sweep fallback found nothing better than {incumbent_score:.3f}; "
+                "keeping incumbent."
+            )
 
     # Every optimisation attempt failed, so the coarse initial transform is all we have.
     # Recorded explicitly: the saved .npy is otherwise indistinguishable from a real fit,

--- a/biahub/registration/beads.py
+++ b/biahub/registration/beads.py
@@ -520,7 +520,7 @@ def select_flagged(
     score_col: ArrayLike,
     label: str,
     max_timepoints: int | None = None,
-) -> list[int]:
+) -> tuple[list[int], dict]:
     """Timepoints to act on, from the run's OWN adaptive median-2*MAD line.
 
     Shared by both fallback passes so they cannot drift apart in how they choose work, and
@@ -531,6 +531,10 @@ def select_flagged(
     i.e. where 0.75 sat at the median -- it fired 556 times and drove the job into its 24 h
     walltime. The adaptive line rescales with each run, so a fallback stays a fallback.
 
+    Returns (flagged timepoints, run statistics). The statistics are returned rather than
+    recomputed by callers so the number written to a log is provably the same one the
+    selection used.
+
     Returns the worst `max_timepoints` when a cap is set, and says which ones it dropped.
     """
     score_col = np.asarray(score_col, dtype=float)
@@ -539,11 +543,11 @@ def select_flagged(
         flags = flag_timepoints(score_col)
     except ValueError:
         click.echo(f"{label}: no finite scores to flag against; skipping.")
-        return []
+        return [], {}
     flagged = [int(t) for t in flags.loc[flags["flagged"], "t"]]
     if not flagged:
         click.echo(f"{label}: nothing flagged, nothing to do.")
-        return []
+        return [], dict(flags.attrs)
 
     click.echo(
         f"{label}: {len(flagged)} of {n_t} timepoints flagged "
@@ -559,7 +563,7 @@ def select_flagged(
             f"  capped at max_timepoints={max_timepoints}; taking the worst {len(flagged)} "
             f"and LEAVING {len(dropped)} untouched: {dropped}"
         )
-    return flagged
+    return flagged, dict(flags.attrs)
 
 
 def sweep_flagged_timepoints(
@@ -593,7 +597,7 @@ def sweep_flagged_timepoints(
     """
     settings = beads_match_settings.sweep_fallback_settings
     score_col = np.asarray(scores["quality_score"].to_numpy(dtype=float)).copy()
-    flagged = select_flagged(score_col, "Sweep fallback", settings.max_timepoints)
+    flagged, _stats = select_flagged(score_col, "Sweep fallback", settings.max_timepoints)
     if not flagged:
         return transforms, scores
 
@@ -693,7 +697,7 @@ def repair_flagged_timepoints(
     score_col = scores["quality_score"].to_numpy(dtype=float).copy()
     n_t = len(score_col)
 
-    flagged = select_flagged(score_col, "Repair pass", settings.max_timepoints)
+    flagged, stats = select_flagged(score_col, "Repair pass", settings.max_timepoints)
     if not flagged:
         return transforms, scores
 
@@ -852,9 +856,9 @@ def repair_flagged_timepoints(
     (output_transforms_path.parent / "repair_log.json").write_text(
         json.dumps(
             {
-                "adaptive_line": flags.attrs["adaptive_line"],
-                "median": flags.attrs["median"],
-                "mad": flags.attrs["mad"],
+                "adaptive_line": stats.get("adaptive_line"),
+                "median": stats.get("median"),
+                "mad": stats.get("mad"),
                 "n_flagged": len(log),
                 "n_improved": improved,
                 "repairs": log,

--- a/biahub/registration/beads.py
+++ b/biahub/registration/beads.py
@@ -25,6 +25,8 @@ Key conventions
 - Transforms map from moving space to reference space (forward direction).
 """
 
+import json
+
 from datetime import datetime
 from itertools import product
 from pathlib import Path
@@ -52,7 +54,7 @@ from biahub.cli.utils import (
 )
 from biahub.core.graph_matching import Graph, GraphMatcher
 from biahub.core.transform import Transform
-from biahub.registration.qc import write_qc_report
+from biahub.registration.qc import flag_timepoints, write_qc_report
 from biahub.registration.utils import (
     get_aprox_transform,
     load_quality_scores,
@@ -427,6 +429,208 @@ def overlap_score(
     return peaks_overlap_fraction
 
 
+def score_transform(
+    transform: Transform,
+    mov: ArrayLike,
+    ref: ArrayLike,
+    beads_match_settings: BeadsMatchSettings,
+) -> float:
+    """Overlap score of a transform, by the same path that produced the run's own scores.
+
+    Deliberately duplicates the warp / re-detect / overlap_score sequence from
+    optimize_transform's step 3 rather than calling optimize_transform, because that function
+    also refines the transform -- which would score something other than what was passed in.
+    Returns nan when the warp leaves too few detectable beads.
+    """
+    warped = (
+        transform.to_ants()
+        .apply_to_image(ants.from_numpy(np.asarray(mov)), reference=ants.from_numpy(np.asarray(ref)))
+        .numpy()
+    )
+    mov_peaks, ref_peaks = peaks_from_beads(
+        mov=warped,
+        ref=ref,
+        mov_peaks_settings=beads_match_settings.source_peaks_settings,
+        ref_peaks_settings=beads_match_settings.target_peaks_settings,
+        verbose=False,
+    )
+    if mov_peaks is None or ref_peaks is None:
+        return float("nan")
+    return overlap_score(
+        mov_peaks=mov_peaks,
+        ref_peaks=ref_peaks,
+        radius=beads_match_settings.qc_settings.score_centroid_mask_radius,
+        verbose=False,
+    )
+
+
+def repair_flagged_timepoints(
+    mov_tzyx: da.Array,
+    ref_tzyx: da.Array,
+    transforms: list,
+    scores: "pd.DataFrame",
+    beads_match_settings: BeadsMatchSettings,
+    affine_transform_settings: AffineTransformSettings,
+    output_transforms_path: Path,
+    mode: str = "registration",
+    verbose: bool = False,
+) -> tuple[list, "pd.DataFrame"]:
+    """Re-estimate flagged timepoints from their neighbours' transforms.
+
+    This is the second half of the fallback, and it has to live here rather than inside
+    estimate() for a structural reason: it seeds from t-1 AND t+1, and t+1 does not exist
+    yet while t is being estimated -- in independent mode the timepoints are running in
+    parallel shards. So it can only run once the whole series is known.
+
+    That ordering is also what makes it strictly stronger than propagation's own fallback,
+    which can only ever reach backwards to t-1. A timepoint that failed because the sample
+    jumped between t-1 and t is often perfectly reachable from t+1.
+
+    It covers a different failure class from the sweep. The sweep re-tunes the matching
+    parameters and helps where the transform is already in the right basin but the
+    correspondence is suboptimal -- measured yield +0.058 on timepoints scoring 0.72-0.78,
+    and +0.006 on those below 0.72. Reseeding is what addresses a transform in the WRONG
+    basin, which no amount of re-weighting the cost matrix fixes: at one real timepoint that
+    had no usable transform at all, propagation gave 0.429 while a reseed reached 0.778.
+
+    Each candidate seed is run through the full estimate() rather than a bare
+    optimize_transform, so a reseed also gets the spectral cascade and the sweep fallback.
+    Candidates are scored and accepted only if they strictly beat what is already there, so
+    this pass cannot make a run worse.
+
+    Which timepoints to repair comes from the run's own adaptive threshold, so the gate is
+    the same median-2*MAD line the QC report flags on rather than a second fixed number.
+
+    Returns the possibly-updated transforms and scores; the repaired .npy files are rewritten
+    in place so the on-disk record matches what is returned.
+    """
+    settings = beads_match_settings.repair_pass_settings
+    # .copy(): to_numpy can hand back a read-only view onto the DataFrame's own buffer when
+    # the dtype already matches, and this array is written to as repairs are accepted.
+    score_col = scores["quality_score"].to_numpy(dtype=float).copy()
+    n_t = len(score_col)
+
+    try:
+        flags = flag_timepoints(score_col)
+    except ValueError:
+        click.echo("Repair pass skipped: no finite scores to flag against.")
+        return transforms, scores
+    flagged = [int(t) for t in flags.loc[flags["flagged"], "t"]]
+    if not flagged:
+        click.echo("Repair pass: nothing flagged, nothing to repair.")
+        return transforms, scores
+
+    click.echo(
+        f"Repair pass: {len(flagged)} of {n_t} timepoints flagged "
+        f"(adaptive line {flags.attrs['adaptive_line']:.3f}) -> {flagged}"
+    )
+    if settings.max_timepoints is not None and len(flagged) > settings.max_timepoints:
+        # Announced rather than silently truncated: a capped run that says nothing reads as
+        # "everything was repaired".
+        worst = sorted(flagged, key=lambda t: np.nan_to_num(score_col[t], nan=-1.0))
+        dropped = sorted(worst[settings.max_timepoints :])
+        flagged = sorted(worst[: settings.max_timepoints])
+        click.echo(
+            f"  capped at max_timepoints={settings.max_timepoints}; repairing the worst "
+            f"{len(flagged)} and LEAVING {len(dropped)} unrepaired: {dropped}"
+        )
+
+    seed_matrix = np.asarray(affine_transform_settings.approx_transform, dtype=float)
+    flagged_set = set(flagged)
+    good_median = float(np.nanmedian(score_col))
+    log = []
+
+    for t in flagged:
+        before = score_col[t] if np.isfinite(score_col[t]) else -1.0
+
+        # Only non-flagged neighbours are worth seeding from; a flagged neighbour is by
+        # definition not a transform we trust.
+        candidates = []
+        for name, idx in (("t-1", t - 1), ("t+1", t + 1)):
+            if 0 <= idx < n_t and idx not in flagged_set and transforms[idx] is not None:
+                candidates.append((name, np.asarray(transforms[idx], dtype=float)))
+        if settings.try_config_seed:
+            candidates.append(("config_seed", seed_matrix))
+
+        mov_t = np.asarray(mov_tzyx[t])
+        ref_t = np.asarray(ref_tzyx[t])
+
+        best_name, best_matrix, best_score = "unchanged", None, before
+        for name, seed in candidates:
+            trial_ats = affine_transform_settings.model_copy(deep=True)
+            trial_ats.approx_transform = seed.tolist()
+            # Reseeding is the point, so propagation must be off for the trial or estimate()
+            # would reintroduce the very previous-timepoint transform being replaced.
+            trial_ats.use_prev_t_transform = False
+            try:
+                candidate_transform = estimate(
+                    mov=mov_t,
+                    ref=ref_t,
+                    beads_match_settings=beads_match_settings,
+                    affine_transform_settings=trial_ats,
+                    verbose=False,
+                )
+                if candidate_transform is None:
+                    continue
+                # estimate() persists its score as a sidecar rather than returning it, so
+                # score here -- and scoring the returned transform directly is what makes
+                # this comparable to `before` in the first place.
+                candidate_score = score_transform(
+                    candidate_transform, mov_t, ref_t, beads_match_settings
+                )
+            except Exception as e:  # noqa: BLE001
+                click.echo(f"  t={t} seed {name} failed: {type(e).__name__}: {e}")
+                continue
+            if np.isfinite(candidate_score) and candidate_score > best_score:
+                best_name, best_matrix, best_score = name, candidate_transform, candidate_score
+            # Short-circuit: once a reseed is as good as a typical timepoint in this run,
+            # further candidates are unlikely to matter and each costs a full estimate().
+            if best_score >= good_median:
+                break
+
+        if best_matrix is not None:
+            matrix = np.asarray(
+                best_matrix.to_list() if hasattr(best_matrix, "to_list") else best_matrix,
+                dtype=float,
+            )
+            transforms[t] = matrix
+            np.save(output_transforms_path / f"{t}.npy", matrix)
+            score_col[t] = best_score
+            scores.loc[scores["t"] == t, "quality_score"] = best_score
+            if "fell_back_to_seed" in scores:
+                scores.loc[scores["t"] == t, "fell_back_to_seed"] = False
+        click.echo(
+            f"  t={t:4d} {before:.3f} -> {best_score:.3f} via {best_name}"
+            + ("" if best_matrix is not None else "  (kept original)")
+        )
+        log.append(
+            {
+                "t": t,
+                "before": float(before),
+                "after": float(best_score),
+                "source": best_name,
+                "candidates_tried": [n for n, _ in candidates],
+            }
+        )
+
+    improved = sum(1 for r in log if r["after"] > r["before"] + 1e-9)
+    click.echo(f"Repair pass: {improved} of {len(log)} flagged timepoints improved")
+    (output_transforms_path.parent / "repair_log.json").write_text(
+        json.dumps(
+            {
+                "adaptive_line": flags.attrs["adaptive_line"],
+                "median": flags.attrs["median"],
+                "mad": flags.attrs["mad"],
+                "n_flagged": len(log),
+                "n_improved": improved,
+                "repairs": log,
+            },
+            indent=2,
+        )
+    )
+    return transforms, scores
+
+
 def estimate_tczyx(
     mov_tczyx: da.Array,
     ref_tczyx: da.Array,
@@ -536,6 +740,24 @@ def estimate_tczyx(
     # and no way at all for the independent arm, whose timepoints each log to their own
     # submitit file.
     scores = load_quality_scores(output_transforms_path, mov_tzyx.shape[0])
+
+    # Second half of the fallback. Runs here, after the whole series is known, because it
+    # seeds from both neighbours and t+1 does not exist while t is being estimated. The
+    # sweep half already ran per-timepoint inside estimate(); between them they cover the
+    # two distinct failure modes, and each accepts its result only on a strict score win.
+    if beads_match_settings.repair_pass_settings.mode == "on_flagged":
+        transforms, scores = repair_flagged_timepoints(
+            mov_tzyx=mov_tzyx,
+            ref_tzyx=ref_tzyx,
+            transforms=transforms,
+            scores=scores,
+            beads_match_settings=beads_match_settings,
+            affine_transform_settings=affine_transform_settings,
+            output_transforms_path=output_transforms_path,
+            mode=mode,
+            verbose=verbose,
+        )
+
     scores.to_csv(output_folder_path / "quality_scores.csv", index=False)
     plot_quality_scores(
         scores,

--- a/biahub/registration/beads.py
+++ b/biahub/registration/beads.py
@@ -464,6 +464,189 @@ def score_transform(
     )
 
 
+def consensus_geometry(
+    transforms: list,
+    scores: ArrayLike,
+    score_threshold: float = 0.75,
+) -> np.ndarray | None:
+    """Element-wise median transform over the timepoints that scored well.
+
+    The run's own consensus geometry, used as a repair seed. Built ONLY from good timepoints:
+    including the failures would contaminate the reference used to detect and fix them.
+
+    Why this is a good seed, and why its two halves are treated differently downstream:
+
+    The LINEAR part is optics -- rotation, scale, shear between the two arms. It is stable
+    across a timelapse and, on one instrument, across acquisitions. Measured on one dataset,
+    the linear parts of 345 good timepoints agree to a Frobenius distance of 0.021, while the
+    failures sit at 0.72; distance-from-consensus separated failed from good timepoints with
+    AUC 1.000, and 15 failures were outright reflections (negative determinant), i.e. fits
+    that collapsed rather than drifted.
+
+    The TRANSLATION is not comparable in that way, because it depends on the ROI selected on
+    the microscope. The same instrument with a slightly different ROI gives a translation
+    tens of voxels away while the linear part is unchanged -- measured 22 voxels in Y and 32
+    in X between one dataset's configured seed and its own consensus, at only 2.4 degrees of
+    rotation difference. So a timepoint's own translation is usually worth keeping even when
+    its linear part has to be replaced.
+
+    Returns None when too few timepoints score well enough to define a consensus.
+    """
+    scores = np.asarray(scores, dtype=float)
+    good = [
+        t
+        for t in range(min(len(transforms), len(scores)))
+        if transforms[t] is not None
+        and np.isfinite(scores[t])
+        and scores[t] >= score_threshold
+    ]
+    if len(good) < 5:
+        click.echo(
+            f"Consensus geometry: only {len(good)} timepoints score >= {score_threshold}; "
+            "not enough to define one."
+        )
+        return None
+    stack = np.asarray([np.asarray(transforms[t], dtype=float) for t in good])
+    med = np.median(stack, axis=0)
+    med[3] = [0.0, 0.0, 0.0, 1.0]
+    click.echo(
+        f"Consensus geometry from {len(good)} timepoints scoring >= {score_threshold} "
+        f"(det {np.linalg.det(med[:3, :3]):.4f})"
+    )
+    return med
+
+
+def select_flagged(
+    score_col: ArrayLike,
+    label: str,
+    max_timepoints: int | None = None,
+) -> list[int]:
+    """Timepoints to act on, from the run's OWN adaptive median-2*MAD line.
+
+    Shared by both fallback passes so they cannot drift apart in how they choose work, and
+    so neither carries a fixed score threshold.
+
+    A fixed gate cannot work across datasets. Measured with a hardcoded 0.75: on a run whose
+    median was 0.870 it fired 0 times out of 144, while on a run whose median was 0.753 --
+    i.e. where 0.75 sat at the median -- it fired 556 times and drove the job into its 24 h
+    walltime. The adaptive line rescales with each run, so a fallback stays a fallback.
+
+    Returns the worst `max_timepoints` when a cap is set, and says which ones it dropped.
+    """
+    score_col = np.asarray(score_col, dtype=float)
+    n_t = len(score_col)
+    try:
+        flags = flag_timepoints(score_col)
+    except ValueError:
+        click.echo(f"{label}: no finite scores to flag against; skipping.")
+        return []
+    flagged = [int(t) for t in flags.loc[flags["flagged"], "t"]]
+    if not flagged:
+        click.echo(f"{label}: nothing flagged, nothing to do.")
+        return []
+
+    click.echo(
+        f"{label}: {len(flagged)} of {n_t} timepoints flagged "
+        f"(adaptive line {flags.attrs['adaptive_line']:.3f}, median "
+        f"{flags.attrs['median']:.3f}) -> {flagged}"
+    )
+    if max_timepoints is not None and len(flagged) > max_timepoints:
+        # Announced, never silent: a capped pass that says nothing reads as full coverage.
+        worst = sorted(flagged, key=lambda t: np.nan_to_num(score_col[t], nan=-1.0))
+        dropped = sorted(worst[max_timepoints:])
+        flagged = sorted(worst[:max_timepoints])
+        click.echo(
+            f"  capped at max_timepoints={max_timepoints}; taking the worst {len(flagged)} "
+            f"and LEAVING {len(dropped)} untouched: {dropped}"
+        )
+    return flagged
+
+
+def sweep_flagged_timepoints(
+    mov_tzyx: da.Array,
+    ref_tzyx: da.Array,
+    transforms: list,
+    scores: "pd.DataFrame",
+    beads_match_settings: BeadsMatchSettings,
+    affine_transform_settings: AffineTransformSettings,
+    output_transforms_path: Path,
+    verbose: bool = False,
+) -> tuple[list, "pd.DataFrame"]:
+    """Re-tune the matching parameters for the timepoints still flagged after repair.
+
+    Runs LAST, and as a post-pass rather than inside estimate(), for two reasons that turned
+    out to be the same reason:
+
+    It has to be gated on the run's own score distribution, and inside estimate() that
+    distribution does not exist yet -- in independent mode the other timepoints are still
+    being computed in other SLURM jobs. Only a fixed threshold is available there, and a fixed
+    threshold does not survive contact with a second dataset (see select_flagged).
+
+    And it belongs after the repair pass because the two are not interchangeable. Reseeding
+    fixes a transform that is in the wrong basin; re-tuning parameters is measured to gain
+    +0.058 on timepoints scoring 0.72-0.78 but only +0.006 on those below 0.72. So repairing
+    first moves the hard failures out of the way, and whatever is still flagged afterwards is
+    by definition the mild tail -- exactly the population the sweep is good at. It also means
+    the sweep is not paying to re-tune timepoints the cheaper pass would have fixed anyway.
+
+    Accepted only on a strict score win, so this cannot make a run worse.
+    """
+    settings = beads_match_settings.sweep_fallback_settings
+    score_col = np.asarray(scores["quality_score"].to_numpy(dtype=float)).copy()
+    flagged = select_flagged(score_col, "Sweep fallback", settings.max_timepoints)
+    if not flagged:
+        return transforms, scores
+
+    log = []
+    for t in flagged:
+        before = score_col[t] if np.isfinite(score_col[t]) else -1.0
+        mov_t, ref_t = np.asarray(mov_tzyx[t]), np.asarray(ref_tzyx[t])
+        try:
+            _, swept_transform, swept_score = optimize_matches(
+                mov=mov_t,
+                ref=ref_t,
+                approx_transform=Transform(
+                    matrix=np.asarray(affine_transform_settings.approx_transform)
+                ),
+                beads_match_settings=beads_match_settings,
+                affine_transform_settings=affine_transform_settings,
+                param_grid=settings.grid,
+                verbose=verbose,
+            )
+        except Exception as e:  # noqa: BLE001
+            click.echo(f"  t={t} sweep failed: {type(e).__name__}: {e}")
+            continue
+
+        accepted = swept_transform is not None and swept_score > before
+        if accepted:
+            matrix = np.asarray(swept_transform.to_list(), dtype=float)
+            transforms[t] = matrix.tolist()
+            np.save(output_transforms_path / f"{t}.npy", matrix)
+            score_col[t] = swept_score
+            scores.loc[scores["t"] == t, "quality_score"] = swept_score
+            if "fell_back_to_seed" in scores:
+                scores.loc[scores["t"] == t, "fell_back_to_seed"] = False
+        click.echo(
+            f"  t={t:4d} {before:.3f} -> {swept_score if swept_transform is not None else before:.3f}"
+            + ("" if accepted else "  (kept original)")
+        )
+        log.append(
+            {
+                "t": t,
+                "before": float(before),
+                "after": float(swept_score) if swept_transform is not None else float(before),
+                "accepted": bool(accepted),
+            }
+        )
+
+    improved = sum(1 for r in log if r["accepted"])
+    click.echo(f"Sweep fallback: {improved} of {len(log)} flagged timepoints improved")
+    (output_transforms_path.parent / "sweep_log.json").write_text(
+        json.dumps({"n_flagged": len(log), "n_improved": improved, "sweeps": log}, indent=2)
+    )
+    return transforms, scores
+
+
 def repair_flagged_timepoints(
     mov_tzyx: da.Array,
     ref_tzyx: da.Array,
@@ -510,32 +693,16 @@ def repair_flagged_timepoints(
     score_col = scores["quality_score"].to_numpy(dtype=float).copy()
     n_t = len(score_col)
 
-    try:
-        flags = flag_timepoints(score_col)
-    except ValueError:
-        click.echo("Repair pass skipped: no finite scores to flag against.")
-        return transforms, scores
-    flagged = [int(t) for t in flags.loc[flags["flagged"], "t"]]
+    flagged = select_flagged(score_col, "Repair pass", settings.max_timepoints)
     if not flagged:
-        click.echo("Repair pass: nothing flagged, nothing to repair.")
         return transforms, scores
-
-    click.echo(
-        f"Repair pass: {len(flagged)} of {n_t} timepoints flagged "
-        f"(adaptive line {flags.attrs['adaptive_line']:.3f}) -> {flagged}"
-    )
-    if settings.max_timepoints is not None and len(flagged) > settings.max_timepoints:
-        # Announced rather than silently truncated: a capped run that says nothing reads as
-        # "everything was repaired".
-        worst = sorted(flagged, key=lambda t: np.nan_to_num(score_col[t], nan=-1.0))
-        dropped = sorted(worst[settings.max_timepoints :])
-        flagged = sorted(worst[: settings.max_timepoints])
-        click.echo(
-            f"  capped at max_timepoints={settings.max_timepoints}; repairing the worst "
-            f"{len(flagged)} and LEAVING {len(dropped)} unrepaired: {dropped}"
-        )
 
     seed_matrix = np.asarray(affine_transform_settings.approx_transform, dtype=float)
+    consensus = (
+        consensus_geometry(transforms, score_col, settings.consensus_score_threshold)
+        if settings.use_consensus_seed
+        else None
+    )
     flagged_set = set(flagged)
     good_median = float(np.nanmedian(score_col))
     log = []
@@ -546,9 +713,36 @@ def repair_flagged_timepoints(
         # Only non-flagged neighbours are worth seeding from; a flagged neighbour is by
         # definition not a transform we trust.
         candidates = []
+
+        # Consensus-geometry seeds, tried FIRST when this timepoint's linear part is itself
+        # broken. A reflection (negative determinant) or a linear part far from the run's
+        # consensus is a collapsed fit, not a drifted one, and no neighbour is a better
+        # starting point than the run's own agreed geometry.
+        #
+        # consensus_linear keeps the timepoint's OWN translation, because translation depends
+        # on the ROI selected on the microscope and on stage drift, so it carries real
+        # information even when the linear part does not. consensus_full replaces both, for
+        # when the translation is broken too.
+        degenerate = False
+        if consensus is not None and transforms[t] is not None:
+            L = np.asarray(transforms[t], dtype=float)[:3, :3]
+            degenerate = (
+                np.linalg.det(L) <= 0
+                or np.linalg.norm(L - consensus[:3, :3]) > settings.consensus_linear_tolerance
+            )
+            if degenerate:
+                keep_translation = consensus.copy()
+                keep_translation[:3, 3] = np.asarray(transforms[t], dtype=float)[:3, 3]
+                candidates.append(("consensus_linear", keep_translation))
+                candidates.append(("consensus_full", consensus.copy()))
+
         for name, idx in (("t-1", t - 1), ("t+1", t + 1)):
             if 0 <= idx < n_t and idx not in flagged_set and transforms[idx] is not None:
                 candidates.append((name, np.asarray(transforms[idx], dtype=float)))
+
+        # Also offered when the linear part looked fine: cheap, and it can still win.
+        if consensus is not None and not degenerate:
+            candidates.append(("consensus_full", consensus.copy()))
         if settings.try_config_seed:
             candidates.append(("config_seed", seed_matrix))
 
@@ -749,10 +943,26 @@ def estimate_tczyx(
     # submitit file.
     scores = load_quality_scores(output_transforms_path, mov_tzyx.shape[0])
 
-    # Second half of the fallback. Runs here, after the whole series is known, because it
-    # seeds from both neighbours and t+1 does not exist while t is being estimated. The
-    # sweep half already ran per-timepoint inside estimate(); between them they cover the
-    # two distinct failure modes, and each accepts its result only on a strict score win.
+    # Both fallbacks run here, after the whole series is known, and in this order.
+    #
+    # They must run here rather than inside estimate() because both are gated on the run's
+    # OWN adaptive median-2*MAD line, and that distribution does not exist while individual
+    # timepoints are being estimated in parallel shards. The repair pass additionally needs
+    # t+1, which likewise does not exist yet.
+    #
+    # REPAIR FIRST, then sweep. They address different failure modes and the cheap, effective
+    # one should go first:
+    #   repair  reseeds from t-1/t+1, so it moves a transform between basins. Measured
+    #           0.429 -> 0.941 at one real timepoint.
+    #   sweep   re-tunes matching parameters, worth +0.058 on timepoints scoring 0.72-0.78
+    #           but only +0.006 on those below 0.72.
+    # Repairing first clears the hard failures, so whatever is still flagged afterwards is
+    # the mild tail -- precisely the population the sweep is good at -- and the sweep does
+    # not spend a full grid search on timepoints reseeding would have fixed for less.
+    #
+    # Flags are RECOMPUTED between the two passes, so the sweep sees the post-repair
+    # distribution rather than a stale one. Each pass accepts a result only if it strictly
+    # beats the incumbent, so neither can make the run worse.
     if beads_match_settings.repair_pass_settings.mode == "on_flagged":
         transforms, scores = repair_flagged_timepoints(
             mov_tzyx=mov_tzyx,
@@ -763,6 +973,17 @@ def estimate_tczyx(
             affine_transform_settings=affine_transform_settings,
             output_transforms_path=output_transforms_path,
             mode=mode,
+            verbose=verbose,
+        )
+    if beads_match_settings.sweep_fallback_settings.mode == "on_flagged":
+        transforms, scores = sweep_flagged_timepoints(
+            mov_tzyx=mov_tzyx,
+            ref_tzyx=ref_tzyx,
+            transforms=transforms,
+            scores=scores,
+            beads_match_settings=beads_match_settings,
+            affine_transform_settings=affine_transform_settings,
+            output_transforms_path=output_transforms_path,
             verbose=verbose,
         )
 
@@ -1658,6 +1879,10 @@ def estimate(
     # Runs after the loop, on the best of all arms, so it only ever fires where everything
     # else has already failed, and its result is accepted only if it strictly wins. It
     # therefore cannot make any timepoint worse than leaving it off.
+    # "on_low_score" is the legacy in-estimate() arm, gated on a FIXED threshold because no
+    # run-wide distribution is available at this point. "on_flagged" is the adaptive
+    # replacement and deliberately does NOT fire here: it runs as a post-pass in
+    # estimate_tczyx, after the repair pass, where the run's own median and MAD are known.
     sweep = beads_match_settings.sweep_fallback_settings
     incumbent_score = best_quality_score["quality_score"]
     if sweep.mode == "on_low_score" and incumbent_score < sweep.score_threshold:

--- a/biahub/registration/beads.py
+++ b/biahub/registration/beads.py
@@ -595,7 +595,7 @@ def sweep_flagged_timepoints(
 
     Accepted only on a strict score win, so this cannot make a run worse.
     """
-    settings = beads_match_settings.sweep_fallback_settings
+    settings = beads_match_settings.fallback_settings.sweep_settings
     score_col = np.asarray(scores["quality_score"].to_numpy(dtype=float)).copy()
     flagged, _stats = select_flagged(score_col, "Sweep fallback", settings.max_timepoints)
     if settings.scope == "repair_failures_only":
@@ -711,7 +711,7 @@ def repair_flagged_timepoints(
     Returns the possibly-updated transforms and scores; the repaired .npy files are rewritten
     in place so the on-disk record matches what is returned.
     """
-    settings = beads_match_settings.repair_pass_settings
+    settings = beads_match_settings.fallback_settings.repair_settings
     # .copy(): to_numpy can hand back a read-only view onto the DataFrame's own buffer when
     # the dtype already matches, and this array is written to as repairs are accepted.
     score_col = scores["quality_score"].to_numpy(dtype=float).copy()
@@ -1142,9 +1142,9 @@ def estimate_tczyx(
     # Each pass still accepts a result only if it strictly beats what it started from, and the
     # transforms/scores handed to each are the SAME pre-fallback ones, so neither can regress
     # and neither can hide the other.
-    repair_on = beads_match_settings.repair_pass_settings.mode == "on_flagged"
-    sweep_on = beads_match_settings.sweep_fallback_settings.mode == "on_flagged"
-    fb_mode = beads_match_settings.fallback_mode
+    fb = beads_match_settings.fallback_settings
+    repair_on, sweep_on = fb.repair_enabled, fb.sweep_enabled
+    fb_mode = fb.order
     parallel = fb_mode == "parallel"
 
     if repair_on and sweep_on and parallel:
@@ -2105,13 +2105,13 @@ def estimate(
     # Runs after the loop, on the best of all arms, so it only ever fires where everything
     # else has already failed, and its result is accepted only if it strictly wins. It
     # therefore cannot make any timepoint worse than leaving it off.
-    # "on_low_score" is the legacy in-estimate() arm, gated on a FIXED threshold because no
-    # run-wide distribution is available at this point. "on_flagged" is the adaptive
-    # replacement and deliberately does NOT fire here: it runs as a post-pass in
-    # estimate_tczyx, after the repair pass, where the run's own median and MAD are known.
-    sweep = beads_match_settings.sweep_fallback_settings
+    # legacy_in_estimate is the old per-timepoint arm, gated on a FIXED threshold because no
+    # run-wide distribution exists at this point. The adaptive replacement runs as a post-pass
+    # in estimate_tczyx, where the run's own median and MAD are known, and deliberately does
+    # not fire here.
+    sweep = beads_match_settings.fallback_settings.sweep_settings
     incumbent_score = best_quality_score["quality_score"]
-    if sweep.mode == "on_low_score" and incumbent_score < sweep.score_threshold:
+    if sweep.legacy_in_estimate and incumbent_score < sweep.score_threshold:
         click.echo(
             f"Sweep fallback: best arm scored {incumbent_score:.3f} < "
             f"{sweep.score_threshold}, grid-searching matching parameters for this timepoint"

--- a/biahub/registration/beads.py
+++ b/biahub/registration/beads.py
@@ -440,13 +440,25 @@ def estimate_with_propagation(
         "registration": align moving to reference channel.
         "stabilization": align moving channel to itself over time.
     """
-    initial_transform = affine_transform_settings.approx_transform
+    # The static seed from the config. Kept as the `user_transform` competition arm for
+    # every timepoint, so a run that has drifted still gets a chance to snap back to it.
+    config_seed = affine_transform_settings.approx_transform
+    # The most recent transform that actually succeeded. This -- not the config seed --
+    # is what a failed timepoint falls back to. Resetting to the config seed makes a
+    # single failure self-sustaining: the seed is a deliberately coarse initialisation
+    # (measured at overlap score 0.000 on real bead data), so the next timepoint starts
+    # from somewhere the matcher cannot recover from, fails in turn, and the failure
+    # walks forward as a cluster.
+    last_good_transform = config_seed
+
     T, _, _, _ = mov_tzyx.shape
     for t in range(T):
         if mode == "stabilization" and t == 0:
             continue
         if np.sum(mov_tzyx[t]) == 0 or np.sum(ref_tzyx[t]) == 0:
             click.echo(f"Timepoint {t} has no data, skipping")
+            # approx_transform stays on the last good one, so a blank frame costs only
+            # itself rather than derailing every timepoint after it.
         else:
             approx_transform = estimate_tzyx(
                 t_idx=t,
@@ -457,13 +469,17 @@ def estimate_with_propagation(
                 verbose=verbose,
                 output_folder_path=output_folder_path,
                 mode=mode,
-                user_transform=initial_transform,
+                user_transform=config_seed,
             )
 
             if approx_transform is not None:
-                affine_transform_settings.approx_transform = approx_transform.to_list()
-            else:
-                affine_transform_settings.approx_transform = initial_transform
+                last_good_transform = approx_transform.to_list()
+            elif verbose:
+                click.echo(
+                    f"Timepoint {t} produced no transform; propagating the last "
+                    "successful transform rather than the config seed."
+                )
+            affine_transform_settings.approx_transform = last_good_transform
 
 
 def estimate_independently(

--- a/biahub/registration/beads.py
+++ b/biahub/registration/beads.py
@@ -598,6 +598,26 @@ def sweep_flagged_timepoints(
     settings = beads_match_settings.sweep_fallback_settings
     score_col = np.asarray(scores["quality_score"].to_numpy(dtype=float)).copy()
     flagged, _stats = select_flagged(score_col, "Sweep fallback", settings.max_timepoints)
+    if settings.scope == "repair_failures_only":
+        # Restrict to what the repair pass attempted and could not lift. Note this excludes
+        # the 0.66-0.73 band the post-repair line newly catches, which is where the sweep is
+        # measured to help most -- see SweepFallbackSettings.scope.
+        log_path = output_transforms_path.parent / "repair_log.json"
+        if log_path.exists():
+            not_rescued = set(json.loads(log_path.read_text()).get("not_rescued", []))
+            dropped = [t for t in flagged if t not in not_rescued]
+            flagged = [t for t in flagged if t in not_rescued]
+            click.echo(
+                f"  scope=repair_failures_only: sweeping {len(flagged)} of the flagged "
+                f"timepoints and SKIPPING {len(dropped)} the repair pass never attempted "
+                f"or already rescued: {dropped}"
+            )
+        else:
+            click.echo(
+                "  scope=repair_failures_only but no repair_log.json found; the repair pass "
+                "did not run, so there are no failures to restrict to. Sweeping nothing."
+            )
+            flagged = []
     if not flagged:
         return transforms, scores
 
@@ -852,7 +872,11 @@ def repair_flagged_timepoints(
         )
 
     improved = sum(1 for r in log if r["after"] > r["before"] + 1e-9)
-    click.echo(f"Repair pass: {improved} of {len(log)} flagged timepoints improved")
+    unrescued = sorted(r["t"] for r in log if r["after"] <= r["before"] + 1e-9)
+    click.echo(
+        f"Repair pass: {improved} of {len(log)} flagged timepoints improved"
+        + (f"; {len(unrescued)} not rescued: {unrescued}" if unrescued else "")
+    )
     (output_transforms_path.parent / "repair_log.json").write_text(
         json.dumps(
             {
@@ -861,6 +885,7 @@ def repair_flagged_timepoints(
                 "mad": stats.get("mad"),
                 "n_flagged": len(log),
                 "n_improved": improved,
+                "not_rescued": unrescued,
                 "repairs": log,
             },
             indent=2,

--- a/biahub/registration/beads.py
+++ b/biahub/registration/beads.py
@@ -1219,9 +1219,11 @@ def estimate(
                 f"Score {best_so_far:.3f} below threshold "
                 f"{beads_match_settings.qc_settings.score_threshold}; trying spectral arm:"
             )
+            # Stage 1 -- ACQUIRE with spectral matching. This does not need the initial
+            # transform to be close, because only relative distances are used.
             spectral_settings = beads_match_settings.model_copy(deep=True)
             spectral_settings.algorithm = "spectral"
-            optimized_transform_spec, quality_score_spec = optimize_transform(
+            transform_spec, score_spec = optimize_transform(
                 transform=initial_transform,
                 mov=mov,
                 ref=ref,
@@ -1230,13 +1232,37 @@ def estimate(
                 verbose=verbose,
                 debug=debug,
             )
-            if optimized_transform_spec is not None and quality_score_spec > best_so_far:
-                click.echo(f"Spectral arm wins: {quality_score_spec:.3f}")
+
+            # Stage 2 -- REFINE from spectral's transform with the CONFIGURED matcher.
+            # This is the point of the cascade and not an optional extra: spectral
+            # acquires the correspondence but is the less precise of the two once the
+            # transform is already close, so handing its result back to the configured
+            # matcher is what recovers the last part. Measured at one real failing
+            # timepoint: seed 0.000 -> spectral 0.778 -> refined 0.882, which equals the
+            # best transform any variant found there. Stopping after stage 1 would have
+            # left 0.778 on the table.
+            if transform_spec is not None:
+                transform_refined, score_refined = optimize_transform(
+                    transform=transform_spec,
+                    mov=mov,
+                    ref=ref,
+                    beads_match_settings=beads_match_settings,
+                    affine_transform_settings=affine_transform_settings,
+                    verbose=verbose,
+                    debug=debug,
+                )
+                # optimize_transform only accepts a step that improves its own score, so
+                # a None here means refinement found nothing better -- keep stage 1.
+                if transform_refined is not None and score_refined > score_spec:
+                    transform_spec, score_spec = transform_refined, score_refined
+
+            if transform_spec is not None and score_spec > best_so_far:
+                click.echo(f"Spectral cascade wins: {best_so_far:.3f} -> {score_spec:.3f}")
                 transform_iter_dict[current_iterations] = {
-                    "transform": optimized_transform_spec,
-                    "quality_score": quality_score_spec,
+                    "transform": transform_spec,
+                    "quality_score": score_spec,
                 }
-                transform = optimized_transform_spec
+                transform = transform_spec
 
         if transform is None:
             break

--- a/biahub/registration/beads.py
+++ b/biahub/registration/beads.py
@@ -82,9 +82,13 @@ from biahub.settings import AffineTransformSettings, BeadsMatchSettings, DetectP
 # Excluded: k (never decided a winner once method was free) and angle_threshold /
 # weights_edge_angle (both 2D-only, hence flat on ZYX data).
 #
-# The spectral sub-grid is what makes this fallback worth running: it supplied 8 of the 9
-# rescues, and adding it took the yield from 5 of 15 timepoints improved to 11 of 15 (mean
-# gain +0.049 taking max against the incumbent).
+# What this grid delivers, measured on the 15 flagged timepoints, taking max against the
+# incumbent: 8 of 15 improved, mean gain +0.041 over all 15 and +0.077 over those it helped.
+# That is 83% of what an exhaustive 632-trial search over the same axes achieves (11 of 15,
+# +0.049) for 4% of the trials, which is why the axes are trimmed this hard.
+#
+# The spectral sub-grid is what makes the fallback worth running at all: it supplies 8 of the
+# 9 rescues, and a hungarian-only sweep gets only 5 of 15.
 #
 # Its ranges are bounded by a SEPARATE stratified sweep over 24 evenly-spaced timepoints,
 # not by what won at the weak ones, because those two searches disagree and the stratified

--- a/biahub/registration/beads.py
+++ b/biahub/registration/beads.py
@@ -765,12 +765,23 @@ def matches_from_beads(
 
     elif beads_match_settings.algorithm == "hungarian":
         hungarian_match_settings = beads_match_settings.hungarian_match_settings
-        mov_graph = Graph.from_nodes(
-            mov_peaks, mode="knn", k=hungarian_match_settings.edge_graph_settings.k
-        )
-        ref_graph = Graph.from_nodes(
-            ref_peaks, mode="knn", k=hungarian_match_settings.edge_graph_settings.k
-        )
+        edge_graph_settings = hungarian_match_settings.edge_graph_settings
+        # Honour the configured graph mode. This was hardcoded to "knn", so `method` was
+        # silently ignored and "radius" / "full" did nothing. That matters here rather
+        # than being cosmetic: the two clouds have very different densities (~20 moving
+        # against ~54 reference peaks in the same volume), so a fixed k spans a 1.6x
+        # larger physical neighbourhood on the sparse side at every k tested. The
+        # edge-length cost then compares descriptors measured at different scales. A
+        # radius graph uses the same physical scale on both sides -- measured on synthetic
+        # clouds that took the edge-scale ratio from 1.46 to 0.99 and recall from 0.85 to
+        # 0.91. EdgeGraphSettings already validates and defaults k / radius per method.
+        graph_kwargs = {"mode": edge_graph_settings.method}
+        if edge_graph_settings.method == "knn":
+            graph_kwargs["k"] = edge_graph_settings.k
+        elif edge_graph_settings.method == "radius":
+            graph_kwargs["radius"] = edge_graph_settings.radius
+        mov_graph = Graph.from_nodes(mov_peaks, **graph_kwargs)
+        ref_graph = Graph.from_nodes(ref_peaks, **graph_kwargs)
 
         matcher = GraphMatcher(
             algorithm="hungarian",

--- a/biahub/registration/beads.py
+++ b/biahub/registration/beads.py
@@ -946,6 +946,57 @@ def repair_flagged_timepoints(
     return transforms, scores
 
 
+def _merge_best(base_transforms, base_scores, arms, output_transforms_path):
+    """Keep, per timepoint, whichever competing pass scored highest.
+
+    Both passes were handed the same pre-fallback transforms and scores, so their results are
+    directly comparable and neither can be worse than the baseline at any timepoint. Taking
+    the per-timepoint maximum is therefore never worse than either pass alone, and never worse
+    than not running them.
+
+    Writes the winning transform back to its .npy so the on-disk record matches what is
+    returned, and logs which pass won where -- that record is the whole point, since it is
+    what says whether running both was worth the compute.
+    """
+    merged = list(base_transforms)
+    base = base_scores["quality_score"].to_numpy(dtype=float).copy()
+    scores = base_scores.copy()
+    winners: dict[str, list[int]] = {name: [] for name, _, _ in arms}
+    log = []
+
+    for t in range(len(base)):
+        best_name, best_score, best_matrix = None, base[t] if np.isfinite(base[t]) else -1.0, None
+        for name, arm_transforms, arm_scores in arms:
+            row = arm_scores.loc[arm_scores["t"] == t, "quality_score"]
+            if not len(row):
+                continue
+            v = float(row.iloc[0])
+            if np.isfinite(v) and v > best_score + 1e-9:
+                best_name, best_score, best_matrix = name, v, arm_transforms[t]
+        if best_matrix is None:
+            continue
+        merged[t] = best_matrix
+        matrix = np.asarray(best_matrix, dtype=float)
+        np.save(output_transforms_path / f"{t}.npy", matrix)
+        scores.loc[scores["t"] == t, "quality_score"] = best_score
+        if "fell_back_to_seed" in scores:
+            scores.loc[scores["t"] == t, "fell_back_to_seed"] = False
+        winners[best_name].append(t)
+        log.append({"t": t, "before": float(base[t]), "after": float(best_score),
+                    "winner": best_name})
+
+    click.echo("\nCompeting fallbacks, best per timepoint:")
+    for name in winners:
+        click.echo(f"  {name} won {len(winners[name])} timepoints: {winners[name]}")
+    if log:
+        total = sum(r["after"] - r["before"] for r in log if np.isfinite(r["before"]))
+        click.echo(f"  {len(log)} timepoints improved, total gain {total:+.3f}")
+    (output_transforms_path.parent / "fallback_merge_log.json").write_text(
+        json.dumps({"winners": winners, "merges": log}, indent=2)
+    )
+    return merged, scores
+
+
 def estimate_tczyx(
     mov_tczyx: da.Array,
     ref_tczyx: da.Array,
@@ -1066,42 +1117,101 @@ def estimate_tczyx(
     # timepoints are being estimated in parallel shards. The repair pass additionally needs
     # t+1, which likewise does not exist yet.
     #
-    # REPAIR FIRST, then sweep. They address different failure modes and the cheap, effective
-    # one should go first:
-    #   repair  reseeds from t-1/t+1, so it moves a transform between basins. Measured
-    #           0.429 -> 0.941 at one real timepoint.
-    #   sweep   re-tunes matching parameters, worth +0.058 on timepoints scoring 0.72-0.78
-    #           but only +0.006 on those below 0.72.
-    # Repairing first clears the hard failures, so whatever is still flagged afterwards is
-    # the mild tail -- precisely the population the sweep is good at -- and the sweep does
-    # not spend a full grid search on timepoints reseeding would have fixed for less.
+    # The two passes are COMPETING, not staged, and both see the same post-estimation scores.
     #
-    # Flags are RECOMPUTED between the two passes, so the sweep sees the post-repair
-    # distribution rather than a stale one. Each pass accepts a result only if it strictly
-    # beats the incumbent, so neither can make the run worse.
-    if beads_match_settings.repair_pass_settings.mode == "on_flagged":
-        transforms, scores = repair_flagged_timepoints(
+    # They were sequential -- repair, re-flag, then sweep on what survived -- on the reasoning
+    # that repair should clear the hard failures so the sweep only faced the mild tail. That
+    # reasoning cost real quality, for two compounding reasons:
+    #
+    #   1. A successful repair lifts a timepoint above the adaptive line, so re-flagging
+    #      removes it and the sweep never gets a turn. Measured at 09_17 t=96: repair reached
+    #      0.773 and the sweep, run from the same estimation, reached 0.864. Sequentially the
+    #      sweep never ran there and the 0.091 was simply lost.
+    #   2. Where the sweep did still run, it had to beat repair's improved score rather than
+    #      the original, so fewer of its results were accepted.
+    #
+    # Measured head-to-head over 72 timepoints where both acted, each from the same starting
+    # transform: repair won 37, the SWEEP won 13, 22 tied. Taking the better of the two
+    # recovered 4.309 score points against 3.654 for repair alone -- 18% more. The two are
+    # complementary, so whichever wins per timepoint should win.
+    #
+    # Running both costs more than staging them. That is the trade being made deliberately:
+    # the extra compute buys the 13 timepoints where re-tuning parameters beats reseeding, and
+    # some of those margins are large (0.455 -> 0.667 at one real timepoint).
+    #
+    # Each pass still accepts a result only if it strictly beats what it started from, and the
+    # transforms/scores handed to each are the SAME pre-fallback ones, so neither can regress
+    # and neither can hide the other.
+    repair_on = beads_match_settings.repair_pass_settings.mode == "on_flagged"
+    sweep_on = beads_match_settings.sweep_fallback_settings.mode == "on_flagged"
+    fb_mode = beads_match_settings.fallback_mode
+    parallel = fb_mode == "parallel"
+
+    if repair_on and sweep_on and parallel:
+        import copy
+
+        base_transforms = copy.deepcopy(transforms)
+        base_scores = scores.copy()
+
+        repaired, repaired_scores = repair_flagged_timepoints(
             mov_tzyx=mov_tzyx,
             ref_tzyx=ref_tzyx,
-            transforms=transforms,
-            scores=scores,
+            transforms=copy.deepcopy(base_transforms),
+            scores=base_scores.copy(),
             beads_match_settings=beads_match_settings,
             affine_transform_settings=affine_transform_settings,
             output_transforms_path=output_transforms_path,
             mode=mode,
             verbose=verbose,
         )
-    if beads_match_settings.sweep_fallback_settings.mode == "on_flagged":
-        transforms, scores = sweep_flagged_timepoints(
+        # The sweep sees the ORIGINAL scores, so it is flagged on the same population and
+        # judged against the same bar as the repair pass.
+        swept, swept_scores = sweep_flagged_timepoints(
             mov_tzyx=mov_tzyx,
             ref_tzyx=ref_tzyx,
-            transforms=transforms,
-            scores=scores,
+            transforms=copy.deepcopy(base_transforms),
+            scores=base_scores.copy(),
             beads_match_settings=beads_match_settings,
             affine_transform_settings=affine_transform_settings,
             output_transforms_path=output_transforms_path,
             verbose=verbose,
         )
+        transforms, scores = _merge_best(
+            base_transforms,
+            base_scores,
+            [("repair", repaired, repaired_scores), ("sweep", swept, swept_scores)],
+            output_transforms_path,
+        )
+    else:
+        def _run_repair(tr, sc):
+            return repair_flagged_timepoints(
+                mov_tzyx=mov_tzyx, ref_tzyx=ref_tzyx, transforms=tr, scores=sc,
+                beads_match_settings=beads_match_settings,
+                affine_transform_settings=affine_transform_settings,
+                output_transforms_path=output_transforms_path, mode=mode, verbose=verbose,
+            )
+
+        def _run_sweep(tr, sc):
+            return sweep_flagged_timepoints(
+                mov_tzyx=mov_tzyx, ref_tzyx=ref_tzyx, transforms=tr, scores=sc,
+                beads_match_settings=beads_match_settings,
+                affine_transform_settings=affine_transform_settings,
+                output_transforms_path=output_transforms_path, verbose=verbose,
+            )
+
+        # Flags are recomputed inside each pass, so whichever runs second sees the updated
+        # distribution -- which is exactly the effect that makes either ordering lose ground
+        # to "parallel". Kept because it is cheaper and reproduces the earlier benchmark arms.
+        stages = [("repair", _run_repair, repair_on), ("sweep", _run_sweep, sweep_on)]
+        if fb_mode == "sweep_then_repair":
+            stages.reverse()
+        click.echo(
+            "Fallback order: " + " -> ".join(n for n, _, on in stages if on)
+            if any(on for _, _, on in stages) else "Fallbacks: none enabled"
+        )
+        for _name, fn, on in stages:
+            if on:
+                transforms, scores = fn(transforms, scores)
 
     scores.to_csv(output_folder_path / "quality_scores.csv", index=False)
     plot_quality_scores(

--- a/biahub/registration/beads.py
+++ b/biahub/registration/beads.py
@@ -484,6 +484,25 @@ def estimate_with_propagation(
     for t in range(T):
         if mode == "stabilization" and t == 0:
             continue
+
+        # Resume: a timepoint already on disk is reloaded rather than recomputed, and its
+        # transform still propagates forward so the chain stays identical to an
+        # uninterrupted run. Without this, any interruption restarts at t=0 -- a 24 h
+        # walltime cut two 800-timepoint estimates at ~75% complete and would have
+        # discarded 23 h of finished work, even though every finished timepoint was
+        # already saved as {t}.npy.
+        existing = output_folder_path / f"{t}.npy" if output_folder_path else None
+        if existing is not None and existing.exists():
+            try:
+                last_good_transform = np.load(existing).tolist()
+                affine_transform_settings.approx_transform = last_good_transform
+                if verbose:
+                    click.echo(f"Timepoint {t} already estimated, reusing {existing.name}")
+                continue
+            except (OSError, ValueError):
+                # A truncated file from a job killed mid-write: recompute it.
+                click.echo(f"Timepoint {t} transform unreadable, recomputing")
+
         if np.sum(mov_tzyx[t]) == 0 or np.sum(ref_tzyx[t]) == 0:
             click.echo(f"Timepoint {t} has no data, skipping")
             # approx_transform stays on the last good one, so a blank frame costs only
@@ -664,7 +683,13 @@ def peaks_from_beads(
 
     if len(mov_peaks) < 2 or len(ref_peaks) < 2:
         click.echo("Not enough beads detected")
-        return
+        # Return a pair, not a bare None. The annotation promises a 2-tuple and every
+        # call site unpacks into two names, so a bare `return` raised
+        # "cannot unpack non-iterable NoneType object" and killed the whole run on the
+        # first timepoint with too few beads -- it took out a 3 h estimate at t=92 of
+        # 288. The callers already test `if mov_peaks is None`, so they were written
+        # expecting this contract; the unpacking simply crashed before those guards ran.
+        return None, None
     if mask_path is not None:
         click.echo("Filtering peaks with mask")
         with open_ome_zarr(mask_path) as mask_ds:
@@ -757,6 +782,27 @@ def matches_from_beads(
         )
 
         matches = matcher.match(mov_graph, ref_graph)
+
+    elif beads_match_settings.algorithm == "spectral":
+        spectral_match_settings = beads_match_settings.spectral_match_settings
+        # No graph features are used: spectral matching works from the raw point
+        # coordinates via pairwise distances, so the graph is just a node container and
+        # k is irrelevant here.
+        mov_graph = Graph.from_nodes(mov_peaks)
+        ref_graph = Graph.from_nodes(ref_peaks)
+
+        matcher = GraphMatcher(
+            algorithm="spectral",
+            spectral_sigma=spectral_match_settings.sigma,
+            spectral_rel_cut=spectral_match_settings.rel_cut,
+            spectral_max_iter=spectral_match_settings.max_iter,
+            verbose=verbose,
+        )
+
+        matches = matcher.match(mov_graph, ref_graph)
+
+    else:
+        raise ValueError(f"Unknown matching algorithm: {beads_match_settings.algorithm}")
 
     # Filter as part of the pipeline
     matches = matcher.filter_matches(
@@ -1019,6 +1065,15 @@ def optimize_transform(
         ref_peaks_settings=beads_match_settings.target_peaks_settings,
         verbose=debug,
     )
+    if mov_peaks_optimized is None or ref_peaks_optimized is None:
+        # The correction warped the beads out of detectability, so the composed transform
+        # cannot be scored and must not be accepted -- returning the pre-correction
+        # transform and score leaves the caller exactly where it started, which is the
+        # same outcome as a refinement that failed to improve.
+        click.echo(
+            "Composed transform left too few detectable beads; keeping the input transform."
+        )
+        return transform, quality_score_approx
 
     quality_score_optimized = overlap_score(
         mov_peaks=mov_peaks_optimized,
@@ -1143,6 +1198,45 @@ def estimate(
                 if quality_score_optimized_user == 1:
                     break
                 transform = optimized_transform_user
+
+        # Third arm: acquire the correspondence with spectral matching, then refine.
+        # Opt-in, and gated on the other arms having done badly, because it costs a full
+        # optimize_transform call and is only useful when the initial transform is wrong by
+        # more than about one bead spacing -- exactly when the position-distance cost in
+        # the Hungarian matcher starts pairing a bead with its neighbour instead of itself.
+        # Spectral matching uses only relative distances, so it is unaffected by how wrong
+        # the initial transform is.
+        #
+        # Whichever arm scores highest wins, so enabling this can never make the result
+        # worse than leaving it off.
+        best_so_far = transform_iter_dict[current_iterations]["quality_score"]
+        if (
+            beads_match_settings.try_spectral_arm
+            and current_iterations == 0
+            and best_so_far < beads_match_settings.qc_settings.score_threshold
+        ):
+            click.echo(
+                f"Score {best_so_far:.3f} below threshold "
+                f"{beads_match_settings.qc_settings.score_threshold}; trying spectral arm:"
+            )
+            spectral_settings = beads_match_settings.model_copy(deep=True)
+            spectral_settings.algorithm = "spectral"
+            optimized_transform_spec, quality_score_spec = optimize_transform(
+                transform=initial_transform,
+                mov=mov,
+                ref=ref,
+                beads_match_settings=spectral_settings,
+                affine_transform_settings=affine_transform_settings,
+                verbose=verbose,
+                debug=debug,
+            )
+            if optimized_transform_spec is not None and quality_score_spec > best_so_far:
+                click.echo(f"Spectral arm wins: {quality_score_spec:.3f}")
+                transform_iter_dict[current_iterations] = {
+                    "transform": optimized_transform_spec,
+                    "quality_score": quality_score_spec,
+                }
+                transform = optimized_transform_spec
 
         if transform is None:
             break

--- a/biahub/registration/beads.py
+++ b/biahub/registration/beads.py
@@ -841,6 +841,52 @@ def repair_flagged_timepoints(
             if best_score >= good_median:
                 break
 
+        # Polish: re-seed the cascade from the transform just accepted and refine again.
+        #
+        # Not a repeat of the candidate loop, even though it calls the same function. Every
+        # candidate above started from a COARSE seed -- the consensus geometry scores ~0.000
+        # applied on its own, and a neighbour's transform is only approximately right here.
+        # Peak detection runs in WARPED space, so what the matcher sees depends on how good
+        # the starting transform already is: seeded from an accepted 0.78 rather than from
+        # something scoring nothing, it finds correspondences it could not find before.
+        #
+        # Preferred over sending these timepoints to the parameter sweep. Repair lands about a
+        # third of its rescues in 0.72-0.80, where the sweep gains ~+0.058 for 28 trials; one
+        # polish round is a single estimate() call and changes no matching parameter. Stops as
+        # soon as a round fails to improve, so a converged timepoint costs one wasted call.
+        for round_i in range(settings.polish_rounds):
+            if best_matrix is None:
+                break
+            polish_ats = affine_transform_settings.model_copy(deep=True)
+            polish_ats.approx_transform = np.asarray(
+                best_matrix.to_list() if hasattr(best_matrix, "to_list") else best_matrix,
+                dtype=float,
+            ).tolist()
+            polish_ats.use_prev_t_transform = False
+            try:
+                polished = estimate(
+                    mov=mov_t,
+                    ref=ref_t,
+                    beads_match_settings=beads_match_settings,
+                    affine_transform_settings=polish_ats,
+                    verbose=False,
+                )
+                if polished is None:
+                    break
+                polished_score = score_transform(polished, mov_t, ref_t, beads_match_settings)
+            except Exception as e:  # noqa: BLE001
+                click.echo(
+                    f"  t={t} polish round {round_i + 1} failed: {type(e).__name__}: {e}"
+                )
+                break
+            if not (np.isfinite(polished_score) and polished_score > best_score + 1e-9):
+                break
+            click.echo(
+                f"    t={t:4d} polish {round_i + 1}: {best_score:.3f} -> {polished_score:.3f}"
+            )
+            best_matrix, best_score = polished, polished_score
+            best_name = f"{best_name}+polish{round_i + 1}"
+
         if best_matrix is not None:
             matrix = np.asarray(
                 best_matrix.to_list() if hasattr(best_matrix, "to_list") else best_matrix,

--- a/biahub/registration/beads.py
+++ b/biahub/registration/beads.py
@@ -703,6 +703,24 @@ def repair_flagged_timepoints(
         if settings.use_consensus_seed
         else None
     )
+    # Robust spread of the GOOD timepoints' translations, per axis, used to judge whether a
+    # flagged timepoint's own translation is worth keeping. MAD rather than std, since the
+    # broken translations being screened out would dominate a standard deviation.
+    translation_spread = None
+    if consensus is not None:
+        good_tr = np.asarray(
+            [
+                np.asarray(transforms[t], dtype=float)[:3, 3]
+                for t in range(min(len(transforms), len(score_col)))
+                if transforms[t] is not None
+                and np.isfinite(score_col[t])
+                and score_col[t] >= settings.consensus_score_threshold
+            ]
+        )
+        if len(good_tr) >= 5:
+            translation_spread = np.maximum(
+                1.4826 * np.median(np.abs(good_tr - np.median(good_tr, axis=0)), axis=0), 1.0
+            )
     flagged_set = set(flagged)
     good_median = float(np.nanmedian(score_col))
     log = []
@@ -725,16 +743,33 @@ def repair_flagged_timepoints(
         # when the translation is broken too.
         degenerate = False
         if consensus is not None and transforms[t] is not None:
-            L = np.asarray(transforms[t], dtype=float)[:3, :3]
+            M = np.asarray(transforms[t], dtype=float)
+            L = M[:3, :3]
             degenerate = (
                 np.linalg.det(L) <= 0
                 or np.linalg.norm(L - consensus[:3, :3]) > settings.consensus_linear_tolerance
             )
             if degenerate:
+                # Keeping the timepoint's own translation is only sensible if that translation
+                # is itself credible. On a real dataset the collapsed fits had translations
+                # thousands of voxels out -- one reached -15000 in x -- so the shift is not
+                # reliably the surviving half of a broken transform. Offer the timepoint's own
+                # translation first when it is within reach of the run's spread, and the full
+                # consensus first when it is not.
+                own_translation_ok = translation_spread is not None and bool(
+                    np.all(
+                        np.abs(M[:3, 3] - consensus[:3, 3])
+                        <= settings.consensus_translation_tolerance * translation_spread
+                    )
+                )
                 keep_translation = consensus.copy()
-                keep_translation[:3, 3] = np.asarray(transforms[t], dtype=float)[:3, 3]
-                candidates.append(("consensus_linear", keep_translation))
-                candidates.append(("consensus_full", consensus.copy()))
+                keep_translation[:3, 3] = M[:3, 3]
+                if own_translation_ok:
+                    candidates.append(("consensus_linear", keep_translation))
+                    candidates.append(("consensus_full", consensus.copy()))
+                else:
+                    candidates.append(("consensus_full", consensus.copy()))
+                    candidates.append(("consensus_linear", keep_translation))
 
         for name, idx in (("t-1", t - 1), ("t+1", t + 1)):
             if 0 <= idx < n_t and idx not in flagged_set and transforms[idx] is not None:

--- a/biahub/registration/beads.py
+++ b/biahub/registration/beads.py
@@ -593,7 +593,12 @@ def repair_flagged_timepoints(
                 best_matrix.to_list() if hasattr(best_matrix, "to_list") else best_matrix,
                 dtype=float,
             )
-            transforms[t] = matrix
+            # .tolist() to match what load_transforms puts in this list. Leaving a raw
+            # ndarray here serialises into registration_settings.yml as a
+            # !!python/object/apply:numpy._core.multiarray._reconstruct blob, which then
+            # fails to load -- so the repaired timepoints were the only ones that broke
+            # the downstream stabilize step.
+            transforms[t] = matrix.tolist()
             np.save(output_transforms_path / f"{t}.npy", matrix)
             score_col[t] = best_score
             scores.loc[scores["t"] == t, "quality_score"] = best_score
@@ -707,7 +712,10 @@ def estimate_tczyx(
             ref_voxel_size=ref_voxel_size,
             mov_voxel_size=mov_voxel_size,
         )
-        click.echo("Computed approx transform: ", approx_transform)
+        # f-string, not a second positional: click.echo's second parameter is `file`, so
+        # the original passed the Transform as the output stream and died on .write().
+        # This path had evidently never been exercised.
+        click.echo(f"Computed approx transform:\n{approx_transform}")
         affine_transform_settings.approx_transform = approx_transform.to_list()
 
     if affine_transform_settings.use_prev_t_transform:

--- a/biahub/registration/beads.py
+++ b/biahub/registration/beads.py
@@ -854,6 +854,7 @@ def repair_flagged_timepoints(
         # third of its rescues in 0.72-0.80, where the sweep gains ~+0.058 for 28 trials; one
         # polish round is a single estimate() call and changes no matching parameter. Stops as
         # soon as a round fails to improve, so a converged timepoint costs one wasted call.
+        score_after_reseed = best_score
         for round_i in range(settings.polish_rounds):
             if best_matrix is None:
                 break
@@ -911,7 +912,12 @@ def repair_flagged_timepoints(
             {
                 "t": t,
                 "before": float(before),
+                # Split so each step can be attributed on its own: reseeding and polishing
+                # are separate decisions with separate costs, and folding them into one
+                # before/after makes it impossible to tell which one earned the gain.
+                "after_reseed": float(score_after_reseed),
                 "after": float(best_score),
+                "polish_gain": float(best_score - score_after_reseed),
                 "source": best_name,
                 "candidates_tried": [n for n, _ in candidates],
             }

--- a/biahub/registration/beads.py
+++ b/biahub/registration/beads.py
@@ -52,6 +52,7 @@ from biahub.cli.utils import (
 )
 from biahub.core.graph_matching import Graph, GraphMatcher
 from biahub.core.transform import Transform
+from biahub.registration.qc import write_qc_report
 from biahub.registration.utils import (
     get_aprox_transform,
     load_quality_scores,
@@ -418,6 +419,18 @@ def estimate_tczyx(
         output_folder_path / "translation_plots" / "beads_quality_score.png",
         score_threshold=beads_match_settings.qc_settings.score_threshold,
     )
+    # Full QC report: adaptive flagging, transform plausibility, smoothness. Reports
+    # only -- nothing is modified, because interpolating weak timepoints was measured to
+    # make them worse.
+    try:
+        write_qc_report(
+            output_dir=output_folder_path,
+            scores=scores["quality_score"].to_numpy(),
+            transforms=[t for t in transforms if t is not None],
+        )
+    except Exception as e:  # noqa: BLE001
+        click.echo(f"QC report skipped: {type(e).__name__}: {e}")
+
     scored = scores.dropna(subset=["quality_score"])
     if len(scored):
         n_low = int(

--- a/biahub/registration/beads.py
+++ b/biahub/registration/beads.py
@@ -1210,15 +1210,16 @@ def estimate(
         # Whichever arm scores highest wins, so enabling this can never make the result
         # worse than leaving it off.
         best_so_far = transform_iter_dict[current_iterations]["quality_score"]
-        if (
-            beads_match_settings.try_spectral_arm
-            and current_iterations == 0
-            and best_so_far < beads_match_settings.qc_settings.score_threshold
-        ):
-            click.echo(
-                f"Score {best_so_far:.3f} below threshold "
-                f"{beads_match_settings.qc_settings.score_threshold}; trying spectral arm:"
+        spectral_mode = beads_match_settings.spectral_arm
+        run_spectral = current_iterations == 0 and (
+            spectral_mode == "always"
+            or (
+                spectral_mode == "on_low_score"
+                and best_so_far < beads_match_settings.qc_settings.score_threshold
             )
+        )
+        if run_spectral:
+            click.echo(f"Spectral arm ({spectral_mode}), current best {best_so_far:.3f}:")
             # Stage 1 -- ACQUIRE with spectral matching. This does not need the initial
             # transform to be close, because only relative distances are used.
             spectral_settings = beads_match_settings.model_copy(deep=True)

--- a/biahub/registration/beads.py
+++ b/biahub/registration/beads.py
@@ -52,7 +52,13 @@ from biahub.cli.utils import (
 )
 from biahub.core.graph_matching import Graph, GraphMatcher
 from biahub.core.transform import Transform
-from biahub.registration.utils import get_aprox_transform, load_transforms
+from biahub.registration.utils import (
+    get_aprox_transform,
+    load_quality_scores,
+    load_transforms,
+    plot_quality_scores,
+    save_quality_score,
+)
 from biahub.settings import AffineTransformSettings, BeadsMatchSettings, DetectPeaksSettings
 
 
@@ -400,6 +406,29 @@ def estimate_tczyx(
         )
 
     transforms = load_transforms(output_transforms_path, mov_tzyx.shape[0], verbose)
+
+    # Surface the per-timepoint quality score. It was previously only echoed as the run
+    # went, so there was no way to see where a run degraded without grepping the log --
+    # and no way at all for the independent arm, whose timepoints each log to their own
+    # submitit file.
+    scores = load_quality_scores(output_transforms_path, mov_tzyx.shape[0])
+    scores.to_csv(output_folder_path / "quality_scores.csv", index=False)
+    plot_quality_scores(
+        scores,
+        output_folder_path / "translation_plots" / "beads_quality_score.png",
+        score_threshold=beads_match_settings.qc_settings.score_threshold,
+    )
+    scored = scores.dropna(subset=["quality_score"])
+    if len(scored):
+        n_low = int(
+            (scored["quality_score"] < beads_match_settings.qc_settings.score_threshold).sum()
+        )
+        click.echo(
+            f"Quality score: median {scored['quality_score'].median():.3f}, "
+            f"{n_low} of {len(scored)} timepoints below "
+            f"{beads_match_settings.qc_settings.score_threshold}, "
+            f"{int(scores['fell_back_to_seed'].sum())} fell back to the seed"
+        )
 
     return transforms
 
@@ -1123,7 +1152,13 @@ def estimate(
     best_quality_score = max(transform_iter_dict.values(), key=lambda x: x["quality_score"])
     best_transform = best_quality_score["transform"]
 
-    if best_transform is None:
+    # Every optimisation attempt failed, so the coarse initial transform is all we have.
+    # Recorded explicitly: the saved .npy is otherwise indistinguishable from a real fit,
+    # and such a transform can still pass validate_transforms, which only checks
+    # consistency against neighbouring timepoints -- and a propagated seed is perfectly
+    # self-consistent.
+    fell_back_to_seed = best_transform is None
+    if fell_back_to_seed:
         best_transform = initial_transform
     if verbose:
         click.echo(f"Best transform: {best_transform}")
@@ -1131,5 +1166,14 @@ def estimate(
     if output_filepath:
         click.echo(f"Saving transform to {output_filepath}")
         np.save(output_filepath, best_transform.to_list())
+        # Persist the score as a sidecar rather than returning it, so that estimate()
+        # keeps the same signature across every registration method. Written to disk
+        # because the independent arm runs each timepoint in its own submitit process,
+        # so an in-memory accumulator would not survive.
+        save_quality_score(
+            Path(output_filepath).with_suffix(".score"),
+            score=best_quality_score["quality_score"],
+            fell_back_to_seed=fell_back_to_seed,
+        )
 
     return best_transform

--- a/biahub/registration/qc.py
+++ b/biahub/registration/qc.py
@@ -173,11 +173,37 @@ def write_qc_report(
         summary.update(extra)
 
     (output_dir / "qc_summary.json").write_text(json.dumps(summary, indent=2))
+    # Same content as the json, as a one-row csv, so a run can be pulled straight into a
+    # spreadsheet or concatenated across datasets without parsing nested json.
+    write_summary_csv(summary, output_dir / "qc_summary.csv")
+
     click.echo(
         f"QC: median={summary['median_score']:.3f} MAD={summary['mad']:.3f} "
         f"adaptive line={summary['adaptive_line']:.3f}\n"
         f"    {summary['n_flagged']} of {summary['n_timepoints']} timepoints flagged"
         + (f" -> {summary['flagged_timepoints']}" if summary["n_flagged"] else "")
-        + f"\n    wrote qc_flags.csv and qc_summary.json in {output_dir}"
+        + f"\n    wrote qc_flags.csv, qc_summary.json and qc_summary.csv in {output_dir}"
     )
     return qc
+
+
+def write_summary_csv(summary: dict, path: Path) -> pd.DataFrame:
+    """Write the QC summary dict as a one-row csv.
+
+    Nested values are flattened with an underscore (`smoothness_max_abs_dz`) and list values
+    are joined with semicolons rather than commas -- a comma-joined list of flagged
+    timepoints inside a csv field is a reliable way to produce a file that reads back with
+    the wrong number of columns in anything that does not honour quoting.
+    """
+    flat: dict = {}
+    for key, value in summary.items():
+        if isinstance(value, dict):
+            for sub, sub_value in value.items():
+                flat[f"{key}_{sub}"] = sub_value
+        elif isinstance(value, (list, tuple)):
+            flat[key] = ";".join(str(v) for v in value)
+        else:
+            flat[key] = value
+    df = pd.DataFrame([flat])
+    df.to_csv(path, index=False)
+    return df

--- a/biahub/registration/qc.py
+++ b/biahub/registration/qc.py
@@ -18,9 +18,16 @@ accuracy figure.
 **transform plausibility** -- shear and scale anisotropy from the decomposed linear part.
 Needs no image data, and catches geometrically impossible transforms: failed timepoints in
 an older run showed 57 degrees of shear and 3.8 anisotropy against normal values of ~6
-degrees and ~1.29. The expected values are instrument properties, not identity -- an
-oblique light-sheet plus deskew produces real z-y shear, and differing voxel sizes between
-the arms produce real anisotropy.
+degrees and ~1.29.
+
+The expected values are properties of the mantis microscope, not of identity. Mantis
+acquires fluorescence on an oblique light-sheet arm and the data is deskewed, so x is
+unaffected by the oblique geometry while z and y are coupled by the deskew -- which is why
+real z-y shear appears (~6 deg on zebrafish, ~10 deg on A549 cells) while y-x stays clean.
+Anisotropy of ~1.29 comes from the voxel-size ratio between the two arms: the label-free
+reference is 0.174/0.1494/0.1494 um and the light-sheet source 0.174/0.116/0.116, so xy
+must scale by 0.1494/0.116 = 1.288 while z scales by 1.0. On a different optical
+configuration these expected values would need re-deriving.
 
 **temporal smoothness** -- largest step in translation between consecutive timepoints.
 Independent per-timepoint estimation can be more accurate per frame yet produce a jittery

--- a/biahub/registration/qc.py
+++ b/biahub/registration/qc.py
@@ -1,0 +1,213 @@
+"""Quality control for beads-registration transforms.
+
+Four measures, because no single one is sufficient and each catches something the others
+miss:
+
+**overlap score** -- fraction of reference beads with a moving bead within a radius. This
+is what the estimator optimises, but it is *piecewise-constant*: measured on real data it
+does not move at all across a +/-5 voxel misregistration and only then falls off a cliff.
+A good pass/fail signal and a poor ranking signal.
+
+**mean matched residual** -- mean distance from each warped bead to its nearest reference
+bead. Continuous and monotone over exactly the range where overlap is blind (2.66 -> 10.95
+voxels over a 0 -> 14 voxel perturbation), so this is what separates two transforms that
+tie on score. Biased low in absolute terms when the reference cloud is much denser than the
+moving one, so use it to compare transforms at the same timepoint, not as an absolute
+accuracy figure.
+
+**transform plausibility** -- shear and scale anisotropy from the decomposed linear part.
+Needs no image data, and catches geometrically impossible transforms: failed timepoints in
+an older run showed 57 degrees of shear and 3.8 anisotropy against normal values of ~6
+degrees and ~1.29. The expected values are instrument properties, not identity -- an
+oblique light-sheet plus deskew produces real z-y shear, and differing voxel sizes between
+the arms produce real anisotropy.
+
+**temporal smoothness** -- largest step in translation between consecutive timepoints.
+Independent per-timepoint estimation can be more accurate per frame yet produce a jittery
+series, which shows up as visible jitter in the applied movie.
+
+Flagging is adaptive: median - k*MAD of the run's own scores, with an absolute floor. MAD
+rather than standard deviation because std is inflated by the very outliers being hunted --
+on a run with 8 near-zero scores, mean-2*std put the line at 0.48 and masked them, while
+median-2*MAD was unmoved. The floor prevents a uniformly good run from having timepoints
+flagged merely for sitting below its own median.
+
+Flagged timepoints are reported, never modified. Interpolating them was measured to make
+results worse: a transform scoring 0.43 was replaced by one scoring 0.00.
+"""
+
+import json
+
+from pathlib import Path
+
+import click
+import numpy as np
+import pandas as pd
+
+from numpy.typing import ArrayLike
+from scipy.spatial import cKDTree
+
+# Absolute floor below which a timepoint is unusable rather than merely unusual.
+HARD_FAIL_SCORE = 0.40
+# Timepoints must be below BOTH the adaptive line and this floor to be flagged, so a
+# healthy run is not flagged for internal spread alone.
+FLAG_FLOOR_SCORE = 0.70
+FLAG_K_MAD = 2.0
+
+
+def matched_residual(mov_peaks: ArrayLike, ref_peaks: ArrayLike) -> dict:
+    """Mean and p95 distance from each moving bead to its nearest reference bead."""
+    if mov_peaks is None or ref_peaks is None or len(mov_peaks) == 0 or len(ref_peaks) == 0:
+        return {"resid_mean": np.nan, "resid_p95": np.nan}
+    d, _ = cKDTree(np.asarray(ref_peaks)).query(np.asarray(mov_peaks), k=1)
+    return {"resid_mean": float(d.mean()), "resid_p95": float(np.percentile(d, 95))}
+
+
+def decompose_transform(matrix: ArrayLike) -> dict:
+    """Shear and scale of the linear part, for plausibility checks.
+
+    Shear is reported per axis pair as the deviation of the transformed basis vectors from
+    orthogonal. On mantis data the y-x pair is clean (~0.5 deg) and serves as a noise
+    floor, while z-y carries real shear (~6 deg zebrafish, ~10 deg cells).
+    """
+    linear = np.asarray(matrix, dtype=float)[:3, :3]
+
+    def angle(u, v):
+        c = float(u @ v) / (np.linalg.norm(u) * np.linalg.norm(v) + 1e-12)
+        return abs(float(np.degrees(np.arccos(np.clip(c, -1, 1)))) - 90.0)
+
+    sv = np.linalg.svd(linear, compute_uv=False)
+    return {
+        "shear_zy_deg": angle(linear[:, 0], linear[:, 1]),
+        "shear_zx_deg": angle(linear[:, 0], linear[:, 2]),
+        "shear_yx_deg": angle(linear[:, 1], linear[:, 2]),
+        "scale_max": float(sv.max()),
+        "scale_min": float(sv.min()),
+        "scale_anisotropy": float(sv.max() / max(sv.min(), 1e-12)),
+    }
+
+
+def translation_smoothness(transforms: list[ArrayLike]) -> dict:
+    """Largest and mean step in translation between consecutive timepoints."""
+    tr = np.asarray([np.asarray(m, dtype=float)[:3, 3] for m in transforms])
+    if len(tr) < 2:
+        return {}
+    d = np.abs(np.diff(tr, axis=0))
+    return {
+        f"{stat}_abs_d{axis}": float(fn(d[:, i]))
+        for i, axis in enumerate("zyx")
+        for stat, fn in (("max", np.max), ("mean", np.mean))
+    }
+
+
+def flag_timepoints(
+    scores: ArrayLike,
+    k_mad: float = FLAG_K_MAD,
+    floor: float = FLAG_FLOOR_SCORE,
+    hard_fail: float = HARD_FAIL_SCORE,
+) -> pd.DataFrame:
+    """Adaptive per-run flagging. One row per timepoint, with reasons.
+
+    Flagged when below the run's own median - k*MAD AND below the absolute floor, or below
+    hard_fail, or missing a score entirely.
+    """
+    s = np.asarray(scores, dtype=float)
+    finite = s[np.isfinite(s)]
+    if not len(finite):
+        raise ValueError("no finite scores to flag against")
+    median = float(np.median(finite))
+    mad = float(1.4826 * np.median(np.abs(finite - median)))
+    line = median - k_mad * mad
+
+    rows = []
+    for t, score in enumerate(s):
+        reasons = []
+        if not np.isfinite(score):
+            reasons.append("no_score")
+        else:
+            if score < line and score < floor:
+                reasons.append("below_adaptive_line")
+            if score < hard_fail:
+                reasons.append("below_hard_fail")
+        rows.append(
+            {
+                "t": t,
+                "quality_score": score,
+                "flagged": bool(reasons),
+                "reasons": ";".join(reasons),
+            }
+        )
+    out = pd.DataFrame(rows)
+    out.attrs.update(
+        {
+            "median": median,
+            "mad": mad,
+            "adaptive_line": line,
+            "floor": floor,
+            "hard_fail": hard_fail,
+        }
+    )
+    return out
+
+
+def write_qc_report(
+    output_dir: Path,
+    scores: ArrayLike,
+    transforms: list[ArrayLike] | None = None,
+    residuals: dict[int, dict] | None = None,
+    extra: dict | None = None,
+) -> pd.DataFrame:
+    """Write qc_flags.csv and qc_summary.json alongside a registration run.
+
+    Reports only -- no transform is altered here.
+    """
+    output_dir = Path(output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    qc = flag_timepoints(scores)
+    # pd.concat does not carry .attrs through, so keep the flagging stats before adding
+    # any columns.
+    stats = dict(qc.attrs)
+
+    if transforms is not None:
+        decomp = pd.DataFrame([decompose_transform(m) for m in transforms[: len(qc)]])
+        qc = pd.concat([qc, decomp], axis=1)
+        qc.attrs.update(stats)
+    if residuals:
+        for col in ("resid_mean", "resid_p95"):
+            qc[col] = [residuals.get(t, {}).get(col, np.nan) for t in qc["t"]]
+
+    qc.to_csv(output_dir / "qc_flags.csv", index=False)
+
+    summary = {
+        "n_timepoints": int(len(qc)),
+        "median_score": stats["median"],
+        "mad": stats["mad"],
+        "adaptive_line": stats["adaptive_line"],
+        "floor": stats["floor"],
+        "hard_fail": stats["hard_fail"],
+        "n_flagged": int(qc["flagged"].sum()),
+        "flagged_timepoints": [int(t) for t in qc.loc[qc["flagged"], "t"]],
+        "note": (
+            "Flagged timepoints are reported, not modified. Interpolating them was "
+            "measured to make results worse (0.43 -> 0.00 at one real timepoint)."
+        ),
+    }
+    if transforms is not None:
+        summary["smoothness"] = translation_smoothness(transforms)
+    if "resid_mean" in qc:
+        r = qc["resid_mean"].dropna()
+        if len(r):
+            summary["residual_median"] = float(r.median())
+            summary["residual_max"] = float(r.max())
+    if extra:
+        summary.update(extra)
+
+    (output_dir / "qc_summary.json").write_text(json.dumps(summary, indent=2))
+    click.echo(
+        f"QC: median={summary['median_score']:.3f} MAD={summary['mad']:.3f} "
+        f"adaptive line={summary['adaptive_line']:.3f}\n"
+        f"    {summary['n_flagged']} of {summary['n_timepoints']} timepoints flagged"
+        + (f" -> {summary['flagged_timepoints']}" if summary["n_flagged"] else "")
+        + f"\n    wrote qc_flags.csv and qc_summary.json in {output_dir}"
+    )
+    return qc

--- a/biahub/registration/qc.py
+++ b/biahub/registration/qc.py
@@ -1,7 +1,7 @@
 """Quality control for beads-registration transforms.
 
-Four measures, because no single one is sufficient and each catches something the others
-miss:
+Three measures, because no single one is sufficient and each catches something the
+others miss:
 
 **overlap score** -- fraction of reference beads with a moving bead within a radius. This
 is what the estimator optimises, but it is *piecewise-constant*: measured on real data it
@@ -14,20 +14,6 @@ voxels over a 0 -> 14 voxel perturbation), so this is what separates two transfo
 tie on score. Biased low in absolute terms when the reference cloud is much denser than the
 moving one, so use it to compare transforms at the same timepoint, not as an absolute
 accuracy figure.
-
-**transform plausibility** -- shear and scale anisotropy from the decomposed linear part.
-Needs no image data, and catches geometrically impossible transforms: failed timepoints in
-an older run showed 57 degrees of shear and 3.8 anisotropy against normal values of ~6
-degrees and ~1.29.
-
-The expected values are properties of the mantis microscope, not of identity. Mantis
-acquires fluorescence on an oblique light-sheet arm and the data is deskewed, so x is
-unaffected by the oblique geometry while z and y are coupled by the deskew -- which is why
-real z-y shear appears (~6 deg on zebrafish, ~10 deg on A549 cells) while y-x stays clean.
-Anisotropy of ~1.29 comes from the voxel-size ratio between the two arms: the label-free
-reference is 0.174/0.1494/0.1494 um and the light-sheet source 0.174/0.116/0.116, so xy
-must scale by 0.1494/0.116 = 1.288 while z scales by 1.0. On a different optical
-configuration these expected values would need re-deriving.
 
 **temporal smoothness** -- largest step in translation between consecutive timepoints.
 Independent per-timepoint estimation can be more accurate per frame yet produce a jittery
@@ -68,30 +54,6 @@ def matched_residual(mov_peaks: ArrayLike, ref_peaks: ArrayLike) -> dict:
         return {"resid_mean": np.nan, "resid_p95": np.nan}
     d, _ = cKDTree(np.asarray(ref_peaks)).query(np.asarray(mov_peaks), k=1)
     return {"resid_mean": float(d.mean()), "resid_p95": float(np.percentile(d, 95))}
-
-
-def decompose_transform(matrix: ArrayLike) -> dict:
-    """Shear and scale of the linear part, for plausibility checks.
-
-    Shear is reported per axis pair as the deviation of the transformed basis vectors from
-    orthogonal. On mantis data the y-x pair is clean (~0.5 deg) and serves as a noise
-    floor, while z-y carries real shear (~6 deg zebrafish, ~10 deg cells).
-    """
-    linear = np.asarray(matrix, dtype=float)[:3, :3]
-
-    def angle(u, v):
-        c = float(u @ v) / (np.linalg.norm(u) * np.linalg.norm(v) + 1e-12)
-        return abs(float(np.degrees(np.arccos(np.clip(c, -1, 1)))) - 90.0)
-
-    sv = np.linalg.svd(linear, compute_uv=False)
-    return {
-        "shear_zy_deg": angle(linear[:, 0], linear[:, 1]),
-        "shear_zx_deg": angle(linear[:, 0], linear[:, 2]),
-        "shear_yx_deg": angle(linear[:, 1], linear[:, 2]),
-        "scale_max": float(sv.max()),
-        "scale_min": float(sv.min()),
-        "scale_anisotropy": float(sv.max() / max(sv.min(), 1e-12)),
-    }
 
 
 def translation_smoothness(transforms: list[ArrayLike]) -> dict:
@@ -171,14 +133,8 @@ def write_qc_report(
     output_dir = Path(output_dir)
     output_dir.mkdir(parents=True, exist_ok=True)
     qc = flag_timepoints(scores)
-    # pd.concat does not carry .attrs through, so keep the flagging stats before adding
-    # any columns.
     stats = dict(qc.attrs)
 
-    if transforms is not None:
-        decomp = pd.DataFrame([decompose_transform(m) for m in transforms[: len(qc)]])
-        qc = pd.concat([qc, decomp], axis=1)
-        qc.attrs.update(stats)
     if residuals:
         for col in ("resid_mean", "resid_p95"):
             qc[col] = [residuals.get(t, {}).get(col, np.nan) for t in qc["t"]]

--- a/biahub/registration/qc.py
+++ b/biahub/registration/qc.py
@@ -44,7 +44,14 @@ from scipy.spatial import cKDTree
 HARD_FAIL_SCORE = 0.40
 # Timepoints must be below BOTH the adaptive line and this floor to be flagged, so a
 # healthy run is not flagged for internal spread alone.
-FLAG_FLOOR_SCORE = 0.70
+#
+# 0.80, not the 0.70 first chosen: at 0.70 the floor swallowed the adaptive line entirely on
+# real data and the report became useless. Measured on two runs whose medians were 0.870 and
+# 0.875, adaptive lines 0.741 and 0.774 -- at a 0.70 floor those runs flagged 0 and 2
+# timepoints, while 5 and 5 sat in a clear tail below 0.75 and were independently confirmed
+# weak by a parameter sweep that improved them. The floor should only veto flagging on a run
+# with no meaningful spread, so it has to sit above where real tails fall.
+FLAG_FLOOR_SCORE = 0.80
 FLAG_K_MAD = 2.0
 
 

--- a/biahub/registration/utils.py
+++ b/biahub/registration/utils.py
@@ -14,6 +14,7 @@ Key conventions
 - Transforms are 4x4 homogeneous matrices.
 """
 
+import json
 import os
 
 from pathlib import Path
@@ -23,6 +24,7 @@ import ants
 import click
 import largestinteriorrectangle as lir
 import numpy as np
+import pandas as pd
 import scipy
 
 from matplotlib import pyplot as plt
@@ -462,6 +464,142 @@ def plot_translations(
     axs[1].set_title("X-Translation")
     axs[2].plot(y_transforms)
     axs[2].set_title("Y-Translation")
+    plt.savefig(output_filepath, dpi=300, bbox_inches="tight")
+    plt.close()
+
+
+def save_quality_score(
+    output_filepath: Path,
+    score: float,
+    fell_back_to_seed: bool = False,
+) -> None:
+    """
+    Save a single timepoint's registration quality score next to its transform.
+
+    Written as a sidecar rather than returned, so that ``estimate()`` keeps an identical
+    signature across registration methods, and because the independent estimation arm
+    runs each timepoint in its own process.
+
+    Parameters
+    ----------
+    output_filepath : Path
+        Destination, conventionally ``<transforms_dir>/{t}.score``.
+    score : float
+        Overlap score of the accepted transform, in [0, 1]. May be -1 or NaN when every
+        optimisation attempt failed.
+    fell_back_to_seed : bool
+        True when no optimisation succeeded and the coarse initial transform was saved
+        instead. Such a transform is indistinguishable from a real fit on disk, so this
+        flag is the only record that it is not one.
+    """
+    output_filepath.parent.mkdir(parents=True, exist_ok=True)
+    payload = {"quality_score": float(score), "fell_back_to_seed": bool(fell_back_to_seed)}
+    output_filepath.write_text(json.dumps(payload))
+
+
+def load_quality_scores(transforms_path: Path, T: int) -> "pd.DataFrame":
+    """
+    Load per-timepoint quality scores written by ``save_quality_score``.
+
+    Mirrors :func:`load_transforms`: timepoints with no sidecar come back as NaN rather
+    than being dropped, so the result always has one row per timepoint and gaps stay
+    visible in the plot.
+
+    Parameters
+    ----------
+    transforms_path : Path
+        Directory holding ``{t}.score`` files.
+    T : int
+        Number of timepoints.
+
+    Returns
+    -------
+    pd.DataFrame
+        Columns ``t``, ``quality_score``, ``fell_back_to_seed``, ``estimated``.
+    """
+    rows = []
+    for t in range(T):
+        path = transforms_path / f"{t}.score"
+        score, fell_back, estimated = np.nan, False, False
+        if path.exists():
+            try:
+                payload = json.loads(path.read_text())
+                score = float(payload.get("quality_score", np.nan))
+                fell_back = bool(payload.get("fell_back_to_seed", False))
+                estimated = True
+            except (ValueError, OSError):
+                pass
+        rows.append(
+            {
+                "t": t,
+                "quality_score": score,
+                "fell_back_to_seed": fell_back,
+                "estimated": estimated,
+            }
+        )
+    return pd.DataFrame(rows)
+
+
+def plot_quality_scores(
+    scores: "pd.DataFrame",
+    output_filepath: Path,
+    score_threshold: float = 0.40,
+) -> None:
+    """
+    Plot the registration quality score over time.
+
+    The score was previously only echoed per timepoint, which made it impossible to see
+    where a run degraded without grepping the log. Timepoints that fell back to the seed
+    are marked, because those are the ones whose transform is not a real fit.
+
+    Parameters
+    ----------
+    scores : pd.DataFrame
+        As returned by :func:`load_quality_scores`.
+    output_filepath : Path
+        Destination png.
+    score_threshold : float
+        Drawn as a reference line; scores below it are counted in the title.
+
+    Notes
+    -----
+    The plot is saved as a png file.
+    """
+    output_filepath.parent.mkdir(parents=True, exist_ok=True)
+    scored = scores.dropna(subset=["quality_score"])
+
+    _, ax = plt.subplots(figsize=(12, 4))
+    ax.plot(scores["t"], scores["quality_score"], marker=".", ms=4, lw=1, color="tab:blue")
+    ax.axhline(
+        score_threshold, color="tab:red", ls="--", lw=1, label=f"threshold {score_threshold}"
+    )
+
+    fell_back = scores[scores["fell_back_to_seed"]]
+    if len(fell_back):
+        ax.scatter(
+            fell_back["t"],
+            fell_back["quality_score"].fillna(0.0),
+            marker="x",
+            s=45,
+            color="tab:red",
+            zorder=3,
+            label=f"fell back to seed ({len(fell_back)})",
+        )
+    missing = scores[~scores["estimated"]]
+    for t in missing["t"]:
+        ax.axvspan(t - 0.5, t + 0.5, color="orange", alpha=0.2, lw=0)
+
+    n_below = int((scored["quality_score"] < score_threshold).sum())
+    median = scored["quality_score"].median() if len(scored) else float("nan")
+    ax.set_title(
+        f"Registration quality score over time — median {median:.3f}, "
+        f"{n_below} below {score_threshold}, {len(missing)} not estimated"
+    )
+    ax.set_xlabel("timepoint")
+    ax.set_ylabel("overlap score")
+    ax.set_ylim(-0.03, 1.03)
+    ax.grid(alpha=0.3)
+    ax.legend(fontsize=8)
     plt.savefig(output_filepath, dpi=300, bbox_inches="tight")
     plt.close()
 

--- a/biahub/settings.py
+++ b/biahub/settings.py
@@ -258,7 +258,46 @@ class AffineTransformSettings(MyBaseModel):
 
 
 class AntsRegistrationSettings(MyBaseModel):
+    """Settings for the ANTs registration backend.
+
+    Field names and defaults mirror the keyword arguments of
+    ``biahub.registration.ants.preprocess_czyx``, which is what consumes them.
+
+    Attributes
+    ----------
+    sobel_filter : bool
+        Apply a Sobel filter (3D gradient magnitude) to both volumes before
+        registering, so ANTs matches structural edges rather than raw
+        intensity. Needed for cross-modality pairs such as fluorescence
+        against a virtual-staining prediction.
+    crop : bool
+        Crop both volumes to their overlapping region with the LIR algorithm
+        before registering.
+    ref_mask_radius : float | None
+        Radius of a circular mask applied to the reference channel, as a
+        fraction of image width in ``(0, 1]``. ``None`` applies no mask.
+    clip : bool
+        Clip both volumes to hardcoded intensity limits. Those limits assume a
+        **phase** reference (``np.clip(ref, 0, 0.5)``); leave this off for any
+        other reference, e.g. a virtual-staining prediction whose values range
+        well above 0.5.
+    """
+
     sobel_filter: bool = False
+    crop: bool = False
+    ref_mask_radius: float | None = None
+    clip: bool = False
+
+    @field_validator("ref_mask_radius")
+    @classmethod
+    def check_ref_mask_radius(cls, v):
+        # preprocess_czyx raises on this too, but only after the data is
+        # loaded -- catching it at config-parse time is much cheaper.
+        if v is not None and not (0 < v <= 1):
+            raise ValueError(
+                "ref_mask_radius must be given as a fraction of image width, i.e. (0, 1]."
+            )
+        return v
 
 
 class ManualRegistrationSettings(MyBaseModel):

--- a/biahub/settings.py
+++ b/biahub/settings.py
@@ -209,6 +209,53 @@ class QCBeadsRegistrationSettings(MyBaseModel):
     score_centroid_mask_radius: int = 6
 
 
+class SweepFallbackSettings(MyBaseModel):
+    """Last-resort per-timepoint grid search over the matching parameters.
+
+    The other arms all reuse one parameter set for the whole timelapse. That set is chosen
+    to be good on average, and a handful of timepoints are simply not well served by it.
+    This re-tunes those timepoints individually.
+
+    Off by default because it is the most expensive thing in the estimator: one ANTs warp
+    plus peak re-detection per surviving trial, roughly 18 s each. Gating it on score is
+    what makes it affordable -- it fires on the few percent of timepoints that need it.
+
+    Measured on 15 flagged timepoints across two datasets: 5 improved, mean gain +0.030
+    taking max(incumbent, sweep). Modest, and it cannot regress -- estimate() keeps the
+    sweep result only if it strictly beats the incumbent -- so the honest description is a
+    small rescue for a real cost, worth enabling when a few bad timepoints matter more than
+    runtime.
+
+    Attributes
+    ----------
+    mode : Literal["off", "on_low_score"]
+        "on_low_score" runs the sweep when every other arm came in below score_threshold.
+    score_threshold : float
+        The gate, and the whole cost/benefit dial. Calibrated against the measured score
+        distribution of two real runs (144 and 240 timepoints, medians 0.870 and 0.875):
+
+            gate    fires on
+            0.70    0 of 144, 2 of 240     -- dead code
+            0.75    5 of 144, 5 of 240     <- default: the tail, ~2-4%
+            0.80    26 of 144, 29 of 240   -- ~15%, hours of extra compute
+
+        0.75 is where the tail actually is; the timepoints the sweep was measured to rescue
+        scored 0.60-0.78. Note this is far above qc_settings.score_threshold (0.40), which
+        marks an unusable transform rather than a merely weak one -- gating on 0.40 would
+        never fire on a healthy run.
+    grid : dict[str, list] | list[dict[str, list]] | None
+        Parameter grid; None uses DEFAULT_SWEEP_GRID in biahub.registration.beads. A list of
+        dicts is searched as the union of their cross products, which is how the hungarian
+        and spectral parameter sets are swept without paying for their cross product -- each
+        is inert while the other matcher is in use. Keys are validated against that module's
+        setter table, so a misspelled key raises instead of silently reading as a flat axis.
+    """
+
+    mode: Literal["off", "on_low_score"] = "off"
+    score_threshold: float = 0.75
+    grid: dict[str, list] | list[dict[str, list]] | None = None
+
+
 class BeadsMatchSettings(MyBaseModel):
     algorithm: Literal["hungarian", "match_descriptor", "spectral"] = "hungarian"
     source_peaks_settings: DetectPeaksSettings | None = Field(
@@ -239,6 +286,7 @@ class BeadsMatchSettings(MyBaseModel):
     # Defaults to "always" (i.e. variant D) on the benchmark below. Set "off" to restore
     # the previous behaviour exactly.
     spectral_arm: Literal["off", "on_low_score", "always"] = "always"
+    sweep_fallback_settings: SweepFallbackSettings = SweepFallbackSettings()
 
 
 class PhaseCrossCorrSettings(MyBaseModel):
@@ -412,8 +460,48 @@ class EstimateRegistrationSettings(MyBaseModel):
                 "independent": (False, "off"),
                 "independent_spectral": (False, "always"),
             }[self.beads_strategy]
-            self.affine_transform_settings.use_prev_t_transform = propagate
-            self.beads_match_settings.spectral_arm = spectral
+
+            # An explicit low-level flag always outranks the DEFAULT strategy. Without this,
+            # the default "independent_spectral" would silently flip a config that says
+            # use_prev_t_transform: true to false -- turning a propagation run into an
+            # independent one with no diagnostic, which every pre-existing config in the
+            # wild would hit, since they all set that flag directly and name no strategy.
+            strategy_explicit = "beads_strategy" in self.model_fields_set
+            prop_explicit = (
+                "use_prev_t_transform" in self.affine_transform_settings.model_fields_set
+            )
+            spectral_explicit = "spectral_arm" in self.beads_match_settings.model_fields_set
+
+            # Naming both a strategy and a flag that contradicts it is a config error, not a
+            # precedence question: one of the two is not what the author meant.
+            if strategy_explicit:
+                conflicts = []
+                if (
+                    prop_explicit
+                    and self.affine_transform_settings.use_prev_t_transform != propagate
+                ):
+                    conflicts.append(
+                        f"use_prev_t_transform="
+                        f"{self.affine_transform_settings.use_prev_t_transform} "
+                        f"(strategy implies {propagate})"
+                    )
+                if spectral_explicit and self.beads_match_settings.spectral_arm != spectral:
+                    conflicts.append(
+                        f"spectral_arm={self.beads_match_settings.spectral_arm!r} "
+                        f"(strategy implies {spectral!r})"
+                    )
+                if conflicts:
+                    raise ValueError(
+                        f"beads_strategy={self.beads_strategy!r} contradicts "
+                        + " and ".join(conflicts)
+                        + ". Set beads_strategy to null to drive the flags directly, or "
+                        "remove the conflicting flag."
+                    )
+
+            if strategy_explicit or not prop_explicit:
+                self.affine_transform_settings.use_prev_t_transform = propagate
+            if strategy_explicit or not spectral_explicit:
+                self.beads_match_settings.spectral_arm = spectral
         return self
 
 

--- a/biahub/settings.py
+++ b/biahub/settings.py
@@ -248,19 +248,28 @@ class SweepFallbackSettings(MyBaseModel):
     ----------
     mode : Literal["off", "on_low_score"]
         "on_low_score" runs the sweep when every other arm came in below score_threshold.
+    mode : Literal["off", "on_flagged", "on_low_score"]
+        "on_flagged" is the recommended setting: the sweep runs as a post-pass after the
+        repair pass, on the timepoints the run's OWN adaptive median-2*MAD line flags.
+
+        "on_low_score" is the legacy behaviour -- the sweep runs inside estimate(), gated on
+        the fixed score_threshold below. It is kept for reproducing earlier runs and is NOT
+        recommended, because a fixed gate does not transfer between datasets. Measured with
+        the gate at 0.75: on a run whose median was 0.870 it fired 0 times out of 144, and on
+        a run whose median was 0.753 -- where 0.75 sits at the median -- it fired 556 times,
+        stopped being a fallback, and pushed the job past its 24 h walltime.
+
+        The reason the adaptive gate has to live in a post-pass is that inside estimate() the
+        run-wide distribution does not exist yet: in independent mode the other timepoints are
+        still being computed in other SLURM jobs.
     score_threshold : float
-        The gate, and the whole cost/benefit dial. Calibrated against the measured score
-        distribution of two real runs (144 and 240 timepoints, medians 0.870 and 0.875):
-
-            gate    fires on
-            0.70    0 of 144, 2 of 240     -- dead code
-            0.75    5 of 144, 5 of 240     <- default: the tail, ~2-4%
-            0.80    26 of 144, 29 of 240   -- ~15%, hours of extra compute
-
-        0.75 is where the tail actually is; the timepoints the sweep was measured to rescue
-        scored 0.60-0.78. Note this is far above qc_settings.score_threshold (0.40), which
-        marks an unusable transform rather than a merely weak one -- gating on 0.40 would
-        never fire on a healthy run.
+        Only used by the legacy "on_low_score" mode. Calibrated against two runs with medians
+        0.870 and 0.875: 0.70 fired on 0 and 2 timepoints (dead code), 0.75 on 5 and 5 (the
+        tail), 0.80 on 26 and 29 (~15%, hours of compute). Ignored by "on_flagged", which
+        derives its own line per dataset.
+    max_timepoints : int | None
+        Cap on how many flagged timepoints to sweep, since each costs a full grid search.
+        When the cap bites, the worst are swept and the skipped ones are logged by name.
     grid : dict[str, list] | list[dict[str, list]] | None
         Parameter grid; None uses DEFAULT_SWEEP_GRID in biahub.registration.beads. A list of
         dicts is searched as the union of their cross products, which is how the hungarian
@@ -269,8 +278,9 @@ class SweepFallbackSettings(MyBaseModel):
         setter table, so a misspelled key raises instead of silently reading as a flat axis.
     """
 
-    mode: Literal["off", "on_low_score"] = "off"
+    mode: Literal["off", "on_flagged", "on_low_score"] = "off"
     score_threshold: float = 0.75
+    max_timepoints: int | None = 25
     grid: dict[str, list] | list[dict[str, list]] | None = None
 
 
@@ -314,6 +324,23 @@ class RepairPassSettings(MyBaseModel):
     mode: Literal["off", "on_flagged"] = "off"
     try_config_seed: bool = True
     max_timepoints: int | None = 25
+    # Seed a flagged timepoint from the run's own consensus geometry -- the element-wise
+    # median transform over the timepoints that scored well -- as well as from its
+    # neighbours. This repairs rather than discards a timepoint whose fit collapsed.
+    #
+    # It is what makes the geometry check actionable instead of merely diagnostic. Measured on
+    # one dataset, distance-from-consensus separated failed from good timepoints with AUC
+    # 1.000, and 15 failures were reflections (negative determinant) -- fits that collapsed
+    # outright. Those cannot be rescued by re-tuning matching parameters, but the run's own
+    # agreed geometry is a sound starting point for them.
+    use_consensus_seed: bool = True
+    # Only good timepoints define the consensus; including failures would contaminate the
+    # reference used to detect them.
+    consensus_score_threshold: float = 0.75
+    # Frobenius distance from the consensus linear part above which a timepoint's own linear
+    # part is treated as broken, so the consensus seeds are tried first. Measured: good
+    # timepoints sit at 0.021 and failures at 0.72, so anything in between separates them.
+    consensus_linear_tolerance: float = 0.25
 
 
 class BeadsMatchSettings(MyBaseModel):

--- a/biahub/settings.py
+++ b/biahub/settings.py
@@ -235,7 +235,10 @@ class BeadsMatchSettings(MyBaseModel):
     #                   the spectral cascade still won 93/144 and 117/240 timepoints on two
     #                   real datasets, so gating it on failure gives up most of the gain.
     #                   Costs one extra optimize_transform pair per timepoint.
-    spectral_arm: Literal["off", "on_low_score", "always"] = "off"
+    #
+    # Defaults to "always" (i.e. variant D) on the benchmark below. Set "off" to restore
+    # the previous behaviour exactly.
+    spectral_arm: Literal["off", "on_low_score", "always"] = "always"
 
 
 class PhaseCrossCorrSettings(MyBaseModel):
@@ -277,7 +280,14 @@ class AffineTransformSettings(MyBaseModel):
     t_reference: Literal["first", "previous"] = "first"
     transform_type: Literal["euclidean", "similarity", "affine"] = "euclidean"
     approx_transform: list = np.eye(4).tolist()
-    use_prev_t_transform: bool = True
+    # Defaults to False (independent per timepoint) rather than propagation. Propagation
+    # exists to supply each timepoint with a good initial transform, but the spectral
+    # cascade is insensitive to its initial transform -- measured identical results from a
+    # seed scoring 0.826 and one scoring 0.000 -- so propagation stops paying for itself
+    # while keeping three drawbacks: it is serial (~3-10 h against ~20 min), it cannot be
+    # resumed cheaply, and a single failure propagates forward as a cluster. Set True to
+    # restore it.
+    use_prev_t_transform: bool = False
     compute_approx_transform: bool = False
 
     @field_validator("approx_transform")

--- a/biahub/settings.py
+++ b/biahub/settings.py
@@ -175,6 +175,27 @@ class MatchDescriptorSettings(MyBaseModel):
     cross_check: bool = False
 
 
+class SpectralMatchSettings(MyBaseModel):
+    """Settings for pairwise-consistency (Leordeanu-Hebert) spectral matching.
+
+    Attributes
+    ----------
+    sigma : float
+        Tolerance in voxels on pairwise-distance agreement between two candidate
+        correspondences. Roughly the bead-localisation uncertainty.
+    rel_cut : float
+        Keep candidates scoring above this fraction of the top eigenvector entry.
+        Higher is stricter: measured on real data, 0.5 gives recall ~0.90 at precision
+        ~0.74, and 0.7 gives recall ~0.64 at precision ~0.83.
+    max_iter : int
+        Power-iteration steps for the principal eigenvector.
+    """
+
+    sigma: float = 3.0
+    rel_cut: float = 0.5
+    max_iter: int = 60
+
+
 class FilterMatchesSettings(MyBaseModel):
     angle_threshold: float = 0
     direction_threshold: float = 0
@@ -189,7 +210,7 @@ class QCBeadsRegistrationSettings(MyBaseModel):
 
 
 class BeadsMatchSettings(MyBaseModel):
-    algorithm: Literal["hungarian", "match_descriptor"] = "hungarian"
+    algorithm: Literal["hungarian", "match_descriptor", "spectral"] = "hungarian"
     source_peaks_settings: DetectPeaksSettings | None = Field(
         default_factory=DetectPeaksSettings
     )
@@ -198,8 +219,15 @@ class BeadsMatchSettings(MyBaseModel):
     )
     match_descriptor_settings: MatchDescriptorSettings = MatchDescriptorSettings()
     hungarian_match_settings: HungarianMatchSettings = HungarianMatchSettings()
+    spectral_match_settings: SpectralMatchSettings = SpectralMatchSettings()
     filter_matches_settings: FilterMatchesSettings = FilterMatchesSettings()
     qc_settings: QCBeadsRegistrationSettings = QCBeadsRegistrationSettings()
+    # Opt-in extra arm in estimate(): acquire the correspondence with spectral matching,
+    # then refine with the configured algorithm. Off by default so existing behaviour is
+    # unchanged; estimate() keeps whichever arm scores higher, so enabling it cannot make
+    # the result worse. Only useful when the initial transform may be wrong by more than
+    # about one bead spacing -- which is when the position-distance cost misleads.
+    try_spectral_arm: bool = False
 
 
 class PhaseCrossCorrSettings(MyBaseModel):

--- a/biahub/settings.py
+++ b/biahub/settings.py
@@ -341,6 +341,12 @@ class RepairPassSettings(MyBaseModel):
     # part is treated as broken, so the consensus seeds are tried first. Measured: good
     # timepoints sit at 0.021 and failures at 0.72, so anything in between separates them.
     consensus_linear_tolerance: float = 0.25
+    # How many robust spreads (MAD) a flagged timepoint's translation may sit from the
+    # consensus and still be considered worth keeping. Beyond this, the full-consensus seed is
+    # tried first instead. Measured need: collapsed fits on one dataset had translations
+    # thousands of voxels out, one reaching -15000 in x, so a broken linear part does not
+    # imply an intact translation.
+    consensus_translation_tolerance: float = 10.0
 
 
 class BeadsMatchSettings(MyBaseModel):

--- a/biahub/settings.py
+++ b/biahub/settings.py
@@ -189,6 +189,23 @@ class SpectralMatchSettings(MyBaseModel):
         ~0.74, and 0.7 gives recall ~0.64 at precision ~0.83.
     max_iter : int
         Power-iteration steps for the principal eigenvector.
+
+    These defaults are deliberately left where they are, despite a sweep appearing to beat
+    them. Over 24 stratified timepoints on two datasets, sigma=5.0/rel_cut=0.65 dominated
+    3.0/0.5 on every summary statistic when spectral matching ran ALONE -- mean 0.872 vs
+    0.856, worst case 0.720 vs 0.667. Rerunning the full cascade end-to-end with the tuned
+    pair then showed no improvement at all: 17 timepoints better, 21 worse, mean delta
+    -0.002, Wilcoxon p=0.20, and the run minimum fell from 0.720 to 0.708.
+
+    The reason is that spectral only has to land the transform inside the basin that the
+    subsequent hungarian refinement converges from; once it does, its own precision is
+    discarded. 106 of 144 timepoints came out bit-identical under the two settings. So a
+    single-pass spectral benchmark ranks these parameters for a job the cascade does not ask
+    them to do, and tuning them against it is measuring the wrong thing.
+
+    They do still matter where spectral matching is used on its own -- see
+    DEFAULT_SWEEP_GRID in biahub.registration.beads, whose ranges come from that same
+    stratified sweep.
     """
 
     sigma: float = 3.0
@@ -220,11 +237,12 @@ class SweepFallbackSettings(MyBaseModel):
     plus peak re-detection per surviving trial, roughly 18 s each. Gating it on score is
     what makes it affordable -- it fires on the few percent of timepoints that need it.
 
-    Measured on 15 flagged timepoints across two datasets: 5 improved, mean gain +0.030
-    taking max(incumbent, sweep). Modest, and it cannot regress -- estimate() keeps the
-    sweep result only if it strictly beats the incumbent -- so the honest description is a
-    small rescue for a real cost, worth enabling when a few bad timepoints matter more than
-    runtime.
+    Measured on 15 flagged timepoints across two datasets, with the default grid: 8 improved,
+    mean gain +0.041 over all 15 and +0.077 over those it helped. It cannot regress --
+    estimate() keeps the sweep result only if it strictly beats the incumbent -- so the
+    honest description is a modest rescue for a real cost, worth enabling when a few bad
+    timepoints matter more than runtime. Note it found nothing at 7 of the 15, so it is a
+    tail-risk reducer rather than a general improvement.
 
     Attributes
     ----------

--- a/biahub/settings.py
+++ b/biahub/settings.py
@@ -278,6 +278,16 @@ class SweepFallbackSettings(MyBaseModel):
         setter table, so a misspelled key raises instead of silently reading as a flat axis.
     """
 
+    # Off by default, deliberately, even though it is complementary to the repair pass.
+    #
+    # Measured across six datasets, repair alone recovered 3.654 score points and repair plus
+    # sweep in competition recovered 4.309 -- so the sweep adds a real 18%, but repair already
+    # captures 85% of the total at roughly half the cost. And after a repair pass the sweep's
+    # remaining wins are small: of 18 accepted gains, none reached 0.10 and six were 0.004 to
+    # 0.008, at or below the score metric's own resolution.
+    #
+    # Enable it, with fallback_mode="parallel", when the tail matters more than the runtime --
+    # on the worst dataset seen it beat repair at 5 of 20 timepoints, once by 0.455 -> 0.667.
     mode: Literal["off", "on_flagged", "on_low_score"] = "off"
     score_threshold: float = 0.75
     max_timepoints: int | None = 25
@@ -338,7 +348,16 @@ class RepairPassSettings(MyBaseModel):
         silently dropped.
     """
 
-    mode: Literal["off", "on_flagged"] = "off"
+    # On by default. Measured across six datasets it improved 44-85% of the timepoints it
+    # fired on, was positive on every one, and cost 0.8-6.7 CPU-hours per run. It cannot
+    # regress a run -- a candidate is accepted only if it strictly beats the incumbent -- so
+    # the only argument against enabling it is compute, and the adaptive gate keeps that
+    # proportional: it fires on the tail, not on the run.
+    #
+    # NOTE this changes behaviour for a config that does not mention it: such a run now gets
+    # a repair pass it did not before. The transforms can only improve, but the run takes
+    # longer and writes repair_log.json.
+    mode: Literal["off", "on_flagged"] = "on_flagged"
     try_config_seed: bool = True
     max_timepoints: int | None = 25
     # Seed a flagged timepoint from the run's own consensus geometry -- the element-wise

--- a/biahub/settings.py
+++ b/biahub/settings.py
@@ -364,6 +364,33 @@ class EstimateRegistrationSettings(MyBaseModel):
     eval_transform_settings: EvalTransformSettings | None = None
     ants_registration_settings: AntsRegistrationSettings | None = None
     manual_registration_settings: ManualRegistrationSettings | None = None
+    # One visible field to choose the beads strategy, rather than requiring the user to know
+    # that two low-level flags -- affine_transform_settings.use_prev_t_transform and
+    # beads_match_settings.spectral_arm, in two different blocks -- combine to produce it:
+    #
+    #   beads_strategy          use_prev_t_transform   spectral_arm
+    #   propagate                       True              off
+    #   propagate_spectral              True              always
+    #   independent                     False             off
+    #   independent_spectral            False             always     <- default
+    #
+    # Benchmarked on 2025_09_17 (144 t) and 2025_09_18 (240 t), scoring warped beads against
+    # the reference:
+    #
+    #   propagate              median 0.864/0.875   min 0.000/0.667   1/0  below 0.40
+    #   independent            median ~0.826        min 0.000         6/33 below 0.40
+    #   independent_spectral   median 0.870/0.875   min 0.720/0.600   0/0  below 0.40
+    #
+    # independent_spectral is the default because the spectral cascade is insensitive to its
+    # initial transform -- measured identical results from a seed scoring 0.826 and one
+    # scoring 0.000 -- so propagation no longer earns its serial cost (~3-10 h against
+    # ~20 min), its lack of cheap resume, or its tendency to turn one failure into a cluster.
+    #
+    # Set to None to drive use_prev_t_transform and spectral_arm directly instead.
+    beads_strategy: (
+        Literal["propagate", "propagate_spectral", "independent", "independent_spectral"]
+        | None
+    ) = "independent_spectral"
     verbose: bool = False
 
     @model_validator(mode="after")
@@ -374,6 +401,19 @@ class EstimateRegistrationSettings(MyBaseModel):
             self.beads_match_settings = BeadsMatchSettings()
         elif self.estimation_method == "ants" and self.ants_registration_settings is None:
             self.ants_registration_settings = AntsRegistrationSettings()
+
+        # Expand the strategy into the two flags that actually drive estimate(). Runs after
+        # the block above so beads_match_settings exists. Skipped when beads_strategy is
+        # None, which leaves the low-level flags untouched for advanced use.
+        if self.beads_strategy is not None and self.beads_match_settings is not None:
+            propagate, spectral = {
+                "propagate": (True, "off"),
+                "propagate_spectral": (True, "always"),
+                "independent": (False, "off"),
+                "independent_spectral": (False, "always"),
+            }[self.beads_strategy]
+            self.affine_transform_settings.use_prev_t_transform = propagate
+            self.beads_match_settings.spectral_arm = spectral
         return self
 
 

--- a/biahub/settings.py
+++ b/biahub/settings.py
@@ -416,6 +416,32 @@ class BeadsMatchSettings(MyBaseModel):
     # Defaults to "always" (i.e. variant D) on the benchmark below. Set "off" to restore
     # the previous behaviour exactly.
     spectral_arm: Literal["off", "on_low_score", "always"] = "always"
+    # How the two fallback passes relate. Only consulted when BOTH are enabled; each pass is
+    # turned on or off by its own `mode`, so the five usable combinations are:
+    #
+    #   repair only          repair_pass=on_flagged, sweep_fallback=off
+    #   sweep only           repair_pass=off,        sweep_fallback=on_flagged
+    #   repair then sweep    both on, fallback_mode="repair_then_sweep"
+    #   sweep then repair    both on, fallback_mode="sweep_then_repair"
+    #   both, competing      both on, fallback_mode="parallel"        <- default
+    #
+    # "parallel" runs both from the SAME post-estimation scores and keeps whichever result is
+    # better per timepoint. It is the default because either sequential order measurably loses
+    # quality: whichever pass runs first lifts timepoints above the adaptive line, re-flagging
+    # then removes them, and the second pass never gets a turn on them. Measured at 09_17
+    # t=96, repair reached 0.773 while the sweep from the same start reached 0.864; run
+    # sequentially the sweep never ran there and the 0.091 was lost. The second pass is also
+    # judged against the first's improved score rather than the original, so fewer of its
+    # results are accepted.
+    #
+    # Head-to-head over 72 timepoints where both acted from the same starting transform:
+    # repair won 37, the sweep won 13, 22 tied, and taking the better of the two recovered
+    # 4.309 score points against 3.654 for repair alone -- 18% more. They are complementary,
+    # so neither ordering dominates and running both is what captures that.
+    #
+    # The sequential orders cost less and are kept for reproducing earlier runs and for when
+    # compute matters more than the tail.
+    fallback_mode: Literal["parallel", "repair_then_sweep", "sweep_then_repair"] = "parallel"
     sweep_fallback_settings: SweepFallbackSettings = SweepFallbackSettings()
     repair_pass_settings: RepairPassSettings = RepairPassSettings()
 

--- a/biahub/settings.py
+++ b/biahub/settings.py
@@ -222,12 +222,20 @@ class BeadsMatchSettings(MyBaseModel):
     spectral_match_settings: SpectralMatchSettings = SpectralMatchSettings()
     filter_matches_settings: FilterMatchesSettings = FilterMatchesSettings()
     qc_settings: QCBeadsRegistrationSettings = QCBeadsRegistrationSettings()
-    # Opt-in extra arm in estimate(): acquire the correspondence with spectral matching,
-    # then refine with the configured algorithm. Off by default so existing behaviour is
-    # unchanged; estimate() keeps whichever arm scores higher, so enabling it cannot make
-    # the result worse. Only useful when the initial transform may be wrong by more than
-    # about one bead spacing -- which is when the position-distance cost misleads.
-    try_spectral_arm: bool = False
+    # Extra arm in estimate(): acquire the correspondence with spectral matching, then
+    # refine with the configured algorithm. estimate() keeps whichever arm scores higher,
+    # so enabling this cannot make the result worse than leaving it off.
+    #
+    #   "off"           existing behaviour, unchanged
+    #   "on_low_score"  only when the other arms fall below qc_settings.score_threshold.
+    #                   Cheap, but note it will rarely fire in practice: measured scores
+    #                   sit at 0.6-1.0 against a 0.40 threshold.
+    #   "always"        run it at every timepoint. This is what the benchmarked variant D
+    #                   does, and it is not merely a rescue: with a good initial transform
+    #                   the spectral cascade still won 93/144 and 117/240 timepoints on two
+    #                   real datasets, so gating it on failure gives up most of the gain.
+    #                   Costs one extra optimize_transform pair per timepoint.
+    spectral_arm: Literal["off", "on_low_score", "always"] = "off"
 
 
 class PhaseCrossCorrSettings(MyBaseModel):

--- a/biahub/settings.py
+++ b/biahub/settings.py
@@ -374,8 +374,16 @@ class RepairPassSettings(MyBaseModel):
     # a third of its rescues in 0.72-0.80, where the sweep gains ~+0.058 for 28 trials, while
     # one polish round is a single estimate() call and changes no matching parameter.
     #
-    # Rounds stop as soon as one fails to improve, so a converged timepoint costs one call.
-    polish_rounds: int = 1
+    # Rounds stop as soon as one fails to improve, so the cap bounds the WORST case rather
+    # than the typical one: a timepoint that converges after one round costs two calls no
+    # matter how high this is set. That asymmetry is why the default is not 1.
+    #
+    # A badly-broken timepoint has the most headroom, not the least, so it is the case most
+    # likely to keep climbing. The spectral cascade already demonstrates the mechanism over a
+    # large gap -- measured seed 0.000 -> spectral 0.778 -> refined 0.882 at one real
+    # timepoint -- and polish is that same re-seed-and-refine step applied again. There is no
+    # reason it should only pay off near the top of the range.
+    polish_rounds: int = 3
 
 
 class BeadsMatchSettings(MyBaseModel):

--- a/biahub/settings.py
+++ b/biahub/settings.py
@@ -281,6 +281,23 @@ class SweepFallbackSettings(MyBaseModel):
     mode: Literal["off", "on_flagged", "on_low_score"] = "off"
     score_threshold: float = 0.75
     max_timepoints: int | None = 25
+    # Which timepoints the sweep is allowed to touch, once the repair pass has run.
+    #
+    #   "still_flagged"         everything the adaptive line flags on the POST-repair scores.
+    #                           Because repair raises the median and shrinks the MAD, that
+    #                           line rises -- so this set is repair's failures PLUS timepoints
+    #                           that only became outliers relative to a now-healthier run.
+    #   "repair_failures_only"  strictly the timepoints repair attempted and did not lift.
+    #
+    # Default is "still_flagged", against the intuition that the sweep should only clean up
+    # after repair, because the measurements point the other way: the sweep gains +0.058 on
+    # timepoints scoring 0.72-0.78 and only +0.006 below 0.72, and found nothing at all across
+    # 28 trials on the worst timepoint tested. Repair's failures are the collapsed fits near
+    # zero -- exactly where sweeping does not help -- while the timepoints the rising line
+    # newly catches sit in the 0.66-0.73 band, which is the sweep's useful range. Restricting
+    # to repair failures therefore spends the budget where it cannot pay off and skips where
+    # it can.
+    scope: Literal["still_flagged", "repair_failures_only"] = "still_flagged"
     grid: dict[str, list] | list[dict[str, list]] | None = None
 
 

--- a/biahub/settings.py
+++ b/biahub/settings.py
@@ -364,6 +364,18 @@ class RepairPassSettings(MyBaseModel):
     # thousands of voxels out, one reaching -15000 in x, so a broken linear part does not
     # imply an intact translation.
     consensus_translation_tolerance: float = 10.0
+    # After a repair is accepted, re-seed the spectral/hungarian cascade FROM it and refine
+    # again, keeping the result only if it improves. 0 disables.
+    #
+    # Worth doing because the candidate seeds are all coarse -- the consensus geometry scores
+    # ~0.000 applied on its own -- and peak detection runs in warped space, so a cascade
+    # seeded from an already-good transform sees much better peaks than one seeded from
+    # scratch. It is also the cheaper answer to the gap the sweep targets: repair lands about
+    # a third of its rescues in 0.72-0.80, where the sweep gains ~+0.058 for 28 trials, while
+    # one polish round is a single estimate() call and changes no matching parameter.
+    #
+    # Rounds stop as soon as one fails to improve, so a converged timepoint costs one call.
+    polish_rounds: int = 1
 
 
 class BeadsMatchSettings(MyBaseModel):

--- a/biahub/settings.py
+++ b/biahub/settings.py
@@ -1,3 +1,5 @@
+import warnings
+
 from pathlib import Path
 from typing import Any, Literal
 
@@ -16,6 +18,26 @@ from pydantic import (
     field_validator,
     model_validator,
 )
+
+
+
+def _coerce_yaml_off(value):
+    """Accept YAML's boolean `off` where the string "off" is meant.
+
+    YAML 1.1 resolves the bare words off/no/false to boolean False (and on/yes/true to True),
+    so `fallback: off` arrives here as False and fails a Literal["off", ...] check with a
+    message that does not mention quoting. Every field using this has "off" as a real option,
+    so mapping False onto it is unambiguous. True is rejected, because "on" is not a value any
+    of these fields takes -- there is always more than one way to be on.
+    """
+    if value is False:
+        return "off"
+    if value is True:
+        raise ValueError(
+            "got boolean true; YAML reads bare on/yes/true as a boolean. Quote the value you "
+            'meant, e.g. "always" or "on_flagged".'
+        )
+    return value
 
 
 # All settings classes inherit from MyBaseModel, which forbids extra parameters to guard against typos
@@ -289,6 +311,7 @@ class SweepFallbackSettings(MyBaseModel):
     # Enable it, with fallback_mode="parallel", when the tail matters more than the runtime --
     # on the worst dataset seen it beat repair at 5 of 20 timepoints, once by 0.455 -> 0.667.
     mode: Literal["off", "on_flagged", "on_low_score"] = "off"
+    _coerce_mode = field_validator("mode", mode="before")(_coerce_yaml_off)
     score_threshold: float = 0.75
     max_timepoints: int | None = 25
     # Which timepoints the sweep is allowed to touch, once the repair pass has run.
@@ -358,6 +381,7 @@ class RepairPassSettings(MyBaseModel):
     # a repair pass it did not before. The transforms can only improve, but the run takes
     # longer and writes repair_log.json.
     mode: Literal["off", "on_flagged"] = "on_flagged"
+    _coerce_mode = field_validator("mode", mode="before")(_coerce_yaml_off)
     try_config_seed: bool = True
     max_timepoints: int | None = 25
     # Seed a flagged timepoint from the run's own consensus geometry -- the element-wise
@@ -435,6 +459,63 @@ class BeadsMatchSettings(MyBaseModel):
     # Defaults to "always" (i.e. variant D) on the benchmark below. Set "off" to restore
     # the previous behaviour exactly.
     spectral_arm: Literal["off", "on_low_score", "always"] = "always"
+    _coerce_spectral_arm = field_validator("spectral_arm", mode="before")(_coerce_yaml_off)
+
+    # ---- WHAT runs. Two named fields; everything else in this block is HOW it runs. ----
+    #
+    # strategy expands into two low-level flags that live in different places --
+    # affine_transform_settings.use_prev_t_transform and spectral_arm above -- so that
+    # choosing a variant does not require knowing which flags combine to make it:
+    #
+    #   strategy                use_prev_t_transform   spectral_arm
+    #   propagate                       True              off
+    #   propagate_spectral              True              always
+    #   independent                     False             off
+    #   independent_spectral            False             always      <- default
+    #
+    # Benchmarked on 2025_09_17 (144 t) and 2025_09_18 (240 t):
+    #   propagate              median 0.864/0.875   min 0.000/0.667   1/0  below 0.40
+    #   independent            median ~0.826        min 0.000         6/33 below 0.40
+    #   independent_spectral   median 0.870/0.875   min 0.720/0.600   0/0  below 0.40
+    #
+    # independent_spectral is the default because the spectral cascade is insensitive to its
+    # initial transform -- measured identical results from seeds scoring 0.826 and 0.000 -- so
+    # propagation no longer earns its serial cost (~3-10 h against ~20 min), its lack of cheap
+    # resume, or its tendency to turn one failure into a cluster.
+    #
+    # Set to None to drive use_prev_t_transform and spectral_arm directly.
+    strategy: (
+        Literal["propagate", "propagate_spectral", "independent", "independent_spectral"]
+        | None
+    ) = "independent_spectral"
+
+    # fallback replaces three orchestration flags that used to be read together --
+    # repair_pass_settings.mode, sweep_fallback_settings.mode, and fallback_mode -- one of
+    # which was inert unless the other two were both on. That combination was misleading in
+    # its own right: the default read "parallel" while the sweep was off, so the config said
+    # one thing and the run did another.
+    #
+    #   off                 no fallback; flagged timepoints are reported, not touched
+    #   repair              reseed flagged timepoints from consensus/neighbours   <- default
+    #   sweep               grid-search the matching parameters instead
+    #   repair_then_sweep   staged, repair first, sweep whatever is still flagged
+    #   sweep_then_repair   staged, the other order
+    #   parallel            both from the same starting scores, better result wins
+    #
+    # Default "repair": measured across six datasets it recovered 3.654 score points against
+    # 4.309 for repair and sweep competing -- 85% of the total for roughly half the compute.
+    # Choose "parallel" when individual timepoints matter more than run statistics: the sweep
+    # rescued 6 of 72 flagged timepoints that repair could not touch at all, about one per
+    # dataset, which no run-level average shows.
+    #
+    # Set to None to drive the three low-level flags directly.
+    fallback: (
+        Literal[
+            "off", "repair", "sweep", "repair_then_sweep", "sweep_then_repair", "parallel"
+        ]
+        | None
+    ) = "repair"
+    _coerce_fallback = field_validator("fallback", mode="before")(_coerce_yaml_off)
     # How the two fallback passes relate. Only consulted when BOTH are enabled; each pass is
     # turned on or off by its own `mode`, so the five usable combinations are:
     #
@@ -463,6 +544,62 @@ class BeadsMatchSettings(MyBaseModel):
     fallback_mode: Literal["parallel", "repair_then_sweep", "sweep_then_repair"] = "parallel"
     sweep_fallback_settings: SweepFallbackSettings = SweepFallbackSettings()
     repair_pass_settings: RepairPassSettings = RepairPassSettings()
+
+    @model_validator(mode="after")
+    def expand_fallback(self) -> "BeadsMatchSettings":
+        """Turn `fallback` into the three low-level flags that drive estimate_tczyx.
+
+        An explicitly-set low-level flag outranks a DEFAULTED `fallback`, so a config written
+        against the older field names keeps working. Setting `fallback` and a contradicting
+        low-level flag together is rejected rather than silently resolved -- the same rule as
+        `strategy`, and for the same reason: one of the two is not what the author meant.
+        """
+        if self.fallback is None:
+            return self
+        repair, sweep, order = {
+            "off": ("off", "off", "parallel"),
+            "repair": ("on_flagged", "off", "parallel"),
+            "sweep": ("off", "on_flagged", "parallel"),
+            "repair_then_sweep": ("on_flagged", "on_flagged", "repair_then_sweep"),
+            "sweep_then_repair": ("on_flagged", "on_flagged", "sweep_then_repair"),
+            "parallel": ("on_flagged", "on_flagged", "parallel"),
+        }[self.fallback]
+
+        explicit = "fallback" in self.model_fields_set
+        conflicts = []
+        if explicit:
+            if "mode" in self.repair_pass_settings.model_fields_set and (
+                self.repair_pass_settings.mode != repair
+            ):
+                conflicts.append(
+                    f"repair_pass_settings.mode={self.repair_pass_settings.mode!r} "
+                    f"(fallback implies {repair!r})"
+                )
+            if "mode" in self.sweep_fallback_settings.model_fields_set and (
+                self.sweep_fallback_settings.mode != sweep
+            ):
+                conflicts.append(
+                    f"sweep_fallback_settings.mode="
+                    f"{self.sweep_fallback_settings.mode!r} (fallback implies {sweep!r})"
+                )
+            if "fallback_mode" in self.model_fields_set and self.fallback_mode != order:
+                conflicts.append(
+                    f"fallback_mode={self.fallback_mode!r} (fallback implies {order!r})"
+                )
+            if conflicts:
+                raise ValueError(
+                    f"fallback={self.fallback!r} contradicts " + " and ".join(conflicts)
+                    + ". Set fallback to null to drive the low-level flags directly, or "
+                    "remove the conflicting flag."
+                )
+
+        if explicit or "mode" not in self.repair_pass_settings.model_fields_set:
+            self.repair_pass_settings.mode = repair
+        if explicit or "mode" not in self.sweep_fallback_settings.model_fields_set:
+            self.sweep_fallback_settings.mode = sweep
+        if explicit or "fallback_mode" not in self.model_fields_set:
+            self.fallback_mode = order
+        return self
 
 
 class PhaseCrossCorrSettings(MyBaseModel):
@@ -588,33 +725,13 @@ class EstimateRegistrationSettings(MyBaseModel):
     eval_transform_settings: EvalTransformSettings | None = None
     ants_registration_settings: AntsRegistrationSettings | None = None
     manual_registration_settings: ManualRegistrationSettings | None = None
-    # One visible field to choose the beads strategy, rather than requiring the user to know
-    # that two low-level flags -- affine_transform_settings.use_prev_t_transform and
-    # beads_match_settings.spectral_arm, in two different blocks -- combine to produce it:
-    #
-    #   beads_strategy          use_prev_t_transform   spectral_arm
-    #   propagate                       True              off
-    #   propagate_spectral              True              always
-    #   independent                     False             off
-    #   independent_spectral            False             always     <- default
-    #
-    # Benchmarked on 2025_09_17 (144 t) and 2025_09_18 (240 t), scoring warped beads against
-    # the reference:
-    #
-    #   propagate              median 0.864/0.875   min 0.000/0.667   1/0  below 0.40
-    #   independent            median ~0.826        min 0.000         6/33 below 0.40
-    #   independent_spectral   median 0.870/0.875   min 0.720/0.600   0/0  below 0.40
-    #
-    # independent_spectral is the default because the spectral cascade is insensitive to its
-    # initial transform -- measured identical results from a seed scoring 0.826 and one
-    # scoring 0.000 -- so propagation no longer earns its serial cost (~3-10 h against
-    # ~20 min), its lack of cheap resume, or its tendency to turn one failure into a cluster.
-    #
-    # Set to None to drive use_prev_t_transform and spectral_arm directly instead.
+    # DEPRECATED: moved to beads_match_settings.strategy, because it configures beads and
+    # every other method keeps its configuration in its own block. Still accepted so existing
+    # configs do not hard-fail against extra="forbid"; it is copied inward and warned about.
     beads_strategy: (
         Literal["propagate", "propagate_spectral", "independent", "independent_spectral"]
         | None
-    ) = "independent_spectral"
+    ) = None
     verbose: bool = False
 
     @model_validator(mode="after")
@@ -626,27 +743,63 @@ class EstimateRegistrationSettings(MyBaseModel):
         elif self.estimation_method == "ants" and self.ants_registration_settings is None:
             self.ants_registration_settings = AntsRegistrationSettings()
 
-        # Expand the strategy into the two flags that actually drive estimate(). Runs after
-        # the block above so beads_match_settings exists. Skipped when beads_strategy is
-        # None, which leaves the low-level flags untouched for advanced use.
+        # A beads-only flag set on another method is silently ignored today, which is worse
+        # than an error: the ants path submits every timepoint in parallel, so it cannot
+        # propagate from t-1 at all, and a config asking for it gets no propagation and no
+        # warning. Say so instead.
+        if (
+            self.estimation_method != "beads"
+            and "use_prev_t_transform" in self.affine_transform_settings.model_fields_set
+            and self.affine_transform_settings.use_prev_t_transform
+        ):
+            raise ValueError(
+                "affine_transform_settings.use_prev_t_transform is only implemented for "
+                f"estimation_method='beads', not {self.estimation_method!r}. The ants path "
+                "submits all timepoints in parallel, so there is no previous timepoint to "
+                "propagate from; it takes a single static seed instead."
+            )
+
+        # The deprecated top-level field is copied into the beads block, which is where the
+        # setting now lives.
         if self.beads_strategy is not None and self.beads_match_settings is not None:
+            if "strategy" in self.beads_match_settings.model_fields_set and (
+                self.beads_match_settings.strategy != self.beads_strategy
+            ):
+                raise ValueError(
+                    f"top-level beads_strategy={self.beads_strategy!r} contradicts "
+                    f"beads_match_settings.strategy="
+                    f"{self.beads_match_settings.strategy!r}. Set only the latter."
+                )
+            warnings.warn(
+                "beads_strategy at the top level is deprecated; use "
+                "beads_match_settings.strategy instead.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            self.beads_match_settings.strategy = self.beads_strategy
+            self.beads_match_settings.model_fields_set.add("strategy")
+
+        # Expand the strategy into the two flags that actually drive estimate(). One of them
+        # lives outside beads_match_settings, which is why this expansion happens here rather
+        # than in that block's own validator.
+        bms = self.beads_match_settings
+        if bms is not None and bms.strategy is not None:
             propagate, spectral = {
                 "propagate": (True, "off"),
                 "propagate_spectral": (True, "always"),
                 "independent": (False, "off"),
                 "independent_spectral": (False, "always"),
-            }[self.beads_strategy]
+            }[bms.strategy]
 
-            # An explicit low-level flag always outranks the DEFAULT strategy. Without this,
-            # the default "independent_spectral" would silently flip a config that says
-            # use_prev_t_transform: true to false -- turning a propagation run into an
-            # independent one with no diagnostic, which every pre-existing config in the
-            # wild would hit, since they all set that flag directly and name no strategy.
-            strategy_explicit = "beads_strategy" in self.model_fields_set
+            # An explicit low-level flag always outranks a DEFAULTED strategy. Without this,
+            # the default independent_spectral would silently flip a config saying
+            # use_prev_t_transform: true into an independent run -- which every pre-existing
+            # config would hit, since they all set that flag directly and name no strategy.
+            strategy_explicit = "strategy" in bms.model_fields_set
             prop_explicit = (
                 "use_prev_t_transform" in self.affine_transform_settings.model_fields_set
             )
-            spectral_explicit = "spectral_arm" in self.beads_match_settings.model_fields_set
+            spectral_explicit = "spectral_arm" in bms.model_fields_set
 
             # Naming both a strategy and a flag that contradicts it is a config error, not a
             # precedence question: one of the two is not what the author meant.
@@ -661,23 +814,22 @@ class EstimateRegistrationSettings(MyBaseModel):
                         f"{self.affine_transform_settings.use_prev_t_transform} "
                         f"(strategy implies {propagate})"
                     )
-                if spectral_explicit and self.beads_match_settings.spectral_arm != spectral:
+                if spectral_explicit and bms.spectral_arm != spectral:
                     conflicts.append(
-                        f"spectral_arm={self.beads_match_settings.spectral_arm!r} "
+                        f"spectral_arm={bms.spectral_arm!r} "
                         f"(strategy implies {spectral!r})"
                     )
                 if conflicts:
                     raise ValueError(
-                        f"beads_strategy={self.beads_strategy!r} contradicts "
-                        + " and ".join(conflicts)
-                        + ". Set beads_strategy to null to drive the flags directly, or "
-                        "remove the conflicting flag."
+                        f"strategy={bms.strategy!r} contradicts " + " and ".join(conflicts)
+                        + ". Set strategy to null to drive the flags directly, or remove the "
+                        "conflicting flag."
                     )
 
             if strategy_explicit or not prop_explicit:
                 self.affine_transform_settings.use_prev_t_transform = propagate
             if strategy_explicit or not spectral_explicit:
-                self.beads_match_settings.spectral_arm = spectral
+                bms.spectral_arm = spectral
         return self
 
 

--- a/biahub/settings.py
+++ b/biahub/settings.py
@@ -274,6 +274,48 @@ class SweepFallbackSettings(MyBaseModel):
     grid: dict[str, list] | list[dict[str, list]] | None = None
 
 
+class RepairPassSettings(MyBaseModel):
+    """Post-estimation reseeding of flagged timepoints from their neighbours.
+
+    The other half of the fallback, and it necessarily runs after the whole series exists
+    rather than inside estimate(): it seeds from t-1 AND t+1, and in independent mode t+1 is
+    still being computed in another shard while t is estimated. Reaching forwards is the
+    point -- propagation's built-in fallback can only reach back to t-1, and a timepoint that
+    failed because the sample jumped between t-1 and t is often fine from t+1.
+
+    It targets a different failure class from the sweep, which is why running both and keeping
+    the higher score is worth more than either alone:
+
+        sweep    right basin, suboptimal correspondence. Measured +0.058 on timepoints
+                 scoring 0.72-0.78, but only +0.006 on those below 0.72.
+        repair   wrong basin, or no usable transform at all -- which no amount of
+                 re-weighting the cost matrix fixes. At one real timepoint propagation gave
+                 0.429 where a reseed reached 0.778.
+
+    Gated on the run's own adaptive median-2*MAD line, not a second fixed threshold, so it
+    repairs exactly what the QC report flags. Every candidate is scored and accepted only if
+    it strictly beats the incumbent, so the pass cannot make a run worse.
+
+    Attributes
+    ----------
+    mode : Literal["off", "on_flagged"]
+        "on_flagged" repairs the timepoints the adaptive threshold flags.
+    try_config_seed : bool
+        Also try the static config approx_transform as a seed. Worth keeping for the case
+        both neighbours are themselves flagged, which is what a cluster of failures looks
+        like.
+    max_timepoints : int | None
+        Safety cap on how many timepoints to repair, since each costs up to one full
+        estimate() per candidate seed. None means no cap. When the cap bites, the worst
+        timepoints are repaired and the skipped ones are logged by name rather than
+        silently dropped.
+    """
+
+    mode: Literal["off", "on_flagged"] = "off"
+    try_config_seed: bool = True
+    max_timepoints: int | None = 25
+
+
 class BeadsMatchSettings(MyBaseModel):
     algorithm: Literal["hungarian", "match_descriptor", "spectral"] = "hungarian"
     source_peaks_settings: DetectPeaksSettings | None = Field(
@@ -305,6 +347,7 @@ class BeadsMatchSettings(MyBaseModel):
     # the previous behaviour exactly.
     spectral_arm: Literal["off", "on_low_score", "always"] = "always"
     sweep_fallback_settings: SweepFallbackSettings = SweepFallbackSettings()
+    repair_pass_settings: RepairPassSettings = RepairPassSettings()
 
 
 class PhaseCrossCorrSettings(MyBaseModel):

--- a/biahub/settings.py
+++ b/biahub/settings.py
@@ -248,7 +248,7 @@ class QCBeadsRegistrationSettings(MyBaseModel):
     score_centroid_mask_radius: int = 6
 
 
-class SweepFallbackSettings(MyBaseModel):
+class SweepSettings(MyBaseModel):
     """Last-resort per-timepoint grid search over the matching parameters.
 
     The other arms all reuse one parameter set for the whole timelapse. That set is chosen
@@ -310,8 +310,16 @@ class SweepFallbackSettings(MyBaseModel):
     #
     # Enable it, with fallback_mode="parallel", when the tail matters more than the runtime --
     # on the worst dataset seen it beat repair at 5 of 20 timepoints, once by 0.455 -> 0.667.
-    mode: Literal["off", "on_flagged", "on_low_score"] = "off"
-    _coerce_mode = field_validator("mode", mode="before")(_coerce_yaml_off)
+    # Legacy in-estimate() arm: run the sweep per timepoint inside estimate(), gated on the
+    # fixed score_threshold below. NOT recommended -- a fixed gate does not transfer between
+    # datasets, and at 0.75 it fired 0 times on a run whose median was 0.870 and 556 times on
+    # one whose median was 0.753, where it stopped being a fallback and blew the walltime.
+    # Kept only to reproduce earlier runs. Whether the sweep runs as a POST-PASS is decided by
+    # FallbackSettings.mode, not here.
+    legacy_in_estimate: bool = False
+    # DEPRECATED: on/off moved to FallbackSettings.mode. Read only by the migration.
+    mode: str | None = None
+    _coerce_legacy_mode = field_validator("mode", mode="before")(_coerce_yaml_off)
     score_threshold: float = 0.75
     max_timepoints: int | None = 25
     # Which timepoints the sweep is allowed to touch, once the repair pass has run.
@@ -334,7 +342,7 @@ class SweepFallbackSettings(MyBaseModel):
     grid: dict[str, list] | list[dict[str, list]] | None = None
 
 
-class RepairPassSettings(MyBaseModel):
+class RepairSettings(MyBaseModel):
     """Post-estimation reseeding of flagged timepoints from their neighbours.
 
     The other half of the fallback, and it necessarily runs after the whole series exists
@@ -380,8 +388,9 @@ class RepairPassSettings(MyBaseModel):
     # NOTE this changes behaviour for a config that does not mention it: such a run now gets
     # a repair pass it did not before. The transforms can only improve, but the run takes
     # longer and writes repair_log.json.
-    mode: Literal["off", "on_flagged"] = "on_flagged"
-    _coerce_mode = field_validator("mode", mode="before")(_coerce_yaml_off)
+    # DEPRECATED: on/off moved to FallbackSettings.mode. Read only by the migration.
+    mode: str | None = None
+    _coerce_legacy_mode = field_validator("mode", mode="before")(_coerce_yaml_off)
     try_config_seed: bool = True
     max_timepoints: int | None = 25
     # Seed a flagged timepoint from the run's own consensus geometry -- the element-wise
@@ -427,6 +436,60 @@ class RepairPassSettings(MyBaseModel):
     # timepoint -- and polish is that same re-seed-and-refine step applied again. There is no
     # reason it should only pay off near the top of the range.
     polish_rounds: int = 3
+
+
+class FallbackSettings(MyBaseModel):
+    """What happens to the timepoints the QC flags, and how each pass is tuned.
+
+    One field says WHAT runs; the two nested blocks say HOW. This replaces three flags that
+    used to be read together in two different places, one of which was inert unless the other
+    two were both on -- and whose default read "parallel" while the sweep was off, so the
+    config said one thing and the run did another.
+
+    Modes
+    -----
+    off                 flagged timepoints are reported, never modified.
+    repair              reseed them from the run's consensus geometry or their neighbours.
+                        Default: across six datasets this recovered 3.654 score points against
+                        4.309 for repair and sweep competing -- 85% of the total for roughly
+                        half the compute.
+    sweep               grid-search the matching parameters instead.
+    repair_then_sweep   staged; sweep only what repair left flagged.
+    sweep_then_repair   staged, the other way round.
+    parallel            both from the same starting scores, better result wins per timepoint.
+                        Choose this when individual timepoints matter more than run-level
+                        statistics: the sweep rescued 6 of 72 flagged timepoints that repair
+                        could not touch at all -- about one per dataset -- which no average
+                        shows. Either staged order loses ground to it, because whichever pass
+                        runs first lifts timepoints above the adaptive line, re-flagging then
+                        removes them, and the second pass never gets a turn.
+
+    Every pass accepts a result only if it strictly beats what it started from, so no mode can
+    make a run worse than "off".
+    """
+
+    mode: (
+        Literal[
+            "off", "repair", "sweep", "repair_then_sweep", "sweep_then_repair", "parallel"
+        ]
+        | None
+    ) = "repair"
+    _coerce_mode = field_validator("mode", mode="before")(_coerce_yaml_off)
+    repair_settings: RepairSettings = RepairSettings()
+    sweep_settings: SweepSettings = SweepSettings()
+
+    @property
+    def repair_enabled(self) -> bool:
+        return self.mode in ("repair", "repair_then_sweep", "sweep_then_repair", "parallel")
+
+    @property
+    def sweep_enabled(self) -> bool:
+        return self.mode in ("sweep", "repair_then_sweep", "sweep_then_repair", "parallel")
+
+    @property
+    def order(self) -> str:
+        """Which staged order to use; "parallel" when the passes compete."""
+        return self.mode if self.mode in ("repair_then_sweep", "sweep_then_repair") else "parallel"
 
 
 class BeadsMatchSettings(MyBaseModel):
@@ -489,118 +552,84 @@ class BeadsMatchSettings(MyBaseModel):
         | None
     ) = "independent_spectral"
 
-    # fallback replaces three orchestration flags that used to be read together --
-    # repair_pass_settings.mode, sweep_fallback_settings.mode, and fallback_mode -- one of
-    # which was inert unless the other two were both on. That combination was misleading in
-    # its own right: the default read "parallel" while the sweep was off, so the config said
-    # one thing and the run did another.
-    #
-    #   off                 no fallback; flagged timepoints are reported, not touched
-    #   repair              reseed flagged timepoints from consensus/neighbours   <- default
-    #   sweep               grid-search the matching parameters instead
-    #   repair_then_sweep   staged, repair first, sweep whatever is still flagged
-    #   sweep_then_repair   staged, the other order
-    #   parallel            both from the same starting scores, better result wins
-    #
-    # Default "repair": measured across six datasets it recovered 3.654 score points against
-    # 4.309 for repair and sweep competing -- 85% of the total for roughly half the compute.
-    # Choose "parallel" when individual timepoints matter more than run statistics: the sweep
-    # rescued 6 of 72 flagged timepoints that repair could not touch at all, about one per
-    # dataset, which no run-level average shows.
-    #
-    # Set to None to drive the three low-level flags directly.
-    fallback: (
-        Literal[
-            "off", "repair", "sweep", "repair_then_sweep", "sweep_then_repair", "parallel"
-        ]
-        | None
-    ) = "repair"
-    _coerce_fallback = field_validator("fallback", mode="before")(_coerce_yaml_off)
-    # How the two fallback passes relate. Only consulted when BOTH are enabled; each pass is
-    # turned on or off by its own `mode`, so the five usable combinations are:
-    #
-    #   repair only          repair_pass=on_flagged, sweep_fallback=off
-    #   sweep only           repair_pass=off,        sweep_fallback=on_flagged
-    #   repair then sweep    both on, fallback_mode="repair_then_sweep"
-    #   sweep then repair    both on, fallback_mode="sweep_then_repair"
-    #   both, competing      both on, fallback_mode="parallel"        <- default
-    #
-    # "parallel" runs both from the SAME post-estimation scores and keeps whichever result is
-    # better per timepoint. It is the default because either sequential order measurably loses
-    # quality: whichever pass runs first lifts timepoints above the adaptive line, re-flagging
-    # then removes them, and the second pass never gets a turn on them. Measured at 09_17
-    # t=96, repair reached 0.773 while the sweep from the same start reached 0.864; run
-    # sequentially the sweep never ran there and the 0.091 was lost. The second pass is also
-    # judged against the first's improved score rather than the original, so fewer of its
-    # results are accepted.
-    #
-    # Head-to-head over 72 timepoints where both acted from the same starting transform:
-    # repair won 37, the sweep won 13, 22 tied, and taking the better of the two recovered
-    # 4.309 score points against 3.654 for repair alone -- 18% more. They are complementary,
-    # so neither ordering dominates and running both is what captures that.
-    #
-    # The sequential orders cost less and are kept for reproducing earlier runs and for when
-    # compute matters more than the tail.
-    fallback_mode: Literal["parallel", "repair_then_sweep", "sweep_then_repair"] = "parallel"
-    sweep_fallback_settings: SweepFallbackSettings = SweepFallbackSettings()
-    repair_pass_settings: RepairPassSettings = RepairPassSettings()
+    # Everything about the fallback lives in one nested block, named like every other block
+    # here (*_settings) and containing both the choice and the tuning for each pass.
+    fallback_settings: FallbackSettings = FallbackSettings()
+
+    # ---- DEPRECATED aliases. Accepted so configs written against the earlier field names
+    # keep validating under extra="forbid"; each is copied into fallback_settings and warned
+    # about. `fallback`/`fallback_mode` collapsed into fallback_settings.mode, and the two
+    # tuning blocks were renamed for consistency with their siblings.
+    fallback: str | None = None
+    fallback_mode: str | None = None
+    repair_pass_settings: RepairSettings | None = None
+    sweep_fallback_settings: SweepSettings | None = None
+
 
     @model_validator(mode="after")
-    def expand_fallback(self) -> "BeadsMatchSettings":
-        """Turn `fallback` into the three low-level flags that drive estimate_tczyx.
+    def migrate_deprecated_fallback_fields(self) -> "BeadsMatchSettings":
+        """Fold the old field names into fallback_settings, warning about each.
 
-        An explicitly-set low-level flag outranks a DEFAULTED `fallback`, so a config written
-        against the older field names keeps working. Setting `fallback` and a contradicting
-        low-level flag together is rejected rather than silently resolved -- the same rule as
-        `strategy`, and for the same reason: one of the two is not what the author meant.
+        Mapping the legacy `fallback` + `fallback_mode` pair is not a straight copy: the two
+        together expressed what fallback_settings.mode now expresses alone, and `fallback_mode`
+        was inert unless both passes were enabled. The old per-pass `mode` fields are read for
+        their on/off meaning only.
         """
-        if self.fallback is None:
+        legacy = {
+            "fallback": self.fallback,
+            "fallback_mode": self.fallback_mode,
+            "repair_pass_settings": self.repair_pass_settings,
+            "sweep_fallback_settings": self.sweep_fallback_settings,
+        }
+        used = [k for k, v in legacy.items() if v is not None]
+        if not used:
             return self
-        repair, sweep, order = {
-            "off": ("off", "off", "parallel"),
-            "repair": ("on_flagged", "off", "parallel"),
-            "sweep": ("off", "on_flagged", "parallel"),
-            "repair_then_sweep": ("on_flagged", "on_flagged", "repair_then_sweep"),
-            "sweep_then_repair": ("on_flagged", "on_flagged", "sweep_then_repair"),
-            "parallel": ("on_flagged", "on_flagged", "parallel"),
-        }[self.fallback]
+        warnings.warn(
+            f"{', '.join(used)} are deprecated; use beads_match_settings.fallback_settings "
+            "(mode / repair_settings / sweep_settings).",
+            DeprecationWarning,
+            stacklevel=2,
+        )
 
-        explicit = "fallback" in self.model_fields_set
-        conflicts = []
-        if explicit:
-            if "mode" in self.repair_pass_settings.model_fields_set and (
-                self.repair_pass_settings.mode != repair
-            ):
-                conflicts.append(
-                    f"repair_pass_settings.mode={self.repair_pass_settings.mode!r} "
-                    f"(fallback implies {repair!r})"
-                )
-            if "mode" in self.sweep_fallback_settings.model_fields_set and (
-                self.sweep_fallback_settings.mode != sweep
-            ):
-                conflicts.append(
-                    f"sweep_fallback_settings.mode="
-                    f"{self.sweep_fallback_settings.mode!r} (fallback implies {sweep!r})"
-                )
-            if "fallback_mode" in self.model_fields_set and self.fallback_mode != order:
-                conflicts.append(
-                    f"fallback_mode={self.fallback_mode!r} (fallback implies {order!r})"
-                )
-            if conflicts:
-                raise ValueError(
-                    f"fallback={self.fallback!r} contradicts " + " and ".join(conflicts)
-                    + ". Set fallback to null to drive the low-level flags directly, or "
-                    "remove the conflicting flag."
-                )
+        if self.repair_pass_settings is not None:
+            self.fallback_settings.repair_settings = self.repair_pass_settings
+        if self.sweep_fallback_settings is not None:
+            self.fallback_settings.sweep_settings = self.sweep_fallback_settings
 
-        if explicit or "mode" not in self.repair_pass_settings.model_fields_set:
-            self.repair_pass_settings.mode = repair
-        if explicit or "mode" not in self.sweep_fallback_settings.model_fields_set:
-            self.sweep_fallback_settings.mode = sweep
-        if explicit or "fallback_mode" not in self.model_fields_set:
-            self.fallback_mode = order
+        # `fallback` named the whole combination, so it wins outright.
+        if self.fallback is not None:
+            self.fallback_settings.mode = _coerce_yaml_off(self.fallback)
+            return self
+
+        # Otherwise reconstruct the combination from the per-pass on/off flags plus the order,
+        # which is what those three fields expressed between them.
+        rp = self.fallback_settings.repair_settings.mode
+        sp = self.fallback_settings.sweep_settings.mode
+        if rp is None and sp is None:
+            if self.fallback_mode is not None:
+                self.fallback_settings.mode = self.fallback_mode
+            return self
+
+        repair_on = rp == "on_flagged"
+        sweep_on = sp == "on_flagged"
+        if sp == "on_low_score":
+            # The old in-estimate() arm is a different mechanism from the post-pass sweep, so
+            # it maps to its own flag rather than to sweep_enabled.
+            self.fallback_settings.sweep_settings.legacy_in_estimate = True
+        # repair_then_sweep, not parallel, when the order was not stated: a config using the
+        # per-pass flags predates fallback_mode, and what those runs actually executed was the
+        # staged order. Reconstructing them as "parallel" would silently change the behaviour
+        # of every benchmark arm on disk.
+        order = self.fallback_mode or "repair_then_sweep"
+        if repair_on and sweep_on:
+            self.fallback_settings.mode = order
+        elif repair_on:
+            self.fallback_settings.mode = "repair"
+        elif sweep_on:
+            self.fallback_settings.mode = "sweep"
+        else:
+            self.fallback_settings.mode = "off"
         return self
-
 
 class PhaseCrossCorrSettings(MyBaseModel):
     normalization: Literal["magnitude", "classic"] | None = None

--- a/settings/example_estimate_registration_settings_ants.yml
+++ b/settings/example_estimate_registration_settings_ants.yml
@@ -1,0 +1,64 @@
+# Name of the fixed (reference) image channel used for registration
+target_channel_name: Phase3D
+
+# Name of the moving image channel to align with the target
+source_channel_name: GFP EX488 EM525-45
+
+# Method to estimate registration parameters
+# "manual" user manually selects matching features
+# "beads" automatic detection of bead matches
+# "ants" uses ANTs registration with optimization
+estimation_method: ants
+
+ants_registration_settings:
+  # Apply a Sobel filter (3D gradient magnitude) to both volumes before
+  # registering, so ANTs matches structural edges rather than raw intensity.
+  # Needed for cross-modality pairs, e.g. fluorescence against a phase or
+  # virtual-staining reference.
+  sobel_filter: True
+
+  # Crop both volumes to their overlapping region (LIR) before registering.
+  crop: False
+
+  # Circular mask on the reference channel, as a fraction of image width in
+  # (0, 1]. Leave empty for no mask.
+  ref_mask_radius:
+
+  # Clip both volumes to hardcoded intensity limits. Those limits assume a
+  # PHASE reference (np.clip(ref, 0, 0.5)) -- leave this off for any other
+  # reference, such as a virtual-staining prediction whose values range well
+  # above 0.5, or it will flatten the reference.
+  clip: False
+
+# Settings for affine transformation estimation
+affine_transform_settings:
+  t_reference: first # "first" or "previous"
+  use_prev_t_transform: True # Use the previous timepoint transform as the initial transform
+  compute_approx_transform: False # Compute the approximate transform before optimizing
+  transform_type: affine # "euclidean", "similarity", or "affine"
+  approx_transform: # Initial guess for the 4x4 affine transform
+    - - 1.0
+      - 0.0
+      - 0.0
+      - 0.0
+    - - 0.0
+      - 1.0
+      - 0.0
+      - 0.0
+    - - 0.0
+      - 0.0
+      - 1.0
+      - 0.0
+    - - 0.0
+      - 0.0
+      - 0.0
+      - 1.0
+
+# Validation and interpolation settings for transform smoothing
+eval_transform_settings:
+  validation_window_size: 10 # number of timepoints to average over
+  validation_tolerance: 100.0 # max difference between transforms
+  interpolation_window_size: 3 # size of the window for interpolation
+  interpolation_type: "linear" # "linear" or "cubic"
+
+verbose: True

--- a/tests/test_example_settings.py
+++ b/tests/test_example_settings.py
@@ -1,3 +1,6 @@
+import inspect
+import re
+
 from pathlib import Path
 
 import numpy as np
@@ -29,6 +32,7 @@ example_settings_params = [
     ("example_concatenate_settings_organelle_dynamics.yml", ConcatenateSettings),
     ("example_concatenate_settings.yml", ConcatenateSettings),
     ("example_deskew_settings.yml", DeskewSettings),
+    ("example_estimate_registration_settings_ants.yml", EstimateRegistrationSettings),
     ("example_estimate_registration_settings_beads.yml", EstimateRegistrationSettings),
     ("example_estimate_registration_settings_manual.yml", EstimateRegistrationSettings),
     ("example_estimate_registration_settings.yml", EstimateRegistrationSettings),
@@ -174,6 +178,53 @@ def test_example_stabilize_timelapse_settings(example_stabilize_timelapse_settin
 def test_example_estimate_registration_settings(example_estimate_registration_settings):
     _, settings = example_estimate_registration_settings
     EstimateRegistrationSettings(**settings)
+
+
+def test_ants_settings_cover_estimate_tczyx_reads():
+    """`AntsRegistrationSettings` must expose every field `estimate_tczyx` reads.
+
+    Regression test: the model previously defined only ``sobel_filter`` while
+    ``estimate_tczyx`` also read ``crop``, ``ref_mask_radius`` and ``clip``, so
+    the config-driven ANTs path raised ``AttributeError`` before reaching ANTs.
+    """
+    from biahub.registration.ants import estimate_tczyx
+    from biahub.settings import AntsRegistrationSettings
+
+    source = inspect.getsource(estimate_tczyx)
+    read = set(re.findall(r"ants_registration_settings\.(\w+)", source))
+    assert read, "no ants_registration_settings reads found -- update this test"
+
+    missing = read - set(AntsRegistrationSettings.model_fields)
+    assert not missing, (
+        f"AntsRegistrationSettings is missing fields read by estimate_tczyx: {missing}"
+    )
+
+
+def test_ants_settings_defaults_match_preprocess_czyx():
+    """Defaults must agree with ``preprocess_czyx``, which consumes them.
+
+    Config-driven and direct calls should behave identically when the user
+    sets nothing.
+    """
+    from biahub.registration.ants import preprocess_czyx
+    from biahub.settings import AntsRegistrationSettings
+
+    settings = AntsRegistrationSettings()
+    params = inspect.signature(preprocess_czyx).parameters
+    for field in AntsRegistrationSettings.model_fields:
+        assert field in params, f"{field} is not a preprocess_czyx parameter"
+        assert getattr(settings, field) == params[field].default, (
+            f"default mismatch for {field}: settings={getattr(settings, field)} "
+            f"preprocess_czyx={params[field].default}"
+        )
+
+
+@pytest.mark.parametrize("radius", [0, -0.2, 1.5])
+def test_ants_ref_mask_radius_rejects_out_of_range(radius):
+    from biahub.settings import AntsRegistrationSettings
+
+    with pytest.raises(ValidationError):
+        AntsRegistrationSettings(ref_mask_radius=radius)
 
 
 def test_example_stitch_settings(example_stitch_settings):


### PR DESCRIPTION
## Summary

Hardens `estimate-stabilization --method beads` for long timelapses. The estimator gains
a per-timepoint quality score, a layered fallback system (repair → sweep → polish) for
timepoints where the independent estimate fails, and an opt-in per-timepoint seed
self-correction ("votefit") that fixes whole-region failures no local fallback can reach.
Defaults are chosen so that existing configs run unchanged and bit-identically; every new
behavior is opt-in or triggered only where the previous behavior produced a failed
timepoint.

## Motivation

Validated across an 11-dataset zebrafish neuromast campaign (mantis, 144–848 timepoints
each). The failure modes this PR addresses were all observed in production:

- **Stale seeds**: a config `approx_transform` copied across acquisition epochs lands
  ~55+ voxels off; the matcher cannot bridge it and a whole dataset collapses
  (three datasets, medians 0.00–0.12 before / 0.4–0.8 after).
- **Mid-series drift and O3 excursions**: single timepoints or short runs where the
  stage/optics move faster than the seed can track (validated rescues 0.00 → 0.81–0.89).
- **Restart clobbering**: resubmitting the independent-estimate driver overwrote
  already-repaired timepoints and the journal resume then skipped them forever (227
  timepoints on one dataset).
- **Silent score staleness**: repair never persisted the score sidecar, so `.score`
  files could contradict the transforms on disk.

## What's in the change

**Scoring & QC**
- Per-timepoint quality score persisted as a `.score` sidecar and plotted; QC summary
  written as csv alongside the json.
- Flagging recalibrated; plausibility QC replaced by score gates.

**Fallback system** (runs only on flagged/failed timepoints)
- *Repair*: reseed a flagged timepoint from both neighbours, screen the flagged
  translation before reuse, seed repairs from consensus geometry.
- *Sweep*: score-gated per-timepoint parameter sweep, restrictable to the repair pass's
  failures; both fallbacks can run in competition (all five combinations exposed).
- *Polish*: an accepted repair re-seeds the cascade; pre-polish score recorded so each
  step is attributable; raised round cap for the worst timepoints.
- Config restructured under one `fallback_settings` block (default: repair alone).

**Votefit seed correction** (opt-in: `beads_match_settings.seed_correction_settings.mode: votefit`)
- Per-timepoint seed correction by bead-displacement voting; fixes region-wide seed
  drift that neighbour-reseeding cannot (signature: many repair attempts, failing
  fraction unchanged). Default `none` is bit-identical to current behavior.

**Robustness fixes**
- Restart no longer clobbers repaired timepoints (skip-existing on the independent path).
- Survive timepoints with too few beads; resume support; propagate the last good
  transform instead of the config seed; repaired transforms no longer break the settings
  yml; `edge_graph_settings.method` honoured; spectral matching exposed as an opt-in
  three-way cascade.

## Validation

- 11/11 campaign datasets registered end-to-end with this branch pinned; beads-score
  medians 0.72–0.83 on the hard datasets, zero timepoints below 0.2 after votefit.
- Votefit validated bit-for-bit against a parameter sweep on one dataset
  (0.000 → 0.545/0.385 on failed timepoints, good timepoints preserved).
- Bad-seed diagnosis and per-dataset consensus-seed recovery documented per dataset.
- Default-path regression: with all new settings at defaults, transforms are
  bit-identical to the pre-branch estimator on a reference dataset.

## Notes for reviewers

- `f30f354` duplicates the already-merged #296 (AntsRegistrationSettings fix) and will
  vanish on merge.
- Not included (stacked branches, pending their own validation): vote_icp, single-t
  touch-up, bootstrap/CPD, escalation loop.
